### PR TITLE
Adapt to coq/coq#12611

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1030,7 +1030,7 @@ Supported attributes:
      | Some field_specs -> (* record: projection... *)
          let names, flags =
            List.(split (map (fun { name; is_coercion; is_canonical } -> name,
-               { Record.pf_subclass = is_coercion ; pf_canonical = is_canonical })
+               { Record.Internal.pf_subclass = is_coercion ; pf_canonical = is_canonical })
              field_specs)) in
          let is_implicit = List.map (fun _ -> []) names in
          let cstr = (ind,1) in
@@ -1038,7 +1038,7 @@ Supported attributes:
          let k_ty = List.(hd (hd me.mind_entry_inds).mind_entry_lc) in
          let fields_as_relctx = Term.prod_assum k_ty in
          let kinds, sp_projs =
-           Record.declare_projections ind ~kind:Decls.Definition
+           Record.Internal.declare_projections ind ~kind:Decls.Definition
              (Evd.univ_entry ~poly:false sigma)
              (Names.Id.of_string "record")
              flags is_implicit fields_as_relctx
@@ -1051,7 +1051,7 @@ Supported attributes:
            s_EXPECTEDPARAM = npars;
          }
          in
-         Record.declare_structure_entry struc;
+         Record.Internal.declare_structure_entry struc;
      end;
      state, !: ind, []))),
   DocAbove);


### PR DESCRIPTION
Hi @gares , in the context of coq/coq#12611 , I was reworking the record declaration API and I see that Coq Elpi does use some internals.

I was wondering if you still would like to access that API, or if Elpi could use the higher-level API already in `Record`, which implements the vernacular command.

It seems to me that the current code in Elpi has some overlap with the internals; how would the proper API look for you? Do you think that the route this PR is going would work (at the cost of using the AST), or would you like to go some other route?