### PR TITLE
Adapt to coq PR #12875: names of arguments can also be passed to Impargs.set_implicit

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1399,8 +1399,8 @@ Supported attributes:
   (fun gref imps ~depth {options} _ -> on_global_state "coq.arguments.set-implicit" (fun state ->
      let local = options.local <> Some false in
      let imps = imps |> List.(map (map (function
-       | Unspec -> Glob_term.Explicit
-       | Given x -> x))) in
+       | Unspec -> Anonymous, Glob_term.Explicit
+       | Given x -> Anonymous, x))) in
      Impargs.set_implicits local gref imps;
      state, (), []))),
   DocAbove);


### PR DESCRIPTION
To be merged synchronously with coq/coq#12875.

In `coq_elpi_builtins.ml`, we set them to `Anonymous` to let `impargs` use its own names.