### PR TITLE
Support for Coq's #[attributes]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,9 @@ written without the `@`.
 
 ### HOAS
 
+- Change type of `main` to take as the second argument the list of attributes
+  passed to the command invocation (Coq syntax is for example `#[myflag]`).
+  See the attribute-value data type in `coq-builtin.elpi`.
 - Change context entry `def` to not carry a cache for the normal form
   of the defined term (now cached by a specific `cache` context entry).
   `def` now carries the exact same information of a `let`, as `decl`

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.3.0] - 2020-01-10
+## [1.3.0] - UNRELEASED
 
 Switch to Elpi 1.9. The main visible change is that opaque data
 types such as `@constructor`, `@inductive` and `@constant` are now
@@ -31,7 +31,7 @@ written without the `@`.
 
 ### HOAS
 
-- Change type of `main` to take as the second argument the list of attributes
+- Add to the context under which `main` is run the list of attributes
   passed to the command invocation (Coq syntax is for example `#[myflag]`).
   See the attribute-value data type in `coq-builtin.elpi`.
 - Change context entry `def` to not carry a cache for the normal form

--- a/coq-HOAS.elpi
+++ b/coq-HOAS.elpi
@@ -13,11 +13,14 @@
 % Command and tactic invocation (coq_elpi_vernacular.ml)
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Entry point for commands. Eg. "Elpi mycommand foo 3 (f x)." becomes
+% Entry point for commands. Eg. "#[att=true] Elpi mycommand foo 3 (f x)." becomes
 %   main [str "foo", int 3, trm (app[f,x])]
-% The encoding of terms is described below.
+% in a context where
+%   attributes [attribute "att" (leaf "true")]
+% holds. The encoding of terms is described below.
 pred main i:list argument.
 pred usage.
+pred attributes o:list attribute.
 
 % Entry point for tactics. Eg. "elpi mytactic foo 3 (f x)." becomes
 %   solve [str "foo", int 3, trm (app[f,x])] <goals> <new goals>

--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -28,11 +28,14 @@
 % Command and tactic invocation (coq_elpi_vernacular.ml)
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Entry point for commands. Eg. "Elpi mycommand foo 3 (f x)." becomes
+% Entry point for commands. Eg. "#[att=true] Elpi mycommand foo 3 (f x)." becomes
 %   main [str "foo", int 3, trm (app[f,x])]
-% The encoding of terms is described below.
+% in a context where
+%   attributes [attribute "att" (leaf "true")]
+% holds. The encoding of terms is described below.
 pred main i:list argument.
 pred usage.
+pred attributes o:list attribute.
 
 % Entry point for tactics. Eg. "elpi mytactic foo 3 (f x)." becomes
 %   solve [str "foo", int 3, trm (app[f,x])] <goals> <new goals>
@@ -690,6 +693,15 @@ external pred coq.notation.add-abbreviation i:id, i:int, i:term,
 % [coq.notation.abbreviation Abbreviation Args Body] Unfolds an abbreviation
 external pred coq.notation.abbreviation i:abbreviation, i:list term, 
                                         o:term.
+
+% Generic attribute value
+kind attribute-value type.
+type leaf string -> attribute-value.
+type node list attribute -> attribute-value.
+
+% Generic attribute
+kind attribute type.
+type attribute string -> attribute-value -> attribute.
 
 % -- Coq's pretyper ---------------------------------------------------
 

--- a/coq-lib.elpi
+++ b/coq-lib.elpi
@@ -276,10 +276,28 @@ with-TC Class Instance->Clause Code :-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+% Coq attribute parser, eg [#[attribute=value] Command]
+%
+% Usage:
+%   main _ :-
+%     attributes A,                                     % fetch
+%     parse-attributes A Spec Opts,                     % parse/validate
+%     Opts => (mycode, get-option "foo" V, mycode).     % use
+%
+% where [Opts] is a list of clauses [get-option StringName Value], where value
+% can have any type and [Spec] is a list of [attribute-sigmature].
+% Example of an attribute signature:
+%   [
+%    att "this" bool,
+%    att "that.thing" int,
+%    att "algebraic" (oneof ["foo" `-> foo-thing, "bar" `-> barbar]),
+%   ]
+
 type get-option string -> A -> prop.
 
 kind attribute-signature type.
 type att string -> attribute-type -> attribute-signature.
+type att-ignore-unknown attribute-signature.
 
 type supported-attribute attribute-signature -> prop.
 
@@ -292,11 +310,12 @@ type oneof list attribute-mapping -> attribute-type.
 kind attribute-mapping type.
 type (`->) string -> any -> attribute-mapping.
 
-pred valid-attribute i:string, i:string, o:string, o:diagnostic.
+pred valid-attribute i:string, i:string, o:option any, o:diagnostic.
 valid-attribute Name Value V Diag :-
   if (supported-attribute (att Name Type))
-     (typecheck-attribute Name Type Value V Diag)
-     (Diag = error {calc ( "Attribute " ^ Name ^ " is not supported")}).
+     (typecheck-attribute Name Type Value LPV Diag, V = some LPV)
+     (if (supported-attribute att-ignore-unknown) (V = none, Diag = ok)
+         (Diag = error {calc ( "Attribute " ^ Name ^ " is not supported")})).
 
 :index (_ 1 1)
 pred typecheck-attribute i:string, i:attribute-type, i:string, o:any, o:diagnostic.
@@ -308,13 +327,15 @@ typecheck-attribute N int Value _ (error Msg) :-
 typecheck-attribute _ string V V ok.
 
 typecheck-attribute _ bool "true"  tt ok.
+typecheck-attribute _ bool "tt"    tt ok.
 typecheck-attribute _ bool "True"  tt ok.
 typecheck-attribute _ bool "on"    tt ok.
-typecheck-attribute _ bool ""    tt ok.
+typecheck-attribute _ bool ""      tt ok.
 typecheck-attribute _ bool "false" ff ok.
 typecheck-attribute _ bool "False" ff ok.
 typecheck-attribute _ bool "off"   ff ok.
-typecheck-attribute N int Value _ (error Msg) :-
+typecheck-attribute _ bool "ff"    ff ok.
+typecheck-attribute N bool Value _ (error Msg) :-
   Msg is "Attribute " ^ N ^ " takes an boolean, got: " ^ Value.
 
 pred is-one-of i:string, o:any, i:attribute-mapping.
@@ -337,8 +358,9 @@ parse-attributes.aux [attribute S (node L)|AS] Prefix R :- !,
   if (Prefix = "") (PS = S) (PS is Prefix ^ "." ^ S),
   parse-attributes.aux L PS R2,
   std.append R1 R2 R.
-parse-attributes.aux [attribute S (leaf V)|AS] Prefix [get-option PS V1|R] :- !,
+parse-attributes.aux [attribute S (leaf V)|AS] Prefix CLS :- !,
   if (Prefix = "") (PS = S) (PS is Prefix ^ "." ^ S),
   valid-attribute PS V V1 Diag,
   if (Diag = error Msg) (coq.error Msg) true,
+  if (V1 = some Val) (CLS = [get-option PS Val|R]) (CLS = R), % ignored
   parse-attributes.aux AS Prefix R.

--- a/coq-lib.elpi
+++ b/coq-lib.elpi
@@ -275,5 +275,70 @@ with-TC Class Instance->Clause Code :-
   Hyps => Code.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% vim:set ft=lprolog spelllang=:
 
+type get-option string -> A -> prop.
+
+kind attribute-signature type.
+type att string -> attribute-type -> attribute-signature.
+
+type supported-attribute attribute-signature -> prop.
+
+kind attribute-type type.
+type int attribute-type.
+type string attribute-type.
+type bool attribute-type.
+type oneof list attribute-mapping -> attribute-type.
+
+kind attribute-mapping type.
+type (`->) string -> any -> attribute-mapping.
+
+pred valid-attribute i:string, i:string, o:string, o:diagnostic.
+valid-attribute Name Value V Diag :-
+  if (supported-attribute (att Name Type))
+     (typecheck-attribute Name Type Value V Diag)
+     (Diag = error {calc ( "Attribute " ^ Name ^ " is not supported")}).
+
+:index (_ 1 1)
+pred typecheck-attribute i:string, i:attribute-type, i:string, o:any, o:diagnostic.
+
+typecheck-attribute _ int Value V ok :- V is string_to_int Value, !.
+typecheck-attribute N int Value _ (error Msg) :-
+  Msg is "Attribute " ^ N ^ " takes an integer, got: " ^ Value.
+
+typecheck-attribute _ string V V ok.
+
+typecheck-attribute _ bool "true"  tt ok.
+typecheck-attribute _ bool "True"  tt ok.
+typecheck-attribute _ bool "on"    tt ok.
+typecheck-attribute _ bool ""    tt ok.
+typecheck-attribute _ bool "false" ff ok.
+typecheck-attribute _ bool "False" ff ok.
+typecheck-attribute _ bool "off"   ff ok.
+typecheck-attribute N int Value _ (error Msg) :-
+  Msg is "Attribute " ^ N ^ " takes an boolean, got: " ^ Value.
+
+pred is-one-of i:string, o:any, i:attribute-mapping.
+is-one-of K V (K `-> V).
+
+typecheck-attribute _ (oneof L) K V ok :- std.exists L (is-one-of K V), !.
+typecheck-attribute N (oneof L) K _ (error Msg) :-
+  std.map L (x\r\ sigma tmp\ x = r `-> tmp) S,
+  std.fold S "" (s\ a\ calc (a ^ " " ^ s)) OneOf,
+  Msg is "Attribute " ^ N ^ " takes one of " ^  OneOf ^ ", got: " ^ K.
+
+pred parse-attributes i:list attribute, i:list attribute-signature, o:list prop.
+
+parse-attributes L S O :-
+  std.map S (x\r\ r = supported-attribute x) CS,
+  CS => parse-attributes.aux L "" O.
+parse-attributes.aux [] _ [].
+parse-attributes.aux [attribute S (node L)|AS] Prefix R :- !,
+  parse-attributes.aux AS Prefix R1,
+  if (Prefix = "") (PS = S) (PS is Prefix ^ "." ^ S),
+  parse-attributes.aux L PS R2,
+  std.append R1 R2 R.
+parse-attributes.aux [attribute S (leaf V)|AS] Prefix [get-option PS V1|R] :- !,
+  if (Prefix = "") (PS = S) (PS is Prefix ^ "." ^ S),
+  valid-attribute PS V V1 Diag,
+  if (Diag = error Msg) (coq.error Msg) true,
+  parse-attributes.aux AS Prefix R.

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -442,6 +442,34 @@ let simplification_strategy = let open API.AlgebraicData in declare {
   ]
 } |> CConv.(!<)
 
+let attribute a = let open API.AlgebraicData in declare {
+  ty = Conv.TyName "attribute";
+  doc = "Generic attribute";
+  pp = (fun fmt a -> Format.fprintf fmt "TODO");
+  constructors = [
+    K("attribute","",A(B.string,A(a,N)),
+      B (fun s a -> s,a),
+      M (fun ~ok ~ko -> function (s,a) -> ok s a));
+  ]
+} |> CConv.(!<)
+
+let attribute_value = let open API.AlgebraicData in let open Attributes in let open CConv in declare {
+  ty = Conv.TyName "attribute-value";
+  doc = "Generic attribute value";
+  pp = (fun fmt a -> Format.fprintf fmt "TODO");
+  constructors = [
+    K("leaf","",A(B.string,N),
+      B (fun s -> if s = "" then VernacFlagEmpty else VernacFlagLeaf s),
+      M (fun ~ok ~ko -> function VernacFlagEmpty -> ok "" | VernacFlagLeaf x -> ok x | _ -> ko ()));
+    K("node","",C((fun self -> !> (B.list (attribute (!< self)))),N),
+      B (fun l -> VernacFlagList l),
+      M (fun ~ok ~ko -> function VernacFlagList l -> ok l | _ -> ko ())
+    )
+  ]
+} |> CConv.(!<)
+
+let attribute = attribute attribute_value
+
 let warning = CWarnings.create ~name:"lib" ~category:"elpi" Pp.str
 
 let if_keep x f =
@@ -1457,6 +1485,9 @@ The term must begin with at least Nargs lambdas.|}))))))),
     state, !: (API.Utils.beta ~depth t arglist), []
   )),
   DocAbove);
+
+  MLData attribute_value;
+  MLData attribute;
 
   LPDoc "-- Coq's pretyper ---------------------------------------------------";
 

--- a/src/coq_elpi_builtins.mli
+++ b/src/coq_elpi_builtins.mli
@@ -12,5 +12,7 @@ val clauses_for_later :
   (string list * Ast.program) list State.component
 val set_accumulate_to_db : ((unit -> Setup.elpi) * (string list -> Compile.compilation_unit -> unit)) -> unit
 
+val attribute : (string * Attributes.vernac_flag_value) Conversion.t
+
 (* In tactic mode some APIs are disabled *)
 val tactic_mode : bool ref

--- a/src/coq_elpi_builtins_HOAS.ml
+++ b/src/coq_elpi_builtins_HOAS.ml
@@ -15,11 +15,14 @@ let code = {|
 % Command and tactic invocation (coq_elpi_vernacular.ml)
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Entry point for commands. Eg. "Elpi mycommand foo 3 (f x)." becomes
+% Entry point for commands. Eg. "#[att=true] Elpi mycommand foo 3 (f x)." becomes
 %   main [str "foo", int 3, trm (app[f,x])]
-% The encoding of terms is described below.
+% in a context where
+%   attributes [attribute "att" (leaf "true")]
+% holds. The encoding of terms is described below.
 pred main i:list argument.
 pred usage.
+pred attributes o:list attribute.
 
 % Entry point for tactics. Eg. "elpi mytactic foo 3 (f x)." becomes
 %   solve [str "foo", int 3, trm (app[f,x])] <goals> <new goals>

--- a/src/coq_elpi_vernacular.mli
+++ b/src/coq_elpi_vernacular.mli
@@ -71,7 +71,7 @@ val subst_record_decl : Mod_subst.substitution -> Coq_elpi_goal_HOAS.glob_record
 val subst_constant_decl : Mod_subst.substitution -> Coq_elpi_goal_HOAS.glob_constant_decl -> Coq_elpi_goal_HOAS.glob_constant_decl
 val subst_context_decl : Mod_subst.substitution -> Coq_elpi_goal_HOAS.glob_context_decl -> Coq_elpi_goal_HOAS.glob_context_decl
 
-val run_program : Loc.t -> qualified_name -> raw_arg list -> unit
+val run_program : Loc.t -> qualified_name -> atts:Attributes.vernac_flags -> raw_arg list -> unit
 val run_in_program : ?program:qualified_name -> Elpi.API.Ast.Loc.t * string -> unit
 val run_tactic : Loc.t -> qualified_name -> Geninterp.interp_sign -> parsed_arg list -> unit Proofview.tactic
 val run_in_tactic : ?program:qualified_name -> Elpi.API.Ast.Loc.t * string -> Geninterp.interp_sign -> parsed_arg list -> unit Proofview.tactic

--- a/src/coq_elpi_vernacular_syntax.mlg
+++ b/src/coq_elpi_vernacular_syntax.mlg
@@ -176,6 +176,9 @@ let telescope = Pcoq.Entry.create "elpi:telescope"
 let colon_sort = Pcoq.Entry.create "elpi:colon_sort"
 let colon_constr = Pcoq.Entry.create "elpi:colon_constr"
 
+let any_attribute : Attributes.vernac_flags Attributes.attribute =
+  Attributes.make_attribute (fun x -> [],x)
+
 }
 
 GRAMMAR EXTEND Gram
@@ -271,10 +274,11 @@ VERNAC COMMAND EXTEND Elpi CLASSIFIED AS SIDEFF
 
 | [ "Elpi" "Export" qualified_name(p) ] => { Vernacextend.(VtSideff [],VtNow) } -> {
     EV.export_command (snd p) (Genarg.get_arg_tag wit_elpi_loc) (Genarg.get_arg_tag wit_elpi_arg)
-   }
+  }
 
-| [ "Elpi" qualified_name(p) elpi_arg_list(args) ] ->
-    { EV.run_program (fst p) (snd p) args }
+| #[ atts = any_attribute ]
+  [ "Elpi" qualified_name(p) elpi_arg_list(args) ] ->
+    { EV.run_program (fst p) (snd p) ~atts args }
 END
 
 TACTIC EXTEND elpi_tac

--- a/theories/tests/test_vernacular1.v
+++ b/theories/tests/test_vernacular1.v
@@ -36,13 +36,17 @@ Elpi Accumulate lp:{{
   main _ :-
     attributes A,
     coq.say A,
-    A = [attribute "foo" (leaf "bar")| _].
+    A = [attribute "foo" (leaf "bar")| _],
+    parse-attributes A [att "foo" string,
+                        att "poly" bool] CL,
+    coq.say CL.
 
 }}.
-
+Elpi Typecheck.
 #[foo="bar"]
-Elpi test.att.
+Elpi test.att. 
 
 Elpi Export test.att.
 
-#[foo="bar",poly,suppa(duppa)] test.att.
+#[foo="bar",poly] test.att.
+Fail #[foo="bar",poly,suppa(duppa)] test.att.

--- a/theories/tests/test_vernacular1.v
+++ b/theories/tests/test_vernacular1.v
@@ -38,15 +38,17 @@ Elpi Accumulate lp:{{
     coq.say A,
     A = [attribute "foo" (leaf "bar")| _],
     parse-attributes A [att "foo" string,
-                        att "poly" bool] CL,
+                        att "poly" bool,
+                        att-ignore-unknown] CL,
     coq.say CL.
 
 }}.
 Elpi Typecheck.
 #[foo="bar"]
-Elpi test.att. 
+Elpi test.att.
 
 Elpi Export test.att.
 
 #[foo="bar",poly] test.att.
-Fail #[foo="bar",poly,suppa(duppa)] test.att.
+Elpi Trace.
+#[foo="bar",poly,suppa(duppa)] test.att.

--- a/theories/tests/test_vernacular1.v
+++ b/theories/tests/test_vernacular1.v
@@ -29,3 +29,20 @@ Elpi Accumulate lp:{{
 }}.
 
 Fail Elpi Typecheck.
+
+Elpi Command test.att.
+Elpi Accumulate lp:{{
+
+  main _ :-
+    attributes A,
+    coq.say A,
+    A = [attribute "foo" (leaf "bar")| _].
+
+}}.
+
+#[foo="bar"]
+Elpi test.att.
+
+Elpi Export test.att.
+
+#[foo="bar",poly,suppa(duppa)] test.att.

--- a/theories/tutorial/coq_elpi.v
+++ b/theories/tutorial/coq_elpi.v
@@ -3,7 +3,7 @@ From elpi Require Import elpi.
    Elpi is an extension language that comes as a library
    to be embedded into host applications such as Coq.
 
-   Elpi is a variant of λProlog enriched with constraints. 
+   Elpi is a variant of λProlog enriched with constraints.
    λProlog is a programming language designed to make it easy
    to manipulate abstract syntax trees containing binders.
    Elpi extends λProlog with programming constructs that are
@@ -25,13 +25,13 @@ From elpi Require Import elpi.
    This tutorial assumes the reader is familiar with Elpi and HOAS; if it is not
    the case, please take a look at this other tutorial first:
      https://github.com/LPCIC/coq-elpi/blob/master/theories/tutorial/elpi_lang.v
-   
+
    - Coq Programs: Commands, Tactics and Db
    - HOAS for Gallina
    - Quotations and Antiquotations
    - Usecase: Synthesizing a term
    - Usecase: Solving a goal
-   
+
 *)
 
 
@@ -59,10 +59,10 @@ From elpi Require Import elpi.
 
    - https://github.com/LPCIC/coq-elpi/blob/master/elpi-command.elpi
    - https://github.com/LPCIC/coq-elpi/blob/master/elpi-tactic.elpi
-   
+
    The "Elpi Accumulate ..." family of commands lets one accumulate clauses
    taken from:
-   
+
    - verbatim text "Elpi Accumulate lp:{{ <code> }}"
    - source files "Elpi Accumulate File <path>"
    - data bases (Db) "Elpi Accumulate Db <name>"
@@ -73,7 +73,7 @@ From elpi Require Import elpi.
 
    and a Db can be later extended via "Elpi Accumulate".
    Indeed a Db is pretty much like a regular program but can be shared among
-   other programs (a program accumulates a Db by name, not by contents). 
+   other programs (a program accumulates a Db by name, not by contents).
 
    Let's define a Db.
   *)
@@ -101,7 +101,7 @@ Elpi Command tutorial.
 Elpi Accumulate Db age.db.
 Elpi Accumulate lp:{{
 
-  main []     :- coq.say "hello world".
+  main []         :- coq.say "hello world".
 
   main [str Name] :- coq.say "hello" Name ", you are" {age Name}.
 
@@ -139,7 +139,7 @@ Elpi tutorial bob.
 *)
 Elpi Accumulate tutorial lp:{{
 
-  main _ :- coq.say "usage: tutorial [name]". 
+  main _ :- coq.say "usage: tutorial [name]".
 
 }}.
 Elpi tutorial "too" "many" "args".
@@ -175,7 +175,7 @@ Elpi Export show_arguments.
 
 show_arguments 1 "2" (3).
 
-(** 
+(**
    Elpi comes with a type checker. It is invoked any time
    a query is run by hand via "Elpi Query", or when invoked via
    "Elpi Typecheck".
@@ -191,7 +191,7 @@ Fail Elpi Typecheck illtyped.
 
 (** ----------------------- HOAS for Gallina ----------------------------- *)
 
-(** 
+(**
      The full syntax of Coq terms can be found here
 
         https://github.com/LPCIC/coq-elpi/blob/master/coq-HOAS.elpi
@@ -202,7 +202,7 @@ Fail Elpi Typecheck illtyped.
 
      Let's start with the "gref" data type and the "global" term
      constructor.
-     
+
      The "coq.locate" builtin resolves a name to a global rerence ("gref").
 
       type const constant -> gref.
@@ -216,7 +216,7 @@ Fail Elpi Typecheck illtyped.
 *)
 
 (* The current program is ill-typed, let's start a new one*)
-Elpi Command global_references. 
+Elpi Command global_references.
 
 Elpi Query lp:{{
   coq.locate "nat" GRnat,   coq.say "nat is:" GRnat,
@@ -247,7 +247,7 @@ Elpi Query lp:{{
     Remark: "indt «nat»" is not a term (or better a type).
     The "global" term constructor turns a "gref" into an actual term.
 
-    type global gref -> term. 
+    type global gref -> term.
 
     Remark: the "app" term constructor is taking a list of terms and building
     the application. "app [global (indc «S»), global (indc «O»)]" is
@@ -273,12 +273,12 @@ Elpi Query lp:{{
    of the bound variable "nat" and a function describing the body:
 
      type fun  name -> term -> (term -> term) -> term.
-   
+
    Remark: name is just for pretty printing, in spite of carrying
    a value in the Coq world, it has no semantical meaning in Elpi. *)
 
 Elpi Query lp:{{ fun `foo` T B = fun `bar` T B }}.
-  
+
 (**
    The other binders "prod" (Coq's "forall", AKA "Π") and "let" are similar,
    so let's rather focus on "fix" here.
@@ -321,9 +321,9 @@ Elpi Query lp:{{
     coq.locate "m" (const C),
     coq.env.const C (some (fun _ _ h\ fun _ _ p\ match _ (RT h p) _)) _,
     coq.say "The return type of m is:" RT
-  
+
 }}.
-  
+
 
 (**
    The last term constructor worth discussing is "sort".
@@ -332,7 +332,7 @@ Elpi Query lp:{{
 
    type prop universe.
    type typ @univ -> universe.
-   
+
    The opaque @univ is a universe level variable. Elpi holds a store of
    constraints among these variable and provides built-in predicates
    named "coq.univ.*" to impose constraints.
@@ -373,7 +373,7 @@ Elpi Query lp:{{
    Writing Gallina terms as we did so far is surely possible but very verbose
    and unhandy. Elpi provides a system of quotations and antiquotations to
    let one take advantage of the Coq parser to write terms.
-   
+
    The antiquotation, from Coq to Elpi, is written lp:{{ .. }} and we have
    been using it since the beginning of the tutorial. The quotation from
    Elpi to Coq is written {{:coq .. }} or also just {{ .. }} since the ":coq" is
@@ -397,11 +397,11 @@ Elpi Query lp:{{
 }}.
 
 (**
-   One rule governs bound variables: 
-    
+   One rule governs bound variables:
+
      if a variable is bound in language X
      then the variable is only visible in language X.
-   
+
    The following example is horrible but proves this point. In real code
    you are encouraged to pick appropriate names for your variables, avoiding
    gratuitous (visual) clashes.
@@ -429,7 +429,7 @@ Elpi Query lp:{{
    Since it is quite frequent to put Coq variables in the scope of an Elpi
    unification variable, a shorhand for "lp:{{ X {{a}} {{b}} }}" is provided
    in the form of "lp:(X a b)".
-    
+
    Note that writing "lp:X a b" (without parentheses) would result in a
    Coq application, not an Elpi one. *)
 
@@ -439,11 +439,11 @@ Elpi Query lp:{{
   coq.say {{ fun a b : nat => lp:(X a b) }}
 
 }}.
-    
+
 (**
     A last commodity quotation lets one access the "coqlib"
     feature introduced in Coq 8.10.
-    
+
     Coqlib gives you an indirection between your code and the actual name
     of constants.
 
@@ -499,7 +499,7 @@ Elpi Accumulate lp:{{
     coq.locate IndName (indt GR),
     coq.env.indt GR _ _ _ _ Kn _,         % get the names of the constructors
     std.length Kn N,                      % count them
-    int->nat N Nnat,                      % turn the integer into a nat 
+    int->nat N Nnat,                      % turn the integer into a nat
     coq.env.add-const Name Nnat _ _ _ _. % save it
 }}.
 Elpi Typecheck.
@@ -724,7 +724,7 @@ solve _ [(goal _ E _ _ as G)] [] :-
 Elpi Typecheck.
 
 Lemma ltac1 (x y : bool) (H : x = y) (H0 : y = y) (H1 := H) (H2 : x = x) : x = y.
-Proof. 
+Proof.
 elpi tutorial.ltac.
 Qed.
 


### PR DESCRIPTION
This is a bit abrupt.. but let's you do
```
#[attribute] Elpi foo.
```
as well as
```
Elpi Export foo.
#[attribute] foo.
```
Attributes use a generic syntax for command options, such as `poly`, `local`, ...
TODO: a little "parser" written in elpi
