### PR TITLE
[coq] Fix Ltac qualification.

### DIFF
--- a/src/coq_elpi_goal_HOAS.ml
+++ b/src/coq_elpi_goal_HOAS.ml
@@ -77,7 +77,7 @@ let reachable_evarmap evd goal =
   aux (Evar.Set.singleton goal)
 
 type parsed_term =
-  Ltac_plugin.Tacinterp.interp_sign * Tacexpr.glob_constr_and_expr
+  Ltac_plugin.Tacinterp.interp_sign * Ltac_plugin.Tacexpr.glob_constr_and_expr
 
 type arg = String of string | Int of int | Term of parsed_term
 

--- a/src/coq_elpi_goal_HOAS.mli
+++ b/src/coq_elpi_goal_HOAS.mli
@@ -5,8 +5,10 @@
 open Elpi_API.Extend
 open Data
 
+open Ltac_plugin
+
 type parsed_term =
-  Ltac_plugin.Tacinterp.interp_sign * Tacexpr.glob_constr_and_expr
+  Tacinterp.interp_sign * Tacexpr.glob_constr_and_expr
 
 type arg = String of string | Int of int | Term of parsed_term
 

--- a/src/coq_elpi_vernacular.mli
+++ b/src/coq_elpi_vernacular.mli
@@ -26,7 +26,7 @@ type 'a arg =
   | DashQualid of qualified_name
   | Term of 'a
 val pr_arg : ('a -> Pp.t) -> 'a arg -> Pp.t
-val glob_arg : Genintern.glob_sign -> Constrexpr.constr_expr arg -> Tacexpr.glob_constr_and_expr arg
+val glob_arg : Genintern.glob_sign -> Constrexpr.constr_expr arg -> Ltac_plugin.Tacexpr.glob_constr_and_expr arg
 val interp_arg : Geninterp.interp_sign -> 'b Evd.sigma -> 'a arg -> Evd.evar_map * (Geninterp.interp_sign * 'a) arg
 
 type program_kind = Command | Tactic


### PR DESCRIPTION
`Ltac_plugin` is a packed module and should be referred in that way.

This works now because `coq_makefile` passes `-I` for packed modules
but this is not compatible with packing per-se I think.