### PR TITLE
[Makefile] COQBIN needs a trailing separator “/”

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 # detection of coq
 ifeq "$(COQBIN)" ""
-COQBIN := $(shell which coqc >/dev/null 2>&1 && dirname `which coqc`)
+COQBIN := $(shell which coqc >/dev/null 2>&1 && dirname `which coqc`)/
 endif
 ifeq "$(COQBIN)" ""
 COQBIN := coq/bin/


### PR DESCRIPTION
Source: https://github.com/coq/coq/blob/fca9ec68937e047d3895d05e57de462387737796/tools/CoqMakefile.in#L85