### PR TITLE
 Adapting to Coq PR #7080: Named.Context.t -> Constr.named_context.

### DIFF
--- a/src/coq_elpi_HOAS.mli
+++ b/src/coq_elpi_HOAS.mli
@@ -123,7 +123,7 @@ val cc_mkArg :
     Compile.State.t * string * term
 
 val cc_in_elpi_ctx :
-  depth:int -> Compile.State.t -> Context.Named.t ->
+  depth:int -> Compile.State.t -> Constr.named_context ->
   ?mk_ctx_item:(term -> term -> term) ->
   (proof_ctx -> int Id.Map.t -> (term * int) list -> depth:int -> Compile.State.t -> Compile.State.t * term) -> Compile.State.t * term
 


### PR DESCRIPTION
Hi again, this is then in anticipation of coq/coq#7080, if ever, this time pushed to the hopefully correct fork. Only one renaming needed actually. (Hi to everybody I know.)