### PR TITLE
Adapt to coq #8808: expressiveness of syntactic definitions get closer to the one of notations

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1428,8 +1428,8 @@ Deprecation can be (pr "version" "note")|})))))))),
                   { nenv with Notation_term.ninterp_var_type =
                        Id.Map.add id Notation_term.NtnInternTypeAny
                          nenv.Notation_term.ninterp_var_type },
-                  (id, (None,[])) :: vars
-               | _ -> nenv, (Names.Id.of_string_soft "_", (None,[])) :: vars in
+                  (id, ((Constrexpr.InConstrEntrySomeLevel,(None,[])),Notation_term.NtnTypeConstr)) :: vars
+               | _ -> nenv, (Names.Id.of_string_soft "_", ((Constrexpr.InConstrEntrySomeLevel,(None,[])),Notation_term.NtnTypeConstr)) :: vars in
              let env = EConstr.push_rel (Context.Rel.Declaration.LocalAssum(name,ty)) env in
              aux vars nenv env (n-1) t
          | _ ->


### PR DESCRIPTION
Hi @gares, in coq/coq#8808, `declare_syntactic_definitions` takes a more informative signature for the variables of the notation. Elpi uses this function, but, as far as I understood, only on a limited fragment where all variables are terms. 

To adapt coq-elpi, I correspondingly set the first new information as the canonical ones for terms, namely the `Notation_term.NtnTypeConstr` type. As for second new information, it is canonically `Constrexpr.InConstrEntrySomeLevel`.

Please tell if my guess, and the corresponding change, are ok. The PR will then have to be merged synchronously.

