### PR TITLE
Mini change mkGApp related to Coq PR #11172

### DIFF
--- a/src/coq_elpi_glob_quotation.ml
+++ b/src/coq_elpi_glob_quotation.ml
@@ -205,13 +205,11 @@ let rec gterm2lp depth state x = match (DAst.get x) (*.CAst.v*) with
           | Anonymous, Anonymous :: rest -> Anonymous,mkGHole, rest
           | Name x, [] -> Name x,DAst.make (GVar x), []
           | Anonymous, [] -> Anonymous,mkGHole, [] in
-        let mkGapp hd args =
-          List.fold_left (Glob_ops.mkGApp ?loc:None) (DAst.make hd) args in
         let rec spine n names args ty =
           match Term.kind_of_type ty with
           | Term.SortType _ ->
              DAst.make (GLambda(as_name,Explicit,
-               mkGapp (GRef(GlobRef.IndRef ind,None)) (List.rev args),
+               Glob_ops.mkGApp (DAst.make (GRef(GlobRef.IndRef ind,None))) (List.rev args),
                Option.default mkGHole oty))
           | Term.ProdType(name,src,tgt) when n = 0 -> 
              let name, var, names = best_name name.Context.binder_name names in


### PR DESCRIPTION
As discussed in Coq [PR#11172](https://github.com/coq/coq/pull/11172#issuecomment-561321645), we agreed to do an API change for `mkGApp` so that it takes a block of argument as other `App` constructors do.