### PR TITLE
Adapt to coq/coq#10811 (SProp default on)

### DIFF
--- a/theories/tests/test_API.v
+++ b/theories/tests/test_API.v
@@ -257,9 +257,9 @@ End X.
 Elpi Query lp:{{
   coq.locate-module "X" MP,
   coq.env.module MP [
-    (indt Xi), (const _), (const _), (const _), 
+    (indt Xi), (const _), (const _), (const _), (const _),
     (const _),
-    (indt XYi), (const _), (const _), (const _), 
+    (indt XYi), (const _), (const _), (const _), (const _),
     (const _)
   ],
   rex_match "\\(Top\\|elpi.tests.test_API\\)\\.X\\.i" {coq.gr->string (indt Xi)},


### PR DESCRIPTION
With SProp on an additional scheme "foo_sind" is automatically created
for each inductive.