### PR TITLE
[NES][FFI] Optimization

### DIFF
--- a/apps/NES/_CoqProject
+++ b/apps/NES/_CoqProject
@@ -9,5 +9,7 @@
 theories/NES.v
 
 tests/test_NES.v
+tests/test_NES_perf.v
+tests/test_NES_perf_optimal.v
 
 examples/usage_NES.v

--- a/apps/NES/elpi/nes.elpi
+++ b/apps/NES/elpi/nes.elpi
@@ -45,7 +45,7 @@ end-ns NS Stack In Out :- In => std.do! [
 
   coq.locate-module NS M,
   if (Path = [])
-     (coq.env.end-module M_aux, coq.env.export-module M_aux, Local = @global!)
+     (std.do! [coq.env.end-module M_aux, coq.env.export-module M_aux, Local = @global!])
      (Local = @local!),
   % NES.Open can put clauses in scope
   std.append Path [NS] NewPath,
@@ -91,6 +91,13 @@ begin-path Path :- std.do! [
   open-super-path Path [],
 
 ].
+
+pred std.time-do! i:list prop.
+std.time-do! [].
+std.time-do! [P|PS] :-
+  std.time P T, coq.say P "\ntakes" T "\n",
+  !,
+  std.time-do! PS.
 
 pred end-path i:list string.
 end-path Path :- std.do! [

--- a/apps/NES/tests/test_NES_perf.v
+++ b/apps/NES/tests/test_NES_perf.v
@@ -1,2002 +1,2001 @@
 From elpi.apps Require Import NES.
 
-Time NES.Begin NS1.
-stop
+NES.Begin NS1.
 Definition x := 0.
 NES.End NS1.
 
-Time NES.Begin NS2.
+NES.Begin NS2.
 Definition x := 0.
 NES.End NS2.
 
-Time NES.Begin NS3.
+NES.Begin NS3.
 Definition x := 0.
 NES.End NS3.
 
-Time NES.Begin NS4.
+NES.Begin NS4.
 Definition x := 0.
 NES.End NS4.
 
-Time NES.Begin NS5.
+NES.Begin NS5.
 Definition x := 0.
 NES.End NS5.
 
-Time NES.Begin NS6.
+NES.Begin NS6.
 Definition x := 0.
 NES.End NS6.
 
-Time NES.Begin NS7.
+NES.Begin NS7.
 Definition x := 0.
 NES.End NS7.
 
-Time NES.Begin NS8.
+NES.Begin NS8.
 Definition x := 0.
 NES.End NS8.
 
-Time NES.Begin NS9.
+NES.Begin NS9.
 Definition x := 0.
 NES.End NS9.
 
-Time NES.Begin NS10.
+NES.Begin NS10.
 Definition x := 0.
 NES.End NS10.
 
-Time NES.Begin NS11.
+NES.Begin NS11.
 Definition x := 0.
 NES.End NS11.
 
-Time NES.Begin NS12.
+NES.Begin NS12.
 Definition x := 0.
 NES.End NS12.
 
-Time NES.Begin NS13.
+NES.Begin NS13.
 Definition x := 0.
 NES.End NS13.
 
-Time NES.Begin NS14.
+NES.Begin NS14.
 Definition x := 0.
 NES.End NS14.
 
-Time NES.Begin NS15.
+NES.Begin NS15.
 Definition x := 0.
 NES.End NS15.
 
-Time NES.Begin NS16.
+NES.Begin NS16.
 Definition x := 0.
 NES.End NS16.
 
-Time NES.Begin NS17.
+NES.Begin NS17.
 Definition x := 0.
 NES.End NS17.
 
-Time NES.Begin NS18.
+NES.Begin NS18.
 Definition x := 0.
 NES.End NS18.
 
-Time NES.Begin NS19.
+NES.Begin NS19.
 Definition x := 0.
 NES.End NS19.
 
-Time NES.Begin NS20.
+NES.Begin NS20.
 Definition x := 0.
 NES.End NS20.
 
-Time NES.Begin NS21.
+NES.Begin NS21.
 Definition x := 0.
 NES.End NS21.
 
-Time NES.Begin NS22.
+NES.Begin NS22.
 Definition x := 0.
 NES.End NS22.
 
-Time NES.Begin NS23.
+NES.Begin NS23.
 Definition x := 0.
 NES.End NS23.
 
-Time NES.Begin NS24.
+NES.Begin NS24.
 Definition x := 0.
 NES.End NS24.
 
-Time NES.Begin NS25.
+NES.Begin NS25.
 Definition x := 0.
 NES.End NS25.
 
-Time NES.Begin NS26.
+NES.Begin NS26.
 Definition x := 0.
 NES.End NS26.
 
-Time NES.Begin NS27.
+NES.Begin NS27.
 Definition x := 0.
 NES.End NS27.
 
-Time NES.Begin NS28.
+NES.Begin NS28.
 Definition x := 0.
 NES.End NS28.
 
-Time NES.Begin NS29.
+NES.Begin NS29.
 Definition x := 0.
 NES.End NS29.
 
-Time NES.Begin NS30.
+NES.Begin NS30.
 Definition x := 0.
 NES.End NS30.
 
-Time NES.Begin NS31.
+NES.Begin NS31.
 Definition x := 0.
 NES.End NS31.
 
-Time NES.Begin NS32.
+NES.Begin NS32.
 Definition x := 0.
 NES.End NS32.
 
-Time NES.Begin NS33.
+NES.Begin NS33.
 Definition x := 0.
 NES.End NS33.
 
-Time NES.Begin NS34.
+NES.Begin NS34.
 Definition x := 0.
 NES.End NS34.
 
-Time NES.Begin NS35.
+NES.Begin NS35.
 Definition x := 0.
 NES.End NS35.
 
-Time NES.Begin NS36.
+NES.Begin NS36.
 Definition x := 0.
 NES.End NS36.
 
-Time NES.Begin NS37.
+NES.Begin NS37.
 Definition x := 0.
 NES.End NS37.
 
-Time NES.Begin NS38.
+NES.Begin NS38.
 Definition x := 0.
 NES.End NS38.
 
-Time NES.Begin NS39.
+NES.Begin NS39.
 Definition x := 0.
 NES.End NS39.
 
-Time NES.Begin NS40.
+NES.Begin NS40.
 Definition x := 0.
 NES.End NS40.
 
-Time NES.Begin NS41.
+NES.Begin NS41.
 Definition x := 0.
 NES.End NS41.
 
-Time NES.Begin NS42.
+NES.Begin NS42.
 Definition x := 0.
 NES.End NS42.
 
-Time NES.Begin NS43.
+NES.Begin NS43.
 Definition x := 0.
 NES.End NS43.
 
-Time NES.Begin NS44.
+NES.Begin NS44.
 Definition x := 0.
 NES.End NS44.
 
-Time NES.Begin NS45.
+NES.Begin NS45.
 Definition x := 0.
 NES.End NS45.
 
-Time NES.Begin NS46.
+NES.Begin NS46.
 Definition x := 0.
 NES.End NS46.
 
-Time NES.Begin NS47.
+NES.Begin NS47.
 Definition x := 0.
 NES.End NS47.
 
-Time NES.Begin NS48.
+NES.Begin NS48.
 Definition x := 0.
 NES.End NS48.
 
-Time NES.Begin NS49.
+NES.Begin NS49.
 Definition x := 0.
 NES.End NS49.
 
-Time NES.Begin NS50.
+NES.Begin NS50.
 Definition x := 0.
 NES.End NS50.
 
-Time NES.Begin NS51.
+NES.Begin NS51.
 Definition x := 0.
 NES.End NS51.
 
-Time NES.Begin NS52.
+NES.Begin NS52.
 Definition x := 0.
 NES.End NS52.
 
-Time NES.Begin NS53.
+NES.Begin NS53.
 Definition x := 0.
 NES.End NS53.
 
-Time NES.Begin NS54.
+NES.Begin NS54.
 Definition x := 0.
 NES.End NS54.
 
-Time NES.Begin NS55.
+NES.Begin NS55.
 Definition x := 0.
 NES.End NS55.
 
-Time NES.Begin NS56.
+NES.Begin NS56.
 Definition x := 0.
 NES.End NS56.
 
-Time NES.Begin NS57.
+NES.Begin NS57.
 Definition x := 0.
 NES.End NS57.
 
-Time NES.Begin NS58.
+NES.Begin NS58.
 Definition x := 0.
 NES.End NS58.
 
-Time NES.Begin NS59.
+NES.Begin NS59.
 Definition x := 0.
 NES.End NS59.
 
-Time NES.Begin NS60.
+NES.Begin NS60.
 Definition x := 0.
 NES.End NS60.
 
-Time NES.Begin NS61.
+NES.Begin NS61.
 Definition x := 0.
 NES.End NS61.
 
-Time NES.Begin NS62.
+NES.Begin NS62.
 Definition x := 0.
 NES.End NS62.
 
-Time NES.Begin NS63.
+NES.Begin NS63.
 Definition x := 0.
 NES.End NS63.
 
-Time NES.Begin NS64.
+NES.Begin NS64.
 Definition x := 0.
 NES.End NS64.
 
-Time NES.Begin NS65.
+NES.Begin NS65.
 Definition x := 0.
 NES.End NS65.
 
-Time NES.Begin NS66.
+NES.Begin NS66.
 Definition x := 0.
 NES.End NS66.
 
-Time NES.Begin NS67.
+NES.Begin NS67.
 Definition x := 0.
 NES.End NS67.
 
-Time NES.Begin NS68.
+NES.Begin NS68.
 Definition x := 0.
 NES.End NS68.
 
-Time NES.Begin NS69.
+NES.Begin NS69.
 Definition x := 0.
 NES.End NS69.
 
-Time NES.Begin NS70.
+NES.Begin NS70.
 Definition x := 0.
 NES.End NS70.
 
-Time NES.Begin NS71.
+NES.Begin NS71.
 Definition x := 0.
 NES.End NS71.
 
-Time NES.Begin NS72.
+NES.Begin NS72.
 Definition x := 0.
 NES.End NS72.
 
-Time NES.Begin NS73.
+NES.Begin NS73.
 Definition x := 0.
 NES.End NS73.
 
-Time NES.Begin NS74.
+NES.Begin NS74.
 Definition x := 0.
 NES.End NS74.
 
-Time NES.Begin NS75.
+NES.Begin NS75.
 Definition x := 0.
 NES.End NS75.
 
-Time NES.Begin NS76.
+NES.Begin NS76.
 Definition x := 0.
 NES.End NS76.
 
-Time NES.Begin NS77.
+NES.Begin NS77.
 Definition x := 0.
 NES.End NS77.
 
-Time NES.Begin NS78.
+NES.Begin NS78.
 Definition x := 0.
 NES.End NS78.
 
-Time NES.Begin NS79.
+NES.Begin NS79.
 Definition x := 0.
 NES.End NS79.
 
-Time NES.Begin NS80.
+NES.Begin NS80.
 Definition x := 0.
 NES.End NS80.
 
-Time NES.Begin NS81.
+NES.Begin NS81.
 Definition x := 0.
 NES.End NS81.
 
-Time NES.Begin NS82.
+NES.Begin NS82.
 Definition x := 0.
 NES.End NS82.
 
-Time NES.Begin NS83.
+NES.Begin NS83.
 Definition x := 0.
 NES.End NS83.
 
-Time NES.Begin NS84.
+NES.Begin NS84.
 Definition x := 0.
 NES.End NS84.
 
-Time NES.Begin NS85.
+NES.Begin NS85.
 Definition x := 0.
 NES.End NS85.
 
-Time NES.Begin NS86.
+NES.Begin NS86.
 Definition x := 0.
 NES.End NS86.
 
-Time NES.Begin NS87.
+NES.Begin NS87.
 Definition x := 0.
 NES.End NS87.
 
-Time NES.Begin NS88.
+NES.Begin NS88.
 Definition x := 0.
 NES.End NS88.
 
-Time NES.Begin NS89.
+NES.Begin NS89.
 Definition x := 0.
 NES.End NS89.
 
-Time NES.Begin NS90.
+NES.Begin NS90.
 Definition x := 0.
 NES.End NS90.
 
-Time NES.Begin NS91.
+NES.Begin NS91.
 Definition x := 0.
 NES.End NS91.
 
-Time NES.Begin NS92.
+NES.Begin NS92.
 Definition x := 0.
 NES.End NS92.
 
-Time NES.Begin NS93.
+NES.Begin NS93.
 Definition x := 0.
 NES.End NS93.
 
-Time NES.Begin NS94.
+NES.Begin NS94.
 Definition x := 0.
 NES.End NS94.
 
-Time NES.Begin NS95.
+NES.Begin NS95.
 Definition x := 0.
 NES.End NS95.
 
-Time NES.Begin NS96.
+NES.Begin NS96.
 Definition x := 0.
 NES.End NS96.
 
-Time NES.Begin NS97.
+NES.Begin NS97.
 Definition x := 0.
 NES.End NS97.
 
-Time NES.Begin NS98.
+NES.Begin NS98.
 Definition x := 0.
 NES.End NS98.
 
-Time NES.Begin NS99.
+NES.Begin NS99.
 Definition x := 0.
 NES.End NS99.
 
-Time NES.Begin NS100.
+NES.Begin NS100.
 Definition x := 0.
 NES.End NS100.
 
-Time NES.Begin NS101.
+NES.Begin NS101.
 Definition x := 0.
 NES.End NS101.
 
-Time NES.Begin NS102.
+NES.Begin NS102.
 Definition x := 0.
 NES.End NS102.
 
-Time NES.Begin NS103.
+NES.Begin NS103.
 Definition x := 0.
 NES.End NS103.
 
-Time NES.Begin NS104.
+NES.Begin NS104.
 Definition x := 0.
 NES.End NS104.
 
-Time NES.Begin NS105.
+NES.Begin NS105.
 Definition x := 0.
 NES.End NS105.
 
-Time NES.Begin NS106.
+NES.Begin NS106.
 Definition x := 0.
 NES.End NS106.
 
-Time NES.Begin NS107.
+NES.Begin NS107.
 Definition x := 0.
 NES.End NS107.
 
-Time NES.Begin NS108.
+NES.Begin NS108.
 Definition x := 0.
 NES.End NS108.
 
-Time NES.Begin NS109.
+NES.Begin NS109.
 Definition x := 0.
 NES.End NS109.
 
-Time NES.Begin NS110.
+NES.Begin NS110.
 Definition x := 0.
 NES.End NS110.
 
-Time NES.Begin NS111.
+NES.Begin NS111.
 Definition x := 0.
 NES.End NS111.
 
-Time NES.Begin NS112.
+NES.Begin NS112.
 Definition x := 0.
 NES.End NS112.
 
-Time NES.Begin NS113.
+NES.Begin NS113.
 Definition x := 0.
 NES.End NS113.
 
-Time NES.Begin NS114.
+NES.Begin NS114.
 Definition x := 0.
 NES.End NS114.
 
-Time NES.Begin NS115.
+NES.Begin NS115.
 Definition x := 0.
 NES.End NS115.
 
-Time NES.Begin NS116.
+NES.Begin NS116.
 Definition x := 0.
 NES.End NS116.
 
-Time NES.Begin NS117.
+NES.Begin NS117.
 Definition x := 0.
 NES.End NS117.
 
-Time NES.Begin NS118.
+NES.Begin NS118.
 Definition x := 0.
 NES.End NS118.
 
-Time NES.Begin NS119.
+NES.Begin NS119.
 Definition x := 0.
 NES.End NS119.
 
-Time NES.Begin NS120.
+NES.Begin NS120.
 Definition x := 0.
 NES.End NS120.
 
-Time NES.Begin NS121.
+NES.Begin NS121.
 Definition x := 0.
 NES.End NS121.
 
-Time NES.Begin NS122.
+NES.Begin NS122.
 Definition x := 0.
 NES.End NS122.
 
-Time NES.Begin NS123.
+NES.Begin NS123.
 Definition x := 0.
 NES.End NS123.
 
-Time NES.Begin NS124.
+NES.Begin NS124.
 Definition x := 0.
 NES.End NS124.
 
-Time NES.Begin NS125.
+NES.Begin NS125.
 Definition x := 0.
 NES.End NS125.
 
-Time NES.Begin NS126.
+NES.Begin NS126.
 Definition x := 0.
 NES.End NS126.
 
-Time NES.Begin NS127.
+NES.Begin NS127.
 Definition x := 0.
 NES.End NS127.
 
-Time NES.Begin NS128.
+NES.Begin NS128.
 Definition x := 0.
 NES.End NS128.
 
-Time NES.Begin NS129.
+NES.Begin NS129.
 Definition x := 0.
 NES.End NS129.
 
-Time NES.Begin NS130.
+NES.Begin NS130.
 Definition x := 0.
 NES.End NS130.
 
-Time NES.Begin NS131.
+NES.Begin NS131.
 Definition x := 0.
 NES.End NS131.
 
-Time NES.Begin NS132.
+NES.Begin NS132.
 Definition x := 0.
 NES.End NS132.
 
-Time NES.Begin NS133.
+NES.Begin NS133.
 Definition x := 0.
 NES.End NS133.
 
-Time NES.Begin NS134.
+NES.Begin NS134.
 Definition x := 0.
 NES.End NS134.
 
-Time NES.Begin NS135.
+NES.Begin NS135.
 Definition x := 0.
 NES.End NS135.
 
-Time NES.Begin NS136.
+NES.Begin NS136.
 Definition x := 0.
 NES.End NS136.
 
-Time NES.Begin NS137.
+NES.Begin NS137.
 Definition x := 0.
 NES.End NS137.
 
-Time NES.Begin NS138.
+NES.Begin NS138.
 Definition x := 0.
 NES.End NS138.
 
-Time NES.Begin NS139.
+NES.Begin NS139.
 Definition x := 0.
 NES.End NS139.
 
-Time NES.Begin NS140.
+NES.Begin NS140.
 Definition x := 0.
 NES.End NS140.
 
-Time NES.Begin NS141.
+NES.Begin NS141.
 Definition x := 0.
 NES.End NS141.
 
-Time NES.Begin NS142.
+NES.Begin NS142.
 Definition x := 0.
 NES.End NS142.
 
-Time NES.Begin NS143.
+NES.Begin NS143.
 Definition x := 0.
 NES.End NS143.
 
-Time NES.Begin NS144.
+NES.Begin NS144.
 Definition x := 0.
 NES.End NS144.
 
-Time NES.Begin NS145.
+NES.Begin NS145.
 Definition x := 0.
 NES.End NS145.
 
-Time NES.Begin NS146.
+NES.Begin NS146.
 Definition x := 0.
 NES.End NS146.
 
-Time NES.Begin NS147.
+NES.Begin NS147.
 Definition x := 0.
 NES.End NS147.
 
-Time NES.Begin NS148.
+NES.Begin NS148.
 Definition x := 0.
 NES.End NS148.
 
-Time NES.Begin NS149.
+NES.Begin NS149.
 Definition x := 0.
 NES.End NS149.
 
-Time NES.Begin NS150.
+NES.Begin NS150.
 Definition x := 0.
 NES.End NS150.
 
-Time NES.Begin NS151.
+NES.Begin NS151.
 Definition x := 0.
 NES.End NS151.
 
-Time NES.Begin NS152.
+NES.Begin NS152.
 Definition x := 0.
 NES.End NS152.
 
-Time NES.Begin NS153.
+NES.Begin NS153.
 Definition x := 0.
 NES.End NS153.
 
-Time NES.Begin NS154.
+NES.Begin NS154.
 Definition x := 0.
 NES.End NS154.
 
-Time NES.Begin NS155.
+NES.Begin NS155.
 Definition x := 0.
 NES.End NS155.
 
-Time NES.Begin NS156.
+NES.Begin NS156.
 Definition x := 0.
 NES.End NS156.
 
-Time NES.Begin NS157.
+NES.Begin NS157.
 Definition x := 0.
 NES.End NS157.
 
-Time NES.Begin NS158.
+NES.Begin NS158.
 Definition x := 0.
 NES.End NS158.
 
-Time NES.Begin NS159.
+NES.Begin NS159.
 Definition x := 0.
 NES.End NS159.
 
-Time NES.Begin NS160.
+NES.Begin NS160.
 Definition x := 0.
 NES.End NS160.
 
-Time NES.Begin NS161.
+NES.Begin NS161.
 Definition x := 0.
 NES.End NS161.
 
-Time NES.Begin NS162.
+NES.Begin NS162.
 Definition x := 0.
 NES.End NS162.
 
-Time NES.Begin NS163.
+NES.Begin NS163.
 Definition x := 0.
 NES.End NS163.
 
-Time NES.Begin NS164.
+NES.Begin NS164.
 Definition x := 0.
 NES.End NS164.
 
-Time NES.Begin NS165.
+NES.Begin NS165.
 Definition x := 0.
 NES.End NS165.
 
-Time NES.Begin NS166.
+NES.Begin NS166.
 Definition x := 0.
 NES.End NS166.
 
-Time NES.Begin NS167.
+NES.Begin NS167.
 Definition x := 0.
 NES.End NS167.
 
-Time NES.Begin NS168.
+NES.Begin NS168.
 Definition x := 0.
 NES.End NS168.
 
-Time NES.Begin NS169.
+NES.Begin NS169.
 Definition x := 0.
 NES.End NS169.
 
-Time NES.Begin NS170.
+NES.Begin NS170.
 Definition x := 0.
 NES.End NS170.
 
-Time NES.Begin NS171.
+NES.Begin NS171.
 Definition x := 0.
 NES.End NS171.
 
-Time NES.Begin NS172.
+NES.Begin NS172.
 Definition x := 0.
 NES.End NS172.
 
-Time NES.Begin NS173.
+NES.Begin NS173.
 Definition x := 0.
 NES.End NS173.
 
-Time NES.Begin NS174.
+NES.Begin NS174.
 Definition x := 0.
 NES.End NS174.
 
-Time NES.Begin NS175.
+NES.Begin NS175.
 Definition x := 0.
 NES.End NS175.
 
-Time NES.Begin NS176.
+NES.Begin NS176.
 Definition x := 0.
 NES.End NS176.
 
-Time NES.Begin NS177.
+NES.Begin NS177.
 Definition x := 0.
 NES.End NS177.
 
-Time NES.Begin NS178.
+NES.Begin NS178.
 Definition x := 0.
 NES.End NS178.
 
-Time NES.Begin NS179.
+NES.Begin NS179.
 Definition x := 0.
 NES.End NS179.
 
-Time NES.Begin NS180.
+NES.Begin NS180.
 Definition x := 0.
 NES.End NS180.
 
-Time NES.Begin NS181.
+NES.Begin NS181.
 Definition x := 0.
 NES.End NS181.
 
-Time NES.Begin NS182.
+NES.Begin NS182.
 Definition x := 0.
 NES.End NS182.
 
-Time NES.Begin NS183.
+NES.Begin NS183.
 Definition x := 0.
 NES.End NS183.
 
-Time NES.Begin NS184.
+NES.Begin NS184.
 Definition x := 0.
 NES.End NS184.
 
-Time NES.Begin NS185.
+NES.Begin NS185.
 Definition x := 0.
 NES.End NS185.
 
-Time NES.Begin NS186.
+NES.Begin NS186.
 Definition x := 0.
 NES.End NS186.
 
-Time NES.Begin NS187.
+NES.Begin NS187.
 Definition x := 0.
 NES.End NS187.
 
-Time NES.Begin NS188.
+NES.Begin NS188.
 Definition x := 0.
 NES.End NS188.
 
-Time NES.Begin NS189.
+NES.Begin NS189.
 Definition x := 0.
 NES.End NS189.
 
-Time NES.Begin NS190.
+NES.Begin NS190.
 Definition x := 0.
 NES.End NS190.
 
-Time NES.Begin NS191.
+NES.Begin NS191.
 Definition x := 0.
 NES.End NS191.
 
-Time NES.Begin NS192.
+NES.Begin NS192.
 Definition x := 0.
 NES.End NS192.
 
-Time NES.Begin NS193.
+NES.Begin NS193.
 Definition x := 0.
 NES.End NS193.
 
-Time NES.Begin NS194.
+NES.Begin NS194.
 Definition x := 0.
 NES.End NS194.
 
-Time NES.Begin NS195.
+NES.Begin NS195.
 Definition x := 0.
 NES.End NS195.
 
-Time NES.Begin NS196.
+NES.Begin NS196.
 Definition x := 0.
 NES.End NS196.
 
-Time NES.Begin NS197.
+NES.Begin NS197.
 Definition x := 0.
 NES.End NS197.
 
-Time NES.Begin NS198.
+NES.Begin NS198.
 Definition x := 0.
 NES.End NS198.
 
-Time NES.Begin NS199.
+NES.Begin NS199.
 Definition x := 0.
 NES.End NS199.
 
-Time NES.Begin NS200.
+NES.Begin NS200.
 Definition x := 0.
 NES.End NS200.
 
-Time NES.Begin NS201.
+NES.Begin NS201.
 Definition x := 0.
 NES.End NS201.
 
-Time NES.Begin NS202.
+NES.Begin NS202.
 Definition x := 0.
 NES.End NS202.
 
-Time NES.Begin NS203.
+NES.Begin NS203.
 Definition x := 0.
 NES.End NS203.
 
-Time NES.Begin NS204.
+NES.Begin NS204.
 Definition x := 0.
 NES.End NS204.
 
-Time NES.Begin NS205.
+NES.Begin NS205.
 Definition x := 0.
 NES.End NS205.
 
-Time NES.Begin NS206.
+NES.Begin NS206.
 Definition x := 0.
 NES.End NS206.
 
-Time NES.Begin NS207.
+NES.Begin NS207.
 Definition x := 0.
 NES.End NS207.
 
-Time NES.Begin NS208.
+NES.Begin NS208.
 Definition x := 0.
 NES.End NS208.
 
-Time NES.Begin NS209.
+NES.Begin NS209.
 Definition x := 0.
 NES.End NS209.
 
-Time NES.Begin NS210.
+NES.Begin NS210.
 Definition x := 0.
 NES.End NS210.
 
-Time NES.Begin NS211.
+NES.Begin NS211.
 Definition x := 0.
 NES.End NS211.
 
-Time NES.Begin NS212.
+NES.Begin NS212.
 Definition x := 0.
 NES.End NS212.
 
-Time NES.Begin NS213.
+NES.Begin NS213.
 Definition x := 0.
 NES.End NS213.
 
-Time NES.Begin NS214.
+NES.Begin NS214.
 Definition x := 0.
 NES.End NS214.
 
-Time NES.Begin NS215.
+NES.Begin NS215.
 Definition x := 0.
 NES.End NS215.
 
-Time NES.Begin NS216.
+NES.Begin NS216.
 Definition x := 0.
 NES.End NS216.
 
-Time NES.Begin NS217.
+NES.Begin NS217.
 Definition x := 0.
 NES.End NS217.
 
-Time NES.Begin NS218.
+NES.Begin NS218.
 Definition x := 0.
 NES.End NS218.
 
-Time NES.Begin NS219.
+NES.Begin NS219.
 Definition x := 0.
 NES.End NS219.
 
-Time NES.Begin NS220.
+NES.Begin NS220.
 Definition x := 0.
 NES.End NS220.
 
-Time NES.Begin NS221.
+NES.Begin NS221.
 Definition x := 0.
 NES.End NS221.
 
-Time NES.Begin NS222.
+NES.Begin NS222.
 Definition x := 0.
 NES.End NS222.
 
-Time NES.Begin NS223.
+NES.Begin NS223.
 Definition x := 0.
 NES.End NS223.
 
-Time NES.Begin NS224.
+NES.Begin NS224.
 Definition x := 0.
 NES.End NS224.
 
-Time NES.Begin NS225.
+NES.Begin NS225.
 Definition x := 0.
 NES.End NS225.
 
-Time NES.Begin NS226.
+NES.Begin NS226.
 Definition x := 0.
 NES.End NS226.
 
-Time NES.Begin NS227.
+NES.Begin NS227.
 Definition x := 0.
 NES.End NS227.
 
-Time NES.Begin NS228.
+NES.Begin NS228.
 Definition x := 0.
 NES.End NS228.
 
-Time NES.Begin NS229.
+NES.Begin NS229.
 Definition x := 0.
 NES.End NS229.
 
-Time NES.Begin NS230.
+NES.Begin NS230.
 Definition x := 0.
 NES.End NS230.
 
-Time NES.Begin NS231.
+NES.Begin NS231.
 Definition x := 0.
 NES.End NS231.
 
-Time NES.Begin NS232.
+NES.Begin NS232.
 Definition x := 0.
 NES.End NS232.
 
-Time NES.Begin NS233.
+NES.Begin NS233.
 Definition x := 0.
 NES.End NS233.
 
-Time NES.Begin NS234.
+NES.Begin NS234.
 Definition x := 0.
 NES.End NS234.
 
-Time NES.Begin NS235.
+NES.Begin NS235.
 Definition x := 0.
 NES.End NS235.
 
-Time NES.Begin NS236.
+NES.Begin NS236.
 Definition x := 0.
 NES.End NS236.
 
-Time NES.Begin NS237.
+NES.Begin NS237.
 Definition x := 0.
 NES.End NS237.
 
-Time NES.Begin NS238.
+NES.Begin NS238.
 Definition x := 0.
 NES.End NS238.
 
-Time NES.Begin NS239.
+NES.Begin NS239.
 Definition x := 0.
 NES.End NS239.
 
-Time NES.Begin NS240.
+NES.Begin NS240.
 Definition x := 0.
 NES.End NS240.
 
-Time NES.Begin NS241.
+NES.Begin NS241.
 Definition x := 0.
 NES.End NS241.
 
-Time NES.Begin NS242.
+NES.Begin NS242.
 Definition x := 0.
 NES.End NS242.
 
-Time NES.Begin NS243.
+NES.Begin NS243.
 Definition x := 0.
 NES.End NS243.
 
-Time NES.Begin NS244.
+NES.Begin NS244.
 Definition x := 0.
 NES.End NS244.
 
-Time NES.Begin NS245.
+NES.Begin NS245.
 Definition x := 0.
 NES.End NS245.
 
-Time NES.Begin NS246.
+NES.Begin NS246.
 Definition x := 0.
 NES.End NS246.
 
-Time NES.Begin NS247.
+NES.Begin NS247.
 Definition x := 0.
 NES.End NS247.
 
-Time NES.Begin NS248.
+NES.Begin NS248.
 Definition x := 0.
 NES.End NS248.
 
-Time NES.Begin NS249.
+NES.Begin NS249.
 Definition x := 0.
 NES.End NS249.
 
-Time NES.Begin NS250.
+NES.Begin NS250.
 Definition x := 0.
 NES.End NS250.
 
-Time NES.Begin NS251.
+NES.Begin NS251.
 Definition x := 0.
 NES.End NS251.
 
-Time NES.Begin NS252.
+NES.Begin NS252.
 Definition x := 0.
 NES.End NS252.
 
-Time NES.Begin NS253.
+NES.Begin NS253.
 Definition x := 0.
 NES.End NS253.
 
-Time NES.Begin NS254.
+NES.Begin NS254.
 Definition x := 0.
 NES.End NS254.
 
-Time NES.Begin NS255.
+NES.Begin NS255.
 Definition x := 0.
 NES.End NS255.
 
-Time NES.Begin NS256.
+NES.Begin NS256.
 Definition x := 0.
 NES.End NS256.
 
-Time NES.Begin NS257.
+NES.Begin NS257.
 Definition x := 0.
 NES.End NS257.
 
-Time NES.Begin NS258.
+NES.Begin NS258.
 Definition x := 0.
 NES.End NS258.
 
-Time NES.Begin NS259.
+NES.Begin NS259.
 Definition x := 0.
 NES.End NS259.
 
-Time NES.Begin NS260.
+NES.Begin NS260.
 Definition x := 0.
 NES.End NS260.
 
-Time NES.Begin NS261.
+NES.Begin NS261.
 Definition x := 0.
 NES.End NS261.
 
-Time NES.Begin NS262.
+NES.Begin NS262.
 Definition x := 0.
 NES.End NS262.
 
-Time NES.Begin NS263.
+NES.Begin NS263.
 Definition x := 0.
 NES.End NS263.
 
-Time NES.Begin NS264.
+NES.Begin NS264.
 Definition x := 0.
 NES.End NS264.
 
-Time NES.Begin NS265.
+NES.Begin NS265.
 Definition x := 0.
 NES.End NS265.
 
-Time NES.Begin NS266.
+NES.Begin NS266.
 Definition x := 0.
 NES.End NS266.
 
-Time NES.Begin NS267.
+NES.Begin NS267.
 Definition x := 0.
 NES.End NS267.
 
-Time NES.Begin NS268.
+NES.Begin NS268.
 Definition x := 0.
 NES.End NS268.
 
-Time NES.Begin NS269.
+NES.Begin NS269.
 Definition x := 0.
 NES.End NS269.
 
-Time NES.Begin NS270.
+NES.Begin NS270.
 Definition x := 0.
 NES.End NS270.
 
-Time NES.Begin NS271.
+NES.Begin NS271.
 Definition x := 0.
 NES.End NS271.
 
-Time NES.Begin NS272.
+NES.Begin NS272.
 Definition x := 0.
 NES.End NS272.
 
-Time NES.Begin NS273.
+NES.Begin NS273.
 Definition x := 0.
 NES.End NS273.
 
-Time NES.Begin NS274.
+NES.Begin NS274.
 Definition x := 0.
 NES.End NS274.
 
-Time NES.Begin NS275.
+NES.Begin NS275.
 Definition x := 0.
 NES.End NS275.
 
-Time NES.Begin NS276.
+NES.Begin NS276.
 Definition x := 0.
 NES.End NS276.
 
-Time NES.Begin NS277.
+NES.Begin NS277.
 Definition x := 0.
 NES.End NS277.
 
-Time NES.Begin NS278.
+NES.Begin NS278.
 Definition x := 0.
 NES.End NS278.
 
-Time NES.Begin NS279.
+NES.Begin NS279.
 Definition x := 0.
 NES.End NS279.
 
-Time NES.Begin NS280.
+NES.Begin NS280.
 Definition x := 0.
 NES.End NS280.
 
-Time NES.Begin NS281.
+NES.Begin NS281.
 Definition x := 0.
 NES.End NS281.
 
-Time NES.Begin NS282.
+NES.Begin NS282.
 Definition x := 0.
 NES.End NS282.
 
-Time NES.Begin NS283.
+NES.Begin NS283.
 Definition x := 0.
 NES.End NS283.
 
-Time NES.Begin NS284.
+NES.Begin NS284.
 Definition x := 0.
 NES.End NS284.
 
-Time NES.Begin NS285.
+NES.Begin NS285.
 Definition x := 0.
 NES.End NS285.
 
-Time NES.Begin NS286.
+NES.Begin NS286.
 Definition x := 0.
 NES.End NS286.
 
-Time NES.Begin NS287.
+NES.Begin NS287.
 Definition x := 0.
 NES.End NS287.
 
-Time NES.Begin NS288.
+NES.Begin NS288.
 Definition x := 0.
 NES.End NS288.
 
-Time NES.Begin NS289.
+NES.Begin NS289.
 Definition x := 0.
 NES.End NS289.
 
-Time NES.Begin NS290.
+NES.Begin NS290.
 Definition x := 0.
 NES.End NS290.
 
-Time NES.Begin NS291.
+NES.Begin NS291.
 Definition x := 0.
 NES.End NS291.
 
-Time NES.Begin NS292.
+NES.Begin NS292.
 Definition x := 0.
 NES.End NS292.
 
-Time NES.Begin NS293.
+NES.Begin NS293.
 Definition x := 0.
 NES.End NS293.
 
-Time NES.Begin NS294.
+NES.Begin NS294.
 Definition x := 0.
 NES.End NS294.
 
-Time NES.Begin NS295.
+NES.Begin NS295.
 Definition x := 0.
 NES.End NS295.
 
-Time NES.Begin NS296.
+NES.Begin NS296.
 Definition x := 0.
 NES.End NS296.
 
-Time NES.Begin NS297.
+NES.Begin NS297.
 Definition x := 0.
 NES.End NS297.
 
-Time NES.Begin NS298.
+NES.Begin NS298.
 Definition x := 0.
 NES.End NS298.
 
-Time NES.Begin NS299.
+NES.Begin NS299.
 Definition x := 0.
 NES.End NS299.
 
-Time NES.Begin NS300.
+NES.Begin NS300.
 Definition x := 0.
 NES.End NS300.
 
-Time NES.Begin NS301.
+NES.Begin NS301.
 Definition x := 0.
 NES.End NS301.
 
-Time NES.Begin NS302.
+NES.Begin NS302.
 Definition x := 0.
 NES.End NS302.
 
-Time NES.Begin NS303.
+NES.Begin NS303.
 Definition x := 0.
 NES.End NS303.
 
-Time NES.Begin NS304.
+NES.Begin NS304.
 Definition x := 0.
 NES.End NS304.
 
-Time NES.Begin NS305.
+NES.Begin NS305.
 Definition x := 0.
 NES.End NS305.
 
-Time NES.Begin NS306.
+NES.Begin NS306.
 Definition x := 0.
 NES.End NS306.
 
-Time NES.Begin NS307.
+NES.Begin NS307.
 Definition x := 0.
 NES.End NS307.
 
-Time NES.Begin NS308.
+NES.Begin NS308.
 Definition x := 0.
 NES.End NS308.
 
-Time NES.Begin NS309.
+NES.Begin NS309.
 Definition x := 0.
 NES.End NS309.
 
-Time NES.Begin NS310.
+NES.Begin NS310.
 Definition x := 0.
 NES.End NS310.
 
-Time NES.Begin NS311.
+NES.Begin NS311.
 Definition x := 0.
 NES.End NS311.
 
-Time NES.Begin NS312.
+NES.Begin NS312.
 Definition x := 0.
 NES.End NS312.
 
-Time NES.Begin NS313.
+NES.Begin NS313.
 Definition x := 0.
 NES.End NS313.
 
-Time NES.Begin NS314.
+NES.Begin NS314.
 Definition x := 0.
 NES.End NS314.
 
-Time NES.Begin NS315.
+NES.Begin NS315.
 Definition x := 0.
 NES.End NS315.
 
-Time NES.Begin NS316.
+NES.Begin NS316.
 Definition x := 0.
 NES.End NS316.
 
-Time NES.Begin NS317.
+NES.Begin NS317.
 Definition x := 0.
 NES.End NS317.
 
-Time NES.Begin NS318.
+NES.Begin NS318.
 Definition x := 0.
 NES.End NS318.
 
-Time NES.Begin NS319.
+NES.Begin NS319.
 Definition x := 0.
 NES.End NS319.
 
-Time NES.Begin NS320.
+NES.Begin NS320.
 Definition x := 0.
 NES.End NS320.
 
-Time NES.Begin NS321.
+NES.Begin NS321.
 Definition x := 0.
 NES.End NS321.
 
-Time NES.Begin NS322.
+NES.Begin NS322.
 Definition x := 0.
 NES.End NS322.
 
-Time NES.Begin NS323.
+NES.Begin NS323.
 Definition x := 0.
 NES.End NS323.
 
-Time NES.Begin NS324.
+NES.Begin NS324.
 Definition x := 0.
 NES.End NS324.
 
-Time NES.Begin NS325.
+NES.Begin NS325.
 Definition x := 0.
 NES.End NS325.
 
-Time NES.Begin NS326.
+NES.Begin NS326.
 Definition x := 0.
 NES.End NS326.
 
-Time NES.Begin NS327.
+NES.Begin NS327.
 Definition x := 0.
 NES.End NS327.
 
-Time NES.Begin NS328.
+NES.Begin NS328.
 Definition x := 0.
 NES.End NS328.
 
-Time NES.Begin NS329.
+NES.Begin NS329.
 Definition x := 0.
 NES.End NS329.
 
-Time NES.Begin NS330.
+NES.Begin NS330.
 Definition x := 0.
 NES.End NS330.
 
-Time NES.Begin NS331.
+NES.Begin NS331.
 Definition x := 0.
 NES.End NS331.
 
-Time NES.Begin NS332.
+NES.Begin NS332.
 Definition x := 0.
 NES.End NS332.
 
-Time NES.Begin NS333.
+NES.Begin NS333.
 Definition x := 0.
 NES.End NS333.
 
-Time NES.Begin NS334.
+NES.Begin NS334.
 Definition x := 0.
 NES.End NS334.
 
-Time NES.Begin NS335.
+NES.Begin NS335.
 Definition x := 0.
 NES.End NS335.
 
-Time NES.Begin NS336.
+NES.Begin NS336.
 Definition x := 0.
 NES.End NS336.
 
-Time NES.Begin NS337.
+NES.Begin NS337.
 Definition x := 0.
 NES.End NS337.
 
-Time NES.Begin NS338.
+NES.Begin NS338.
 Definition x := 0.
 NES.End NS338.
 
-Time NES.Begin NS339.
+NES.Begin NS339.
 Definition x := 0.
 NES.End NS339.
 
-Time NES.Begin NS340.
+NES.Begin NS340.
 Definition x := 0.
 NES.End NS340.
 
-Time NES.Begin NS341.
+NES.Begin NS341.
 Definition x := 0.
 NES.End NS341.
 
-Time NES.Begin NS342.
+NES.Begin NS342.
 Definition x := 0.
 NES.End NS342.
 
-Time NES.Begin NS343.
+NES.Begin NS343.
 Definition x := 0.
 NES.End NS343.
 
-Time NES.Begin NS344.
+NES.Begin NS344.
 Definition x := 0.
 NES.End NS344.
 
-Time NES.Begin NS345.
+NES.Begin NS345.
 Definition x := 0.
 NES.End NS345.
 
-Time NES.Begin NS346.
+NES.Begin NS346.
 Definition x := 0.
 NES.End NS346.
 
-Time NES.Begin NS347.
+NES.Begin NS347.
 Definition x := 0.
 NES.End NS347.
 
-Time NES.Begin NS348.
+NES.Begin NS348.
 Definition x := 0.
 NES.End NS348.
 
-Time NES.Begin NS349.
+NES.Begin NS349.
 Definition x := 0.
 NES.End NS349.
 
-Time NES.Begin NS350.
+NES.Begin NS350.
 Definition x := 0.
 NES.End NS350.
 
-Time NES.Begin NS351.
+NES.Begin NS351.
 Definition x := 0.
 NES.End NS351.
 
-Time NES.Begin NS352.
+NES.Begin NS352.
 Definition x := 0.
 NES.End NS352.
 
-Time NES.Begin NS353.
+NES.Begin NS353.
 Definition x := 0.
 NES.End NS353.
 
-Time NES.Begin NS354.
+NES.Begin NS354.
 Definition x := 0.
 NES.End NS354.
 
-Time NES.Begin NS355.
+NES.Begin NS355.
 Definition x := 0.
 NES.End NS355.
 
-Time NES.Begin NS356.
+NES.Begin NS356.
 Definition x := 0.
 NES.End NS356.
 
-Time NES.Begin NS357.
+NES.Begin NS357.
 Definition x := 0.
 NES.End NS357.
 
-Time NES.Begin NS358.
+NES.Begin NS358.
 Definition x := 0.
 NES.End NS358.
 
-Time NES.Begin NS359.
+NES.Begin NS359.
 Definition x := 0.
 NES.End NS359.
 
-Time NES.Begin NS360.
+NES.Begin NS360.
 Definition x := 0.
 NES.End NS360.
 
-Time NES.Begin NS361.
+NES.Begin NS361.
 Definition x := 0.
 NES.End NS361.
 
-Time NES.Begin NS362.
+NES.Begin NS362.
 Definition x := 0.
 NES.End NS362.
 
-Time NES.Begin NS363.
+NES.Begin NS363.
 Definition x := 0.
 NES.End NS363.
 
-Time NES.Begin NS364.
+NES.Begin NS364.
 Definition x := 0.
 NES.End NS364.
 
-Time NES.Begin NS365.
+NES.Begin NS365.
 Definition x := 0.
 NES.End NS365.
 
-Time NES.Begin NS366.
+NES.Begin NS366.
 Definition x := 0.
 NES.End NS366.
 
-Time NES.Begin NS367.
+NES.Begin NS367.
 Definition x := 0.
 NES.End NS367.
 
-Time NES.Begin NS368.
+NES.Begin NS368.
 Definition x := 0.
 NES.End NS368.
 
-Time NES.Begin NS369.
+NES.Begin NS369.
 Definition x := 0.
 NES.End NS369.
 
-Time NES.Begin NS370.
+NES.Begin NS370.
 Definition x := 0.
 NES.End NS370.
 
-Time NES.Begin NS371.
+NES.Begin NS371.
 Definition x := 0.
 NES.End NS371.
 
-Time NES.Begin NS372.
+NES.Begin NS372.
 Definition x := 0.
 NES.End NS372.
 
-Time NES.Begin NS373.
+NES.Begin NS373.
 Definition x := 0.
 NES.End NS373.
 
-Time NES.Begin NS374.
+NES.Begin NS374.
 Definition x := 0.
 NES.End NS374.
 
-Time NES.Begin NS375.
+NES.Begin NS375.
 Definition x := 0.
 NES.End NS375.
 
-Time NES.Begin NS376.
+NES.Begin NS376.
 Definition x := 0.
 NES.End NS376.
 
-Time NES.Begin NS377.
+NES.Begin NS377.
 Definition x := 0.
 NES.End NS377.
 
-Time NES.Begin NS378.
+NES.Begin NS378.
 Definition x := 0.
 NES.End NS378.
 
-Time NES.Begin NS379.
+NES.Begin NS379.
 Definition x := 0.
 NES.End NS379.
 
-Time NES.Begin NS380.
+NES.Begin NS380.
 Definition x := 0.
 NES.End NS380.
 
-Time NES.Begin NS381.
+NES.Begin NS381.
 Definition x := 0.
 NES.End NS381.
 
-Time NES.Begin NS382.
+NES.Begin NS382.
 Definition x := 0.
 NES.End NS382.
 
-Time NES.Begin NS383.
+NES.Begin NS383.
 Definition x := 0.
 NES.End NS383.
 
-Time NES.Begin NS384.
+NES.Begin NS384.
 Definition x := 0.
 NES.End NS384.
 
-Time NES.Begin NS385.
+NES.Begin NS385.
 Definition x := 0.
 NES.End NS385.
 
-Time NES.Begin NS386.
+NES.Begin NS386.
 Definition x := 0.
 NES.End NS386.
 
-Time NES.Begin NS387.
+NES.Begin NS387.
 Definition x := 0.
 NES.End NS387.
 
-Time NES.Begin NS388.
+NES.Begin NS388.
 Definition x := 0.
 NES.End NS388.
 
-Time NES.Begin NS389.
+NES.Begin NS389.
 Definition x := 0.
 NES.End NS389.
 
-Time NES.Begin NS390.
+NES.Begin NS390.
 Definition x := 0.
 NES.End NS390.
 
-Time NES.Begin NS391.
+NES.Begin NS391.
 Definition x := 0.
 NES.End NS391.
 
-Time NES.Begin NS392.
+NES.Begin NS392.
 Definition x := 0.
 NES.End NS392.
 
-Time NES.Begin NS393.
+NES.Begin NS393.
 Definition x := 0.
 NES.End NS393.
 
-Time NES.Begin NS394.
+NES.Begin NS394.
 Definition x := 0.
 NES.End NS394.
 
-Time NES.Begin NS395.
+NES.Begin NS395.
 Definition x := 0.
 NES.End NS395.
 
-Time NES.Begin NS396.
+NES.Begin NS396.
 Definition x := 0.
 NES.End NS396.
 
-Time NES.Begin NS397.
+NES.Begin NS397.
 Definition x := 0.
 NES.End NS397.
 
-Time NES.Begin NS398.
+NES.Begin NS398.
 Definition x := 0.
 NES.End NS398.
 
-Time NES.Begin NS399.
+NES.Begin NS399.
 Definition x := 0.
 NES.End NS399.
 
-Time NES.Begin NS400.
+NES.Begin NS400.
 Definition x := 0.
 NES.End NS400.
 
-Time NES.Begin NS401.
+NES.Begin NS401.
 Definition x := 0.
 NES.End NS401.
 
-Time NES.Begin NS402.
+NES.Begin NS402.
 Definition x := 0.
 NES.End NS402.
 
-Time NES.Begin NS403.
+NES.Begin NS403.
 Definition x := 0.
 NES.End NS403.
 
-Time NES.Begin NS404.
+NES.Begin NS404.
 Definition x := 0.
 NES.End NS404.
 
-Time NES.Begin NS405.
+NES.Begin NS405.
 Definition x := 0.
 NES.End NS405.
 
-Time NES.Begin NS406.
+NES.Begin NS406.
 Definition x := 0.
 NES.End NS406.
 
-Time NES.Begin NS407.
+NES.Begin NS407.
 Definition x := 0.
 NES.End NS407.
 
-Time NES.Begin NS408.
+NES.Begin NS408.
 Definition x := 0.
 NES.End NS408.
 
-Time NES.Begin NS409.
+NES.Begin NS409.
 Definition x := 0.
 NES.End NS409.
 
-Time NES.Begin NS410.
+NES.Begin NS410.
 Definition x := 0.
 NES.End NS410.
 
-Time NES.Begin NS411.
+NES.Begin NS411.
 Definition x := 0.
 NES.End NS411.
 
-Time NES.Begin NS412.
+NES.Begin NS412.
 Definition x := 0.
 NES.End NS412.
 
-Time NES.Begin NS413.
+NES.Begin NS413.
 Definition x := 0.
 NES.End NS413.
 
-Time NES.Begin NS414.
+NES.Begin NS414.
 Definition x := 0.
 NES.End NS414.
 
-Time NES.Begin NS415.
+NES.Begin NS415.
 Definition x := 0.
 NES.End NS415.
 
-Time NES.Begin NS416.
+NES.Begin NS416.
 Definition x := 0.
 NES.End NS416.
 
-Time NES.Begin NS417.
+NES.Begin NS417.
 Definition x := 0.
 NES.End NS417.
 
-Time NES.Begin NS418.
+NES.Begin NS418.
 Definition x := 0.
 NES.End NS418.
 
-Time NES.Begin NS419.
+NES.Begin NS419.
 Definition x := 0.
 NES.End NS419.
 
-Time NES.Begin NS420.
+NES.Begin NS420.
 Definition x := 0.
 NES.End NS420.
 
-Time NES.Begin NS421.
+NES.Begin NS421.
 Definition x := 0.
 NES.End NS421.
 
-Time NES.Begin NS422.
+NES.Begin NS422.
 Definition x := 0.
 NES.End NS422.
 
-Time NES.Begin NS423.
+NES.Begin NS423.
 Definition x := 0.
 NES.End NS423.
 
-Time NES.Begin NS424.
+NES.Begin NS424.
 Definition x := 0.
 NES.End NS424.
 
-Time NES.Begin NS425.
+NES.Begin NS425.
 Definition x := 0.
 NES.End NS425.
 
-Time NES.Begin NS426.
+NES.Begin NS426.
 Definition x := 0.
 NES.End NS426.
 
-Time NES.Begin NS427.
+NES.Begin NS427.
 Definition x := 0.
 NES.End NS427.
 
-Time NES.Begin NS428.
+NES.Begin NS428.
 Definition x := 0.
 NES.End NS428.
 
-Time NES.Begin NS429.
+NES.Begin NS429.
 Definition x := 0.
 NES.End NS429.
 
-Time NES.Begin NS430.
+NES.Begin NS430.
 Definition x := 0.
 NES.End NS430.
 
-Time NES.Begin NS431.
+NES.Begin NS431.
 Definition x := 0.
 NES.End NS431.
 
-Time NES.Begin NS432.
+NES.Begin NS432.
 Definition x := 0.
 NES.End NS432.
 
-Time NES.Begin NS433.
+NES.Begin NS433.
 Definition x := 0.
 NES.End NS433.
 
-Time NES.Begin NS434.
+NES.Begin NS434.
 Definition x := 0.
 NES.End NS434.
 
-Time NES.Begin NS435.
+NES.Begin NS435.
 Definition x := 0.
 NES.End NS435.
 
-Time NES.Begin NS436.
+NES.Begin NS436.
 Definition x := 0.
 NES.End NS436.
 
-Time NES.Begin NS437.
+NES.Begin NS437.
 Definition x := 0.
 NES.End NS437.
 
-Time NES.Begin NS438.
+NES.Begin NS438.
 Definition x := 0.
 NES.End NS438.
 
-Time NES.Begin NS439.
+NES.Begin NS439.
 Definition x := 0.
 NES.End NS439.
 
-Time NES.Begin NS440.
+NES.Begin NS440.
 Definition x := 0.
 NES.End NS440.
 
-Time NES.Begin NS441.
+NES.Begin NS441.
 Definition x := 0.
 NES.End NS441.
 
-Time NES.Begin NS442.
+NES.Begin NS442.
 Definition x := 0.
 NES.End NS442.
 
-Time NES.Begin NS443.
+NES.Begin NS443.
 Definition x := 0.
 NES.End NS443.
 
-Time NES.Begin NS444.
+NES.Begin NS444.
 Definition x := 0.
 NES.End NS444.
 
-Time NES.Begin NS445.
+NES.Begin NS445.
 Definition x := 0.
 NES.End NS445.
 
-Time NES.Begin NS446.
+NES.Begin NS446.
 Definition x := 0.
 NES.End NS446.
 
-Time NES.Begin NS447.
+NES.Begin NS447.
 Definition x := 0.
 NES.End NS447.
 
-Time NES.Begin NS448.
+NES.Begin NS448.
 Definition x := 0.
 NES.End NS448.
 
-Time NES.Begin NS449.
+NES.Begin NS449.
 Definition x := 0.
 NES.End NS449.
 
-Time NES.Begin NS450.
+NES.Begin NS450.
 Definition x := 0.
 NES.End NS450.
 
-Time NES.Begin NS451.
+NES.Begin NS451.
 Definition x := 0.
 NES.End NS451.
 
-Time NES.Begin NS452.
+NES.Begin NS452.
 Definition x := 0.
 NES.End NS452.
 
-Time NES.Begin NS453.
+NES.Begin NS453.
 Definition x := 0.
 NES.End NS453.
 
-Time NES.Begin NS454.
+NES.Begin NS454.
 Definition x := 0.
 NES.End NS454.
 
-Time NES.Begin NS455.
+NES.Begin NS455.
 Definition x := 0.
 NES.End NS455.
 
-Time NES.Begin NS456.
+NES.Begin NS456.
 Definition x := 0.
 NES.End NS456.
 
-Time NES.Begin NS457.
+NES.Begin NS457.
 Definition x := 0.
 NES.End NS457.
 
-Time NES.Begin NS458.
+NES.Begin NS458.
 Definition x := 0.
 NES.End NS458.
 
-Time NES.Begin NS459.
+NES.Begin NS459.
 Definition x := 0.
 NES.End NS459.
 
-Time NES.Begin NS460.
+NES.Begin NS460.
 Definition x := 0.
 NES.End NS460.
 
-Time NES.Begin NS461.
+NES.Begin NS461.
 Definition x := 0.
 NES.End NS461.
 
-Time NES.Begin NS462.
+NES.Begin NS462.
 Definition x := 0.
 NES.End NS462.
 
-Time NES.Begin NS463.
+NES.Begin NS463.
 Definition x := 0.
 NES.End NS463.
 
-Time NES.Begin NS464.
+NES.Begin NS464.
 Definition x := 0.
 NES.End NS464.
 
-Time NES.Begin NS465.
+NES.Begin NS465.
 Definition x := 0.
 NES.End NS465.
 
-Time NES.Begin NS466.
+NES.Begin NS466.
 Definition x := 0.
 NES.End NS466.
 
-Time NES.Begin NS467.
+NES.Begin NS467.
 Definition x := 0.
 NES.End NS467.
 
-Time NES.Begin NS468.
+NES.Begin NS468.
 Definition x := 0.
 NES.End NS468.
 
-Time NES.Begin NS469.
+NES.Begin NS469.
 Definition x := 0.
 NES.End NS469.
 
-Time NES.Begin NS470.
+NES.Begin NS470.
 Definition x := 0.
 NES.End NS470.
 
-Time NES.Begin NS471.
+NES.Begin NS471.
 Definition x := 0.
 NES.End NS471.
 
-Time NES.Begin NS472.
+NES.Begin NS472.
 Definition x := 0.
 NES.End NS472.
 
-Time NES.Begin NS473.
+NES.Begin NS473.
 Definition x := 0.
 NES.End NS473.
 
-Time NES.Begin NS474.
+NES.Begin NS474.
 Definition x := 0.
 NES.End NS474.
 
-Time NES.Begin NS475.
+NES.Begin NS475.
 Definition x := 0.
 NES.End NS475.
 
-Time NES.Begin NS476.
+NES.Begin NS476.
 Definition x := 0.
 NES.End NS476.
 
-Time NES.Begin NS477.
+NES.Begin NS477.
 Definition x := 0.
 NES.End NS477.
 
-Time NES.Begin NS478.
+NES.Begin NS478.
 Definition x := 0.
 NES.End NS478.
 
-Time NES.Begin NS479.
+NES.Begin NS479.
 Definition x := 0.
 NES.End NS479.
 
-Time NES.Begin NS480.
+NES.Begin NS480.
 Definition x := 0.
 NES.End NS480.
 
-Time NES.Begin NS481.
+NES.Begin NS481.
 Definition x := 0.
 NES.End NS481.
 
-Time NES.Begin NS482.
+NES.Begin NS482.
 Definition x := 0.
 NES.End NS482.
 
-Time NES.Begin NS483.
+NES.Begin NS483.
 Definition x := 0.
 NES.End NS483.
 
-Time NES.Begin NS484.
+NES.Begin NS484.
 Definition x := 0.
 NES.End NS484.
 
-Time NES.Begin NS485.
+NES.Begin NS485.
 Definition x := 0.
 NES.End NS485.
 
-Time NES.Begin NS486.
+NES.Begin NS486.
 Definition x := 0.
 NES.End NS486.
 
-Time NES.Begin NS487.
+NES.Begin NS487.
 Definition x := 0.
 NES.End NS487.
 
-Time NES.Begin NS488.
+NES.Begin NS488.
 Definition x := 0.
 NES.End NS488.
 
-Time NES.Begin NS489.
+NES.Begin NS489.
 Definition x := 0.
 NES.End NS489.
 
-Time NES.Begin NS490.
+NES.Begin NS490.
 Definition x := 0.
 NES.End NS490.
 
-Time NES.Begin NS491.
+NES.Begin NS491.
 Definition x := 0.
 NES.End NS491.
 
-Time NES.Begin NS492.
+NES.Begin NS492.
 Definition x := 0.
 NES.End NS492.
 
-Time NES.Begin NS493.
+NES.Begin NS493.
 Definition x := 0.
 NES.End NS493.
 
-Time NES.Begin NS494.
+NES.Begin NS494.
 Definition x := 0.
 NES.End NS494.
 
-Time NES.Begin NS495.
+NES.Begin NS495.
 Definition x := 0.
 NES.End NS495.
 
-Time NES.Begin NS496.
+NES.Begin NS496.
 Definition x := 0.
 NES.End NS496.
 
-Time NES.Begin NS497.
+NES.Begin NS497.
 Definition x := 0.
 NES.End NS497.
 
-Time NES.Begin NS498.
+NES.Begin NS498.
 Definition x := 0.
 NES.End NS498.
 
-Time NES.Begin NS499.
+NES.Begin NS499.
 Definition x := 0.
 NES.End NS499.
 
-Time NES.Begin NS500.
+NES.Begin NS500.
 Definition x := 0.
 NES.End NS500.

--- a/apps/NES/tests/test_NES_perf.v
+++ b/apps/NES/tests/test_NES_perf.v
@@ -1,0 +1,2002 @@
+From elpi.apps Require Import NES.
+
+Time NES.Begin NS1.
+stop
+Definition x := 0.
+NES.End NS1.
+
+Time NES.Begin NS2.
+Definition x := 0.
+NES.End NS2.
+
+Time NES.Begin NS3.
+Definition x := 0.
+NES.End NS3.
+
+Time NES.Begin NS4.
+Definition x := 0.
+NES.End NS4.
+
+Time NES.Begin NS5.
+Definition x := 0.
+NES.End NS5.
+
+Time NES.Begin NS6.
+Definition x := 0.
+NES.End NS6.
+
+Time NES.Begin NS7.
+Definition x := 0.
+NES.End NS7.
+
+Time NES.Begin NS8.
+Definition x := 0.
+NES.End NS8.
+
+Time NES.Begin NS9.
+Definition x := 0.
+NES.End NS9.
+
+Time NES.Begin NS10.
+Definition x := 0.
+NES.End NS10.
+
+Time NES.Begin NS11.
+Definition x := 0.
+NES.End NS11.
+
+Time NES.Begin NS12.
+Definition x := 0.
+NES.End NS12.
+
+Time NES.Begin NS13.
+Definition x := 0.
+NES.End NS13.
+
+Time NES.Begin NS14.
+Definition x := 0.
+NES.End NS14.
+
+Time NES.Begin NS15.
+Definition x := 0.
+NES.End NS15.
+
+Time NES.Begin NS16.
+Definition x := 0.
+NES.End NS16.
+
+Time NES.Begin NS17.
+Definition x := 0.
+NES.End NS17.
+
+Time NES.Begin NS18.
+Definition x := 0.
+NES.End NS18.
+
+Time NES.Begin NS19.
+Definition x := 0.
+NES.End NS19.
+
+Time NES.Begin NS20.
+Definition x := 0.
+NES.End NS20.
+
+Time NES.Begin NS21.
+Definition x := 0.
+NES.End NS21.
+
+Time NES.Begin NS22.
+Definition x := 0.
+NES.End NS22.
+
+Time NES.Begin NS23.
+Definition x := 0.
+NES.End NS23.
+
+Time NES.Begin NS24.
+Definition x := 0.
+NES.End NS24.
+
+Time NES.Begin NS25.
+Definition x := 0.
+NES.End NS25.
+
+Time NES.Begin NS26.
+Definition x := 0.
+NES.End NS26.
+
+Time NES.Begin NS27.
+Definition x := 0.
+NES.End NS27.
+
+Time NES.Begin NS28.
+Definition x := 0.
+NES.End NS28.
+
+Time NES.Begin NS29.
+Definition x := 0.
+NES.End NS29.
+
+Time NES.Begin NS30.
+Definition x := 0.
+NES.End NS30.
+
+Time NES.Begin NS31.
+Definition x := 0.
+NES.End NS31.
+
+Time NES.Begin NS32.
+Definition x := 0.
+NES.End NS32.
+
+Time NES.Begin NS33.
+Definition x := 0.
+NES.End NS33.
+
+Time NES.Begin NS34.
+Definition x := 0.
+NES.End NS34.
+
+Time NES.Begin NS35.
+Definition x := 0.
+NES.End NS35.
+
+Time NES.Begin NS36.
+Definition x := 0.
+NES.End NS36.
+
+Time NES.Begin NS37.
+Definition x := 0.
+NES.End NS37.
+
+Time NES.Begin NS38.
+Definition x := 0.
+NES.End NS38.
+
+Time NES.Begin NS39.
+Definition x := 0.
+NES.End NS39.
+
+Time NES.Begin NS40.
+Definition x := 0.
+NES.End NS40.
+
+Time NES.Begin NS41.
+Definition x := 0.
+NES.End NS41.
+
+Time NES.Begin NS42.
+Definition x := 0.
+NES.End NS42.
+
+Time NES.Begin NS43.
+Definition x := 0.
+NES.End NS43.
+
+Time NES.Begin NS44.
+Definition x := 0.
+NES.End NS44.
+
+Time NES.Begin NS45.
+Definition x := 0.
+NES.End NS45.
+
+Time NES.Begin NS46.
+Definition x := 0.
+NES.End NS46.
+
+Time NES.Begin NS47.
+Definition x := 0.
+NES.End NS47.
+
+Time NES.Begin NS48.
+Definition x := 0.
+NES.End NS48.
+
+Time NES.Begin NS49.
+Definition x := 0.
+NES.End NS49.
+
+Time NES.Begin NS50.
+Definition x := 0.
+NES.End NS50.
+
+Time NES.Begin NS51.
+Definition x := 0.
+NES.End NS51.
+
+Time NES.Begin NS52.
+Definition x := 0.
+NES.End NS52.
+
+Time NES.Begin NS53.
+Definition x := 0.
+NES.End NS53.
+
+Time NES.Begin NS54.
+Definition x := 0.
+NES.End NS54.
+
+Time NES.Begin NS55.
+Definition x := 0.
+NES.End NS55.
+
+Time NES.Begin NS56.
+Definition x := 0.
+NES.End NS56.
+
+Time NES.Begin NS57.
+Definition x := 0.
+NES.End NS57.
+
+Time NES.Begin NS58.
+Definition x := 0.
+NES.End NS58.
+
+Time NES.Begin NS59.
+Definition x := 0.
+NES.End NS59.
+
+Time NES.Begin NS60.
+Definition x := 0.
+NES.End NS60.
+
+Time NES.Begin NS61.
+Definition x := 0.
+NES.End NS61.
+
+Time NES.Begin NS62.
+Definition x := 0.
+NES.End NS62.
+
+Time NES.Begin NS63.
+Definition x := 0.
+NES.End NS63.
+
+Time NES.Begin NS64.
+Definition x := 0.
+NES.End NS64.
+
+Time NES.Begin NS65.
+Definition x := 0.
+NES.End NS65.
+
+Time NES.Begin NS66.
+Definition x := 0.
+NES.End NS66.
+
+Time NES.Begin NS67.
+Definition x := 0.
+NES.End NS67.
+
+Time NES.Begin NS68.
+Definition x := 0.
+NES.End NS68.
+
+Time NES.Begin NS69.
+Definition x := 0.
+NES.End NS69.
+
+Time NES.Begin NS70.
+Definition x := 0.
+NES.End NS70.
+
+Time NES.Begin NS71.
+Definition x := 0.
+NES.End NS71.
+
+Time NES.Begin NS72.
+Definition x := 0.
+NES.End NS72.
+
+Time NES.Begin NS73.
+Definition x := 0.
+NES.End NS73.
+
+Time NES.Begin NS74.
+Definition x := 0.
+NES.End NS74.
+
+Time NES.Begin NS75.
+Definition x := 0.
+NES.End NS75.
+
+Time NES.Begin NS76.
+Definition x := 0.
+NES.End NS76.
+
+Time NES.Begin NS77.
+Definition x := 0.
+NES.End NS77.
+
+Time NES.Begin NS78.
+Definition x := 0.
+NES.End NS78.
+
+Time NES.Begin NS79.
+Definition x := 0.
+NES.End NS79.
+
+Time NES.Begin NS80.
+Definition x := 0.
+NES.End NS80.
+
+Time NES.Begin NS81.
+Definition x := 0.
+NES.End NS81.
+
+Time NES.Begin NS82.
+Definition x := 0.
+NES.End NS82.
+
+Time NES.Begin NS83.
+Definition x := 0.
+NES.End NS83.
+
+Time NES.Begin NS84.
+Definition x := 0.
+NES.End NS84.
+
+Time NES.Begin NS85.
+Definition x := 0.
+NES.End NS85.
+
+Time NES.Begin NS86.
+Definition x := 0.
+NES.End NS86.
+
+Time NES.Begin NS87.
+Definition x := 0.
+NES.End NS87.
+
+Time NES.Begin NS88.
+Definition x := 0.
+NES.End NS88.
+
+Time NES.Begin NS89.
+Definition x := 0.
+NES.End NS89.
+
+Time NES.Begin NS90.
+Definition x := 0.
+NES.End NS90.
+
+Time NES.Begin NS91.
+Definition x := 0.
+NES.End NS91.
+
+Time NES.Begin NS92.
+Definition x := 0.
+NES.End NS92.
+
+Time NES.Begin NS93.
+Definition x := 0.
+NES.End NS93.
+
+Time NES.Begin NS94.
+Definition x := 0.
+NES.End NS94.
+
+Time NES.Begin NS95.
+Definition x := 0.
+NES.End NS95.
+
+Time NES.Begin NS96.
+Definition x := 0.
+NES.End NS96.
+
+Time NES.Begin NS97.
+Definition x := 0.
+NES.End NS97.
+
+Time NES.Begin NS98.
+Definition x := 0.
+NES.End NS98.
+
+Time NES.Begin NS99.
+Definition x := 0.
+NES.End NS99.
+
+Time NES.Begin NS100.
+Definition x := 0.
+NES.End NS100.
+
+Time NES.Begin NS101.
+Definition x := 0.
+NES.End NS101.
+
+Time NES.Begin NS102.
+Definition x := 0.
+NES.End NS102.
+
+Time NES.Begin NS103.
+Definition x := 0.
+NES.End NS103.
+
+Time NES.Begin NS104.
+Definition x := 0.
+NES.End NS104.
+
+Time NES.Begin NS105.
+Definition x := 0.
+NES.End NS105.
+
+Time NES.Begin NS106.
+Definition x := 0.
+NES.End NS106.
+
+Time NES.Begin NS107.
+Definition x := 0.
+NES.End NS107.
+
+Time NES.Begin NS108.
+Definition x := 0.
+NES.End NS108.
+
+Time NES.Begin NS109.
+Definition x := 0.
+NES.End NS109.
+
+Time NES.Begin NS110.
+Definition x := 0.
+NES.End NS110.
+
+Time NES.Begin NS111.
+Definition x := 0.
+NES.End NS111.
+
+Time NES.Begin NS112.
+Definition x := 0.
+NES.End NS112.
+
+Time NES.Begin NS113.
+Definition x := 0.
+NES.End NS113.
+
+Time NES.Begin NS114.
+Definition x := 0.
+NES.End NS114.
+
+Time NES.Begin NS115.
+Definition x := 0.
+NES.End NS115.
+
+Time NES.Begin NS116.
+Definition x := 0.
+NES.End NS116.
+
+Time NES.Begin NS117.
+Definition x := 0.
+NES.End NS117.
+
+Time NES.Begin NS118.
+Definition x := 0.
+NES.End NS118.
+
+Time NES.Begin NS119.
+Definition x := 0.
+NES.End NS119.
+
+Time NES.Begin NS120.
+Definition x := 0.
+NES.End NS120.
+
+Time NES.Begin NS121.
+Definition x := 0.
+NES.End NS121.
+
+Time NES.Begin NS122.
+Definition x := 0.
+NES.End NS122.
+
+Time NES.Begin NS123.
+Definition x := 0.
+NES.End NS123.
+
+Time NES.Begin NS124.
+Definition x := 0.
+NES.End NS124.
+
+Time NES.Begin NS125.
+Definition x := 0.
+NES.End NS125.
+
+Time NES.Begin NS126.
+Definition x := 0.
+NES.End NS126.
+
+Time NES.Begin NS127.
+Definition x := 0.
+NES.End NS127.
+
+Time NES.Begin NS128.
+Definition x := 0.
+NES.End NS128.
+
+Time NES.Begin NS129.
+Definition x := 0.
+NES.End NS129.
+
+Time NES.Begin NS130.
+Definition x := 0.
+NES.End NS130.
+
+Time NES.Begin NS131.
+Definition x := 0.
+NES.End NS131.
+
+Time NES.Begin NS132.
+Definition x := 0.
+NES.End NS132.
+
+Time NES.Begin NS133.
+Definition x := 0.
+NES.End NS133.
+
+Time NES.Begin NS134.
+Definition x := 0.
+NES.End NS134.
+
+Time NES.Begin NS135.
+Definition x := 0.
+NES.End NS135.
+
+Time NES.Begin NS136.
+Definition x := 0.
+NES.End NS136.
+
+Time NES.Begin NS137.
+Definition x := 0.
+NES.End NS137.
+
+Time NES.Begin NS138.
+Definition x := 0.
+NES.End NS138.
+
+Time NES.Begin NS139.
+Definition x := 0.
+NES.End NS139.
+
+Time NES.Begin NS140.
+Definition x := 0.
+NES.End NS140.
+
+Time NES.Begin NS141.
+Definition x := 0.
+NES.End NS141.
+
+Time NES.Begin NS142.
+Definition x := 0.
+NES.End NS142.
+
+Time NES.Begin NS143.
+Definition x := 0.
+NES.End NS143.
+
+Time NES.Begin NS144.
+Definition x := 0.
+NES.End NS144.
+
+Time NES.Begin NS145.
+Definition x := 0.
+NES.End NS145.
+
+Time NES.Begin NS146.
+Definition x := 0.
+NES.End NS146.
+
+Time NES.Begin NS147.
+Definition x := 0.
+NES.End NS147.
+
+Time NES.Begin NS148.
+Definition x := 0.
+NES.End NS148.
+
+Time NES.Begin NS149.
+Definition x := 0.
+NES.End NS149.
+
+Time NES.Begin NS150.
+Definition x := 0.
+NES.End NS150.
+
+Time NES.Begin NS151.
+Definition x := 0.
+NES.End NS151.
+
+Time NES.Begin NS152.
+Definition x := 0.
+NES.End NS152.
+
+Time NES.Begin NS153.
+Definition x := 0.
+NES.End NS153.
+
+Time NES.Begin NS154.
+Definition x := 0.
+NES.End NS154.
+
+Time NES.Begin NS155.
+Definition x := 0.
+NES.End NS155.
+
+Time NES.Begin NS156.
+Definition x := 0.
+NES.End NS156.
+
+Time NES.Begin NS157.
+Definition x := 0.
+NES.End NS157.
+
+Time NES.Begin NS158.
+Definition x := 0.
+NES.End NS158.
+
+Time NES.Begin NS159.
+Definition x := 0.
+NES.End NS159.
+
+Time NES.Begin NS160.
+Definition x := 0.
+NES.End NS160.
+
+Time NES.Begin NS161.
+Definition x := 0.
+NES.End NS161.
+
+Time NES.Begin NS162.
+Definition x := 0.
+NES.End NS162.
+
+Time NES.Begin NS163.
+Definition x := 0.
+NES.End NS163.
+
+Time NES.Begin NS164.
+Definition x := 0.
+NES.End NS164.
+
+Time NES.Begin NS165.
+Definition x := 0.
+NES.End NS165.
+
+Time NES.Begin NS166.
+Definition x := 0.
+NES.End NS166.
+
+Time NES.Begin NS167.
+Definition x := 0.
+NES.End NS167.
+
+Time NES.Begin NS168.
+Definition x := 0.
+NES.End NS168.
+
+Time NES.Begin NS169.
+Definition x := 0.
+NES.End NS169.
+
+Time NES.Begin NS170.
+Definition x := 0.
+NES.End NS170.
+
+Time NES.Begin NS171.
+Definition x := 0.
+NES.End NS171.
+
+Time NES.Begin NS172.
+Definition x := 0.
+NES.End NS172.
+
+Time NES.Begin NS173.
+Definition x := 0.
+NES.End NS173.
+
+Time NES.Begin NS174.
+Definition x := 0.
+NES.End NS174.
+
+Time NES.Begin NS175.
+Definition x := 0.
+NES.End NS175.
+
+Time NES.Begin NS176.
+Definition x := 0.
+NES.End NS176.
+
+Time NES.Begin NS177.
+Definition x := 0.
+NES.End NS177.
+
+Time NES.Begin NS178.
+Definition x := 0.
+NES.End NS178.
+
+Time NES.Begin NS179.
+Definition x := 0.
+NES.End NS179.
+
+Time NES.Begin NS180.
+Definition x := 0.
+NES.End NS180.
+
+Time NES.Begin NS181.
+Definition x := 0.
+NES.End NS181.
+
+Time NES.Begin NS182.
+Definition x := 0.
+NES.End NS182.
+
+Time NES.Begin NS183.
+Definition x := 0.
+NES.End NS183.
+
+Time NES.Begin NS184.
+Definition x := 0.
+NES.End NS184.
+
+Time NES.Begin NS185.
+Definition x := 0.
+NES.End NS185.
+
+Time NES.Begin NS186.
+Definition x := 0.
+NES.End NS186.
+
+Time NES.Begin NS187.
+Definition x := 0.
+NES.End NS187.
+
+Time NES.Begin NS188.
+Definition x := 0.
+NES.End NS188.
+
+Time NES.Begin NS189.
+Definition x := 0.
+NES.End NS189.
+
+Time NES.Begin NS190.
+Definition x := 0.
+NES.End NS190.
+
+Time NES.Begin NS191.
+Definition x := 0.
+NES.End NS191.
+
+Time NES.Begin NS192.
+Definition x := 0.
+NES.End NS192.
+
+Time NES.Begin NS193.
+Definition x := 0.
+NES.End NS193.
+
+Time NES.Begin NS194.
+Definition x := 0.
+NES.End NS194.
+
+Time NES.Begin NS195.
+Definition x := 0.
+NES.End NS195.
+
+Time NES.Begin NS196.
+Definition x := 0.
+NES.End NS196.
+
+Time NES.Begin NS197.
+Definition x := 0.
+NES.End NS197.
+
+Time NES.Begin NS198.
+Definition x := 0.
+NES.End NS198.
+
+Time NES.Begin NS199.
+Definition x := 0.
+NES.End NS199.
+
+Time NES.Begin NS200.
+Definition x := 0.
+NES.End NS200.
+
+Time NES.Begin NS201.
+Definition x := 0.
+NES.End NS201.
+
+Time NES.Begin NS202.
+Definition x := 0.
+NES.End NS202.
+
+Time NES.Begin NS203.
+Definition x := 0.
+NES.End NS203.
+
+Time NES.Begin NS204.
+Definition x := 0.
+NES.End NS204.
+
+Time NES.Begin NS205.
+Definition x := 0.
+NES.End NS205.
+
+Time NES.Begin NS206.
+Definition x := 0.
+NES.End NS206.
+
+Time NES.Begin NS207.
+Definition x := 0.
+NES.End NS207.
+
+Time NES.Begin NS208.
+Definition x := 0.
+NES.End NS208.
+
+Time NES.Begin NS209.
+Definition x := 0.
+NES.End NS209.
+
+Time NES.Begin NS210.
+Definition x := 0.
+NES.End NS210.
+
+Time NES.Begin NS211.
+Definition x := 0.
+NES.End NS211.
+
+Time NES.Begin NS212.
+Definition x := 0.
+NES.End NS212.
+
+Time NES.Begin NS213.
+Definition x := 0.
+NES.End NS213.
+
+Time NES.Begin NS214.
+Definition x := 0.
+NES.End NS214.
+
+Time NES.Begin NS215.
+Definition x := 0.
+NES.End NS215.
+
+Time NES.Begin NS216.
+Definition x := 0.
+NES.End NS216.
+
+Time NES.Begin NS217.
+Definition x := 0.
+NES.End NS217.
+
+Time NES.Begin NS218.
+Definition x := 0.
+NES.End NS218.
+
+Time NES.Begin NS219.
+Definition x := 0.
+NES.End NS219.
+
+Time NES.Begin NS220.
+Definition x := 0.
+NES.End NS220.
+
+Time NES.Begin NS221.
+Definition x := 0.
+NES.End NS221.
+
+Time NES.Begin NS222.
+Definition x := 0.
+NES.End NS222.
+
+Time NES.Begin NS223.
+Definition x := 0.
+NES.End NS223.
+
+Time NES.Begin NS224.
+Definition x := 0.
+NES.End NS224.
+
+Time NES.Begin NS225.
+Definition x := 0.
+NES.End NS225.
+
+Time NES.Begin NS226.
+Definition x := 0.
+NES.End NS226.
+
+Time NES.Begin NS227.
+Definition x := 0.
+NES.End NS227.
+
+Time NES.Begin NS228.
+Definition x := 0.
+NES.End NS228.
+
+Time NES.Begin NS229.
+Definition x := 0.
+NES.End NS229.
+
+Time NES.Begin NS230.
+Definition x := 0.
+NES.End NS230.
+
+Time NES.Begin NS231.
+Definition x := 0.
+NES.End NS231.
+
+Time NES.Begin NS232.
+Definition x := 0.
+NES.End NS232.
+
+Time NES.Begin NS233.
+Definition x := 0.
+NES.End NS233.
+
+Time NES.Begin NS234.
+Definition x := 0.
+NES.End NS234.
+
+Time NES.Begin NS235.
+Definition x := 0.
+NES.End NS235.
+
+Time NES.Begin NS236.
+Definition x := 0.
+NES.End NS236.
+
+Time NES.Begin NS237.
+Definition x := 0.
+NES.End NS237.
+
+Time NES.Begin NS238.
+Definition x := 0.
+NES.End NS238.
+
+Time NES.Begin NS239.
+Definition x := 0.
+NES.End NS239.
+
+Time NES.Begin NS240.
+Definition x := 0.
+NES.End NS240.
+
+Time NES.Begin NS241.
+Definition x := 0.
+NES.End NS241.
+
+Time NES.Begin NS242.
+Definition x := 0.
+NES.End NS242.
+
+Time NES.Begin NS243.
+Definition x := 0.
+NES.End NS243.
+
+Time NES.Begin NS244.
+Definition x := 0.
+NES.End NS244.
+
+Time NES.Begin NS245.
+Definition x := 0.
+NES.End NS245.
+
+Time NES.Begin NS246.
+Definition x := 0.
+NES.End NS246.
+
+Time NES.Begin NS247.
+Definition x := 0.
+NES.End NS247.
+
+Time NES.Begin NS248.
+Definition x := 0.
+NES.End NS248.
+
+Time NES.Begin NS249.
+Definition x := 0.
+NES.End NS249.
+
+Time NES.Begin NS250.
+Definition x := 0.
+NES.End NS250.
+
+Time NES.Begin NS251.
+Definition x := 0.
+NES.End NS251.
+
+Time NES.Begin NS252.
+Definition x := 0.
+NES.End NS252.
+
+Time NES.Begin NS253.
+Definition x := 0.
+NES.End NS253.
+
+Time NES.Begin NS254.
+Definition x := 0.
+NES.End NS254.
+
+Time NES.Begin NS255.
+Definition x := 0.
+NES.End NS255.
+
+Time NES.Begin NS256.
+Definition x := 0.
+NES.End NS256.
+
+Time NES.Begin NS257.
+Definition x := 0.
+NES.End NS257.
+
+Time NES.Begin NS258.
+Definition x := 0.
+NES.End NS258.
+
+Time NES.Begin NS259.
+Definition x := 0.
+NES.End NS259.
+
+Time NES.Begin NS260.
+Definition x := 0.
+NES.End NS260.
+
+Time NES.Begin NS261.
+Definition x := 0.
+NES.End NS261.
+
+Time NES.Begin NS262.
+Definition x := 0.
+NES.End NS262.
+
+Time NES.Begin NS263.
+Definition x := 0.
+NES.End NS263.
+
+Time NES.Begin NS264.
+Definition x := 0.
+NES.End NS264.
+
+Time NES.Begin NS265.
+Definition x := 0.
+NES.End NS265.
+
+Time NES.Begin NS266.
+Definition x := 0.
+NES.End NS266.
+
+Time NES.Begin NS267.
+Definition x := 0.
+NES.End NS267.
+
+Time NES.Begin NS268.
+Definition x := 0.
+NES.End NS268.
+
+Time NES.Begin NS269.
+Definition x := 0.
+NES.End NS269.
+
+Time NES.Begin NS270.
+Definition x := 0.
+NES.End NS270.
+
+Time NES.Begin NS271.
+Definition x := 0.
+NES.End NS271.
+
+Time NES.Begin NS272.
+Definition x := 0.
+NES.End NS272.
+
+Time NES.Begin NS273.
+Definition x := 0.
+NES.End NS273.
+
+Time NES.Begin NS274.
+Definition x := 0.
+NES.End NS274.
+
+Time NES.Begin NS275.
+Definition x := 0.
+NES.End NS275.
+
+Time NES.Begin NS276.
+Definition x := 0.
+NES.End NS276.
+
+Time NES.Begin NS277.
+Definition x := 0.
+NES.End NS277.
+
+Time NES.Begin NS278.
+Definition x := 0.
+NES.End NS278.
+
+Time NES.Begin NS279.
+Definition x := 0.
+NES.End NS279.
+
+Time NES.Begin NS280.
+Definition x := 0.
+NES.End NS280.
+
+Time NES.Begin NS281.
+Definition x := 0.
+NES.End NS281.
+
+Time NES.Begin NS282.
+Definition x := 0.
+NES.End NS282.
+
+Time NES.Begin NS283.
+Definition x := 0.
+NES.End NS283.
+
+Time NES.Begin NS284.
+Definition x := 0.
+NES.End NS284.
+
+Time NES.Begin NS285.
+Definition x := 0.
+NES.End NS285.
+
+Time NES.Begin NS286.
+Definition x := 0.
+NES.End NS286.
+
+Time NES.Begin NS287.
+Definition x := 0.
+NES.End NS287.
+
+Time NES.Begin NS288.
+Definition x := 0.
+NES.End NS288.
+
+Time NES.Begin NS289.
+Definition x := 0.
+NES.End NS289.
+
+Time NES.Begin NS290.
+Definition x := 0.
+NES.End NS290.
+
+Time NES.Begin NS291.
+Definition x := 0.
+NES.End NS291.
+
+Time NES.Begin NS292.
+Definition x := 0.
+NES.End NS292.
+
+Time NES.Begin NS293.
+Definition x := 0.
+NES.End NS293.
+
+Time NES.Begin NS294.
+Definition x := 0.
+NES.End NS294.
+
+Time NES.Begin NS295.
+Definition x := 0.
+NES.End NS295.
+
+Time NES.Begin NS296.
+Definition x := 0.
+NES.End NS296.
+
+Time NES.Begin NS297.
+Definition x := 0.
+NES.End NS297.
+
+Time NES.Begin NS298.
+Definition x := 0.
+NES.End NS298.
+
+Time NES.Begin NS299.
+Definition x := 0.
+NES.End NS299.
+
+Time NES.Begin NS300.
+Definition x := 0.
+NES.End NS300.
+
+Time NES.Begin NS301.
+Definition x := 0.
+NES.End NS301.
+
+Time NES.Begin NS302.
+Definition x := 0.
+NES.End NS302.
+
+Time NES.Begin NS303.
+Definition x := 0.
+NES.End NS303.
+
+Time NES.Begin NS304.
+Definition x := 0.
+NES.End NS304.
+
+Time NES.Begin NS305.
+Definition x := 0.
+NES.End NS305.
+
+Time NES.Begin NS306.
+Definition x := 0.
+NES.End NS306.
+
+Time NES.Begin NS307.
+Definition x := 0.
+NES.End NS307.
+
+Time NES.Begin NS308.
+Definition x := 0.
+NES.End NS308.
+
+Time NES.Begin NS309.
+Definition x := 0.
+NES.End NS309.
+
+Time NES.Begin NS310.
+Definition x := 0.
+NES.End NS310.
+
+Time NES.Begin NS311.
+Definition x := 0.
+NES.End NS311.
+
+Time NES.Begin NS312.
+Definition x := 0.
+NES.End NS312.
+
+Time NES.Begin NS313.
+Definition x := 0.
+NES.End NS313.
+
+Time NES.Begin NS314.
+Definition x := 0.
+NES.End NS314.
+
+Time NES.Begin NS315.
+Definition x := 0.
+NES.End NS315.
+
+Time NES.Begin NS316.
+Definition x := 0.
+NES.End NS316.
+
+Time NES.Begin NS317.
+Definition x := 0.
+NES.End NS317.
+
+Time NES.Begin NS318.
+Definition x := 0.
+NES.End NS318.
+
+Time NES.Begin NS319.
+Definition x := 0.
+NES.End NS319.
+
+Time NES.Begin NS320.
+Definition x := 0.
+NES.End NS320.
+
+Time NES.Begin NS321.
+Definition x := 0.
+NES.End NS321.
+
+Time NES.Begin NS322.
+Definition x := 0.
+NES.End NS322.
+
+Time NES.Begin NS323.
+Definition x := 0.
+NES.End NS323.
+
+Time NES.Begin NS324.
+Definition x := 0.
+NES.End NS324.
+
+Time NES.Begin NS325.
+Definition x := 0.
+NES.End NS325.
+
+Time NES.Begin NS326.
+Definition x := 0.
+NES.End NS326.
+
+Time NES.Begin NS327.
+Definition x := 0.
+NES.End NS327.
+
+Time NES.Begin NS328.
+Definition x := 0.
+NES.End NS328.
+
+Time NES.Begin NS329.
+Definition x := 0.
+NES.End NS329.
+
+Time NES.Begin NS330.
+Definition x := 0.
+NES.End NS330.
+
+Time NES.Begin NS331.
+Definition x := 0.
+NES.End NS331.
+
+Time NES.Begin NS332.
+Definition x := 0.
+NES.End NS332.
+
+Time NES.Begin NS333.
+Definition x := 0.
+NES.End NS333.
+
+Time NES.Begin NS334.
+Definition x := 0.
+NES.End NS334.
+
+Time NES.Begin NS335.
+Definition x := 0.
+NES.End NS335.
+
+Time NES.Begin NS336.
+Definition x := 0.
+NES.End NS336.
+
+Time NES.Begin NS337.
+Definition x := 0.
+NES.End NS337.
+
+Time NES.Begin NS338.
+Definition x := 0.
+NES.End NS338.
+
+Time NES.Begin NS339.
+Definition x := 0.
+NES.End NS339.
+
+Time NES.Begin NS340.
+Definition x := 0.
+NES.End NS340.
+
+Time NES.Begin NS341.
+Definition x := 0.
+NES.End NS341.
+
+Time NES.Begin NS342.
+Definition x := 0.
+NES.End NS342.
+
+Time NES.Begin NS343.
+Definition x := 0.
+NES.End NS343.
+
+Time NES.Begin NS344.
+Definition x := 0.
+NES.End NS344.
+
+Time NES.Begin NS345.
+Definition x := 0.
+NES.End NS345.
+
+Time NES.Begin NS346.
+Definition x := 0.
+NES.End NS346.
+
+Time NES.Begin NS347.
+Definition x := 0.
+NES.End NS347.
+
+Time NES.Begin NS348.
+Definition x := 0.
+NES.End NS348.
+
+Time NES.Begin NS349.
+Definition x := 0.
+NES.End NS349.
+
+Time NES.Begin NS350.
+Definition x := 0.
+NES.End NS350.
+
+Time NES.Begin NS351.
+Definition x := 0.
+NES.End NS351.
+
+Time NES.Begin NS352.
+Definition x := 0.
+NES.End NS352.
+
+Time NES.Begin NS353.
+Definition x := 0.
+NES.End NS353.
+
+Time NES.Begin NS354.
+Definition x := 0.
+NES.End NS354.
+
+Time NES.Begin NS355.
+Definition x := 0.
+NES.End NS355.
+
+Time NES.Begin NS356.
+Definition x := 0.
+NES.End NS356.
+
+Time NES.Begin NS357.
+Definition x := 0.
+NES.End NS357.
+
+Time NES.Begin NS358.
+Definition x := 0.
+NES.End NS358.
+
+Time NES.Begin NS359.
+Definition x := 0.
+NES.End NS359.
+
+Time NES.Begin NS360.
+Definition x := 0.
+NES.End NS360.
+
+Time NES.Begin NS361.
+Definition x := 0.
+NES.End NS361.
+
+Time NES.Begin NS362.
+Definition x := 0.
+NES.End NS362.
+
+Time NES.Begin NS363.
+Definition x := 0.
+NES.End NS363.
+
+Time NES.Begin NS364.
+Definition x := 0.
+NES.End NS364.
+
+Time NES.Begin NS365.
+Definition x := 0.
+NES.End NS365.
+
+Time NES.Begin NS366.
+Definition x := 0.
+NES.End NS366.
+
+Time NES.Begin NS367.
+Definition x := 0.
+NES.End NS367.
+
+Time NES.Begin NS368.
+Definition x := 0.
+NES.End NS368.
+
+Time NES.Begin NS369.
+Definition x := 0.
+NES.End NS369.
+
+Time NES.Begin NS370.
+Definition x := 0.
+NES.End NS370.
+
+Time NES.Begin NS371.
+Definition x := 0.
+NES.End NS371.
+
+Time NES.Begin NS372.
+Definition x := 0.
+NES.End NS372.
+
+Time NES.Begin NS373.
+Definition x := 0.
+NES.End NS373.
+
+Time NES.Begin NS374.
+Definition x := 0.
+NES.End NS374.
+
+Time NES.Begin NS375.
+Definition x := 0.
+NES.End NS375.
+
+Time NES.Begin NS376.
+Definition x := 0.
+NES.End NS376.
+
+Time NES.Begin NS377.
+Definition x := 0.
+NES.End NS377.
+
+Time NES.Begin NS378.
+Definition x := 0.
+NES.End NS378.
+
+Time NES.Begin NS379.
+Definition x := 0.
+NES.End NS379.
+
+Time NES.Begin NS380.
+Definition x := 0.
+NES.End NS380.
+
+Time NES.Begin NS381.
+Definition x := 0.
+NES.End NS381.
+
+Time NES.Begin NS382.
+Definition x := 0.
+NES.End NS382.
+
+Time NES.Begin NS383.
+Definition x := 0.
+NES.End NS383.
+
+Time NES.Begin NS384.
+Definition x := 0.
+NES.End NS384.
+
+Time NES.Begin NS385.
+Definition x := 0.
+NES.End NS385.
+
+Time NES.Begin NS386.
+Definition x := 0.
+NES.End NS386.
+
+Time NES.Begin NS387.
+Definition x := 0.
+NES.End NS387.
+
+Time NES.Begin NS388.
+Definition x := 0.
+NES.End NS388.
+
+Time NES.Begin NS389.
+Definition x := 0.
+NES.End NS389.
+
+Time NES.Begin NS390.
+Definition x := 0.
+NES.End NS390.
+
+Time NES.Begin NS391.
+Definition x := 0.
+NES.End NS391.
+
+Time NES.Begin NS392.
+Definition x := 0.
+NES.End NS392.
+
+Time NES.Begin NS393.
+Definition x := 0.
+NES.End NS393.
+
+Time NES.Begin NS394.
+Definition x := 0.
+NES.End NS394.
+
+Time NES.Begin NS395.
+Definition x := 0.
+NES.End NS395.
+
+Time NES.Begin NS396.
+Definition x := 0.
+NES.End NS396.
+
+Time NES.Begin NS397.
+Definition x := 0.
+NES.End NS397.
+
+Time NES.Begin NS398.
+Definition x := 0.
+NES.End NS398.
+
+Time NES.Begin NS399.
+Definition x := 0.
+NES.End NS399.
+
+Time NES.Begin NS400.
+Definition x := 0.
+NES.End NS400.
+
+Time NES.Begin NS401.
+Definition x := 0.
+NES.End NS401.
+
+Time NES.Begin NS402.
+Definition x := 0.
+NES.End NS402.
+
+Time NES.Begin NS403.
+Definition x := 0.
+NES.End NS403.
+
+Time NES.Begin NS404.
+Definition x := 0.
+NES.End NS404.
+
+Time NES.Begin NS405.
+Definition x := 0.
+NES.End NS405.
+
+Time NES.Begin NS406.
+Definition x := 0.
+NES.End NS406.
+
+Time NES.Begin NS407.
+Definition x := 0.
+NES.End NS407.
+
+Time NES.Begin NS408.
+Definition x := 0.
+NES.End NS408.
+
+Time NES.Begin NS409.
+Definition x := 0.
+NES.End NS409.
+
+Time NES.Begin NS410.
+Definition x := 0.
+NES.End NS410.
+
+Time NES.Begin NS411.
+Definition x := 0.
+NES.End NS411.
+
+Time NES.Begin NS412.
+Definition x := 0.
+NES.End NS412.
+
+Time NES.Begin NS413.
+Definition x := 0.
+NES.End NS413.
+
+Time NES.Begin NS414.
+Definition x := 0.
+NES.End NS414.
+
+Time NES.Begin NS415.
+Definition x := 0.
+NES.End NS415.
+
+Time NES.Begin NS416.
+Definition x := 0.
+NES.End NS416.
+
+Time NES.Begin NS417.
+Definition x := 0.
+NES.End NS417.
+
+Time NES.Begin NS418.
+Definition x := 0.
+NES.End NS418.
+
+Time NES.Begin NS419.
+Definition x := 0.
+NES.End NS419.
+
+Time NES.Begin NS420.
+Definition x := 0.
+NES.End NS420.
+
+Time NES.Begin NS421.
+Definition x := 0.
+NES.End NS421.
+
+Time NES.Begin NS422.
+Definition x := 0.
+NES.End NS422.
+
+Time NES.Begin NS423.
+Definition x := 0.
+NES.End NS423.
+
+Time NES.Begin NS424.
+Definition x := 0.
+NES.End NS424.
+
+Time NES.Begin NS425.
+Definition x := 0.
+NES.End NS425.
+
+Time NES.Begin NS426.
+Definition x := 0.
+NES.End NS426.
+
+Time NES.Begin NS427.
+Definition x := 0.
+NES.End NS427.
+
+Time NES.Begin NS428.
+Definition x := 0.
+NES.End NS428.
+
+Time NES.Begin NS429.
+Definition x := 0.
+NES.End NS429.
+
+Time NES.Begin NS430.
+Definition x := 0.
+NES.End NS430.
+
+Time NES.Begin NS431.
+Definition x := 0.
+NES.End NS431.
+
+Time NES.Begin NS432.
+Definition x := 0.
+NES.End NS432.
+
+Time NES.Begin NS433.
+Definition x := 0.
+NES.End NS433.
+
+Time NES.Begin NS434.
+Definition x := 0.
+NES.End NS434.
+
+Time NES.Begin NS435.
+Definition x := 0.
+NES.End NS435.
+
+Time NES.Begin NS436.
+Definition x := 0.
+NES.End NS436.
+
+Time NES.Begin NS437.
+Definition x := 0.
+NES.End NS437.
+
+Time NES.Begin NS438.
+Definition x := 0.
+NES.End NS438.
+
+Time NES.Begin NS439.
+Definition x := 0.
+NES.End NS439.
+
+Time NES.Begin NS440.
+Definition x := 0.
+NES.End NS440.
+
+Time NES.Begin NS441.
+Definition x := 0.
+NES.End NS441.
+
+Time NES.Begin NS442.
+Definition x := 0.
+NES.End NS442.
+
+Time NES.Begin NS443.
+Definition x := 0.
+NES.End NS443.
+
+Time NES.Begin NS444.
+Definition x := 0.
+NES.End NS444.
+
+Time NES.Begin NS445.
+Definition x := 0.
+NES.End NS445.
+
+Time NES.Begin NS446.
+Definition x := 0.
+NES.End NS446.
+
+Time NES.Begin NS447.
+Definition x := 0.
+NES.End NS447.
+
+Time NES.Begin NS448.
+Definition x := 0.
+NES.End NS448.
+
+Time NES.Begin NS449.
+Definition x := 0.
+NES.End NS449.
+
+Time NES.Begin NS450.
+Definition x := 0.
+NES.End NS450.
+
+Time NES.Begin NS451.
+Definition x := 0.
+NES.End NS451.
+
+Time NES.Begin NS452.
+Definition x := 0.
+NES.End NS452.
+
+Time NES.Begin NS453.
+Definition x := 0.
+NES.End NS453.
+
+Time NES.Begin NS454.
+Definition x := 0.
+NES.End NS454.
+
+Time NES.Begin NS455.
+Definition x := 0.
+NES.End NS455.
+
+Time NES.Begin NS456.
+Definition x := 0.
+NES.End NS456.
+
+Time NES.Begin NS457.
+Definition x := 0.
+NES.End NS457.
+
+Time NES.Begin NS458.
+Definition x := 0.
+NES.End NS458.
+
+Time NES.Begin NS459.
+Definition x := 0.
+NES.End NS459.
+
+Time NES.Begin NS460.
+Definition x := 0.
+NES.End NS460.
+
+Time NES.Begin NS461.
+Definition x := 0.
+NES.End NS461.
+
+Time NES.Begin NS462.
+Definition x := 0.
+NES.End NS462.
+
+Time NES.Begin NS463.
+Definition x := 0.
+NES.End NS463.
+
+Time NES.Begin NS464.
+Definition x := 0.
+NES.End NS464.
+
+Time NES.Begin NS465.
+Definition x := 0.
+NES.End NS465.
+
+Time NES.Begin NS466.
+Definition x := 0.
+NES.End NS466.
+
+Time NES.Begin NS467.
+Definition x := 0.
+NES.End NS467.
+
+Time NES.Begin NS468.
+Definition x := 0.
+NES.End NS468.
+
+Time NES.Begin NS469.
+Definition x := 0.
+NES.End NS469.
+
+Time NES.Begin NS470.
+Definition x := 0.
+NES.End NS470.
+
+Time NES.Begin NS471.
+Definition x := 0.
+NES.End NS471.
+
+Time NES.Begin NS472.
+Definition x := 0.
+NES.End NS472.
+
+Time NES.Begin NS473.
+Definition x := 0.
+NES.End NS473.
+
+Time NES.Begin NS474.
+Definition x := 0.
+NES.End NS474.
+
+Time NES.Begin NS475.
+Definition x := 0.
+NES.End NS475.
+
+Time NES.Begin NS476.
+Definition x := 0.
+NES.End NS476.
+
+Time NES.Begin NS477.
+Definition x := 0.
+NES.End NS477.
+
+Time NES.Begin NS478.
+Definition x := 0.
+NES.End NS478.
+
+Time NES.Begin NS479.
+Definition x := 0.
+NES.End NS479.
+
+Time NES.Begin NS480.
+Definition x := 0.
+NES.End NS480.
+
+Time NES.Begin NS481.
+Definition x := 0.
+NES.End NS481.
+
+Time NES.Begin NS482.
+Definition x := 0.
+NES.End NS482.
+
+Time NES.Begin NS483.
+Definition x := 0.
+NES.End NS483.
+
+Time NES.Begin NS484.
+Definition x := 0.
+NES.End NS484.
+
+Time NES.Begin NS485.
+Definition x := 0.
+NES.End NS485.
+
+Time NES.Begin NS486.
+Definition x := 0.
+NES.End NS486.
+
+Time NES.Begin NS487.
+Definition x := 0.
+NES.End NS487.
+
+Time NES.Begin NS488.
+Definition x := 0.
+NES.End NS488.
+
+Time NES.Begin NS489.
+Definition x := 0.
+NES.End NS489.
+
+Time NES.Begin NS490.
+Definition x := 0.
+NES.End NS490.
+
+Time NES.Begin NS491.
+Definition x := 0.
+NES.End NS491.
+
+Time NES.Begin NS492.
+Definition x := 0.
+NES.End NS492.
+
+Time NES.Begin NS493.
+Definition x := 0.
+NES.End NS493.
+
+Time NES.Begin NS494.
+Definition x := 0.
+NES.End NS494.
+
+Time NES.Begin NS495.
+Definition x := 0.
+NES.End NS495.
+
+Time NES.Begin NS496.
+Definition x := 0.
+NES.End NS496.
+
+Time NES.Begin NS497.
+Definition x := 0.
+NES.End NS497.
+
+Time NES.Begin NS498.
+Definition x := 0.
+NES.End NS498.
+
+Time NES.Begin NS499.
+Definition x := 0.
+NES.End NS499.
+
+Time NES.Begin NS500.
+Definition x := 0.
+NES.End NS500.

--- a/apps/NES/tests/test_NES_perf_optimal.v
+++ b/apps/NES/tests/test_NES_perf_optimal.v
@@ -1,0 +1,2001 @@
+From elpi.apps Require Import NES.
+
+Module NS1. Module NS1.
+Definition x := 0.
+End NS1. End NS1. Export NS1.
+
+Module NS2. Module NS2.
+Definition x := 0.
+End NS2. End NS2. Export NS2.
+
+Module NS3. Module NS3.
+Definition x := 0.
+End NS3. End NS3. Export NS3.
+
+Module NS4. Module NS4.
+Definition x := 0.
+End NS4. End NS4. Export NS4.
+
+Module NS5. Module NS5.
+Definition x := 0.
+End NS5. End NS5. Export NS5.
+
+Module NS6. Module NS6.
+Definition x := 0.
+End NS6. End NS6. Export NS6.
+
+Module NS7. Module NS7.
+Definition x := 0.
+End NS7. End NS7. Export NS7.
+
+Module NS8. Module NS8.
+Definition x := 0.
+End NS8. End NS8. Export NS8.
+
+Module NS9. Module NS9.
+Definition x := 0.
+End NS9. End NS9. Export NS9.
+
+Module NS10. Module NS10.
+Definition x := 0.
+End NS10. End NS10. Export NS10.
+
+Module NS11. Module NS11.
+Definition x := 0.
+End NS11. End NS11. Export NS11.
+
+Module NS12. Module NS12.
+Definition x := 0.
+End NS12. End NS12. Export NS12.
+
+Module NS13. Module NS13.
+Definition x := 0.
+End NS13. End NS13. Export NS13.
+
+Module NS14. Module NS14.
+Definition x := 0.
+End NS14. End NS14. Export NS14.
+
+Module NS15. Module NS15.
+Definition x := 0.
+End NS15. End NS15. Export NS15.
+
+Module NS16. Module NS16.
+Definition x := 0.
+End NS16. End NS16. Export NS16.
+
+Module NS17. Module NS17.
+Definition x := 0.
+End NS17. End NS17. Export NS17.
+
+Module NS18. Module NS18.
+Definition x := 0.
+End NS18. End NS18. Export NS18.
+
+Module NS19. Module NS19.
+Definition x := 0.
+End NS19. End NS19. Export NS19.
+
+Module NS20. Module NS20.
+Definition x := 0.
+End NS20. End NS20. Export NS20.
+
+Module NS21. Module NS21.
+Definition x := 0.
+End NS21. End NS21. Export NS21.
+
+Module NS22. Module NS22.
+Definition x := 0.
+End NS22. End NS22. Export NS22.
+
+Module NS23. Module NS23.
+Definition x := 0.
+End NS23. End NS23. Export NS23.
+
+Module NS24. Module NS24.
+Definition x := 0.
+End NS24. End NS24. Export NS24.
+
+Module NS25. Module NS25.
+Definition x := 0.
+End NS25. End NS25. Export NS25.
+
+Module NS26. Module NS26.
+Definition x := 0.
+End NS26. End NS26. Export NS26.
+
+Module NS27. Module NS27.
+Definition x := 0.
+End NS27. End NS27. Export NS27.
+
+Module NS28. Module NS28.
+Definition x := 0.
+End NS28. End NS28. Export NS28.
+
+Module NS29. Module NS29.
+Definition x := 0.
+End NS29. End NS29. Export NS29.
+
+Module NS30. Module NS30.
+Definition x := 0.
+End NS30. End NS30. Export NS30.
+
+Module NS31. Module NS31.
+Definition x := 0.
+End NS31. End NS31. Export NS31.
+
+Module NS32. Module NS32.
+Definition x := 0.
+End NS32. End NS32. Export NS32.
+
+Module NS33. Module NS33.
+Definition x := 0.
+End NS33. End NS33. Export NS33.
+
+Module NS34. Module NS34.
+Definition x := 0.
+End NS34. End NS34. Export NS34.
+
+Module NS35. Module NS35.
+Definition x := 0.
+End NS35. End NS35. Export NS35.
+
+Module NS36. Module NS36.
+Definition x := 0.
+End NS36. End NS36. Export NS36.
+
+Module NS37. Module NS37.
+Definition x := 0.
+End NS37. End NS37. Export NS37.
+
+Module NS38. Module NS38.
+Definition x := 0.
+End NS38. End NS38. Export NS38.
+
+Module NS39. Module NS39.
+Definition x := 0.
+End NS39. End NS39. Export NS39.
+
+Module NS40. Module NS40.
+Definition x := 0.
+End NS40. End NS40. Export NS40.
+
+Module NS41. Module NS41.
+Definition x := 0.
+End NS41. End NS41. Export NS41.
+
+Module NS42. Module NS42.
+Definition x := 0.
+End NS42. End NS42. Export NS42.
+
+Module NS43. Module NS43.
+Definition x := 0.
+End NS43. End NS43. Export NS43.
+
+Module NS44. Module NS44.
+Definition x := 0.
+End NS44. End NS44. Export NS44.
+
+Module NS45. Module NS45.
+Definition x := 0.
+End NS45. End NS45. Export NS45.
+
+Module NS46. Module NS46.
+Definition x := 0.
+End NS46. End NS46. Export NS46.
+
+Module NS47. Module NS47.
+Definition x := 0.
+End NS47. End NS47. Export NS47.
+
+Module NS48. Module NS48.
+Definition x := 0.
+End NS48. End NS48. Export NS48.
+
+Module NS49. Module NS49.
+Definition x := 0.
+End NS49. End NS49. Export NS49.
+
+Module NS50. Module NS50.
+Definition x := 0.
+End NS50. End NS50. Export NS50.
+
+Module NS51. Module NS51.
+Definition x := 0.
+End NS51. End NS51. Export NS51.
+
+Module NS52. Module NS52.
+Definition x := 0.
+End NS52. End NS52. Export NS52.
+
+Module NS53. Module NS53.
+Definition x := 0.
+End NS53. End NS53. Export NS53.
+
+Module NS54. Module NS54.
+Definition x := 0.
+End NS54. End NS54. Export NS54.
+
+Module NS55. Module NS55.
+Definition x := 0.
+End NS55. End NS55. Export NS55.
+
+Module NS56. Module NS56.
+Definition x := 0.
+End NS56. End NS56. Export NS56.
+
+Module NS57. Module NS57.
+Definition x := 0.
+End NS57. End NS57. Export NS57.
+
+Module NS58. Module NS58.
+Definition x := 0.
+End NS58. End NS58. Export NS58.
+
+Module NS59. Module NS59.
+Definition x := 0.
+End NS59. End NS59. Export NS59.
+
+Module NS60. Module NS60.
+Definition x := 0.
+End NS60. End NS60. Export NS60.
+
+Module NS61. Module NS61.
+Definition x := 0.
+End NS61. End NS61. Export NS61.
+
+Module NS62. Module NS62.
+Definition x := 0.
+End NS62. End NS62. Export NS62.
+
+Module NS63. Module NS63.
+Definition x := 0.
+End NS63. End NS63. Export NS63.
+
+Module NS64. Module NS64.
+Definition x := 0.
+End NS64. End NS64. Export NS64.
+
+Module NS65. Module NS65.
+Definition x := 0.
+End NS65. End NS65. Export NS65.
+
+Module NS66. Module NS66.
+Definition x := 0.
+End NS66. End NS66. Export NS66.
+
+Module NS67. Module NS67.
+Definition x := 0.
+End NS67. End NS67. Export NS67.
+
+Module NS68. Module NS68.
+Definition x := 0.
+End NS68. End NS68. Export NS68.
+
+Module NS69. Module NS69.
+Definition x := 0.
+End NS69. End NS69. Export NS69.
+
+Module NS70. Module NS70.
+Definition x := 0.
+End NS70. End NS70. Export NS70.
+
+Module NS71. Module NS71.
+Definition x := 0.
+End NS71. End NS71. Export NS71.
+
+Module NS72. Module NS72.
+Definition x := 0.
+End NS72. End NS72. Export NS72.
+
+Module NS73. Module NS73.
+Definition x := 0.
+End NS73. End NS73. Export NS73.
+
+Module NS74. Module NS74.
+Definition x := 0.
+End NS74. End NS74. Export NS74.
+
+Module NS75. Module NS75.
+Definition x := 0.
+End NS75. End NS75. Export NS75.
+
+Module NS76. Module NS76.
+Definition x := 0.
+End NS76. End NS76. Export NS76.
+
+Module NS77. Module NS77.
+Definition x := 0.
+End NS77. End NS77. Export NS77.
+
+Module NS78. Module NS78.
+Definition x := 0.
+End NS78. End NS78. Export NS78.
+
+Module NS79. Module NS79.
+Definition x := 0.
+End NS79. End NS79. Export NS79.
+
+Module NS80. Module NS80.
+Definition x := 0.
+End NS80. End NS80. Export NS80.
+
+Module NS81. Module NS81.
+Definition x := 0.
+End NS81. End NS81. Export NS81.
+
+Module NS82. Module NS82.
+Definition x := 0.
+End NS82. End NS82. Export NS82.
+
+Module NS83. Module NS83.
+Definition x := 0.
+End NS83. End NS83. Export NS83.
+
+Module NS84. Module NS84.
+Definition x := 0.
+End NS84. End NS84. Export NS84.
+
+Module NS85. Module NS85.
+Definition x := 0.
+End NS85. End NS85. Export NS85.
+
+Module NS86. Module NS86.
+Definition x := 0.
+End NS86. End NS86. Export NS86.
+
+Module NS87. Module NS87.
+Definition x := 0.
+End NS87. End NS87. Export NS87.
+
+Module NS88. Module NS88.
+Definition x := 0.
+End NS88. End NS88. Export NS88.
+
+Module NS89. Module NS89.
+Definition x := 0.
+End NS89. End NS89. Export NS89.
+
+Module NS90. Module NS90.
+Definition x := 0.
+End NS90. End NS90. Export NS90.
+
+Module NS91. Module NS91.
+Definition x := 0.
+End NS91. End NS91. Export NS91.
+
+Module NS92. Module NS92.
+Definition x := 0.
+End NS92. End NS92. Export NS92.
+
+Module NS93. Module NS93.
+Definition x := 0.
+End NS93. End NS93. Export NS93.
+
+Module NS94. Module NS94.
+Definition x := 0.
+End NS94. End NS94. Export NS94.
+
+Module NS95. Module NS95.
+Definition x := 0.
+End NS95. End NS95. Export NS95.
+
+Module NS96. Module NS96.
+Definition x := 0.
+End NS96. End NS96. Export NS96.
+
+Module NS97. Module NS97.
+Definition x := 0.
+End NS97. End NS97. Export NS97.
+
+Module NS98. Module NS98.
+Definition x := 0.
+End NS98. End NS98. Export NS98.
+
+Module NS99. Module NS99.
+Definition x := 0.
+End NS99. End NS99. Export NS99.
+
+Module NS100. Module NS100.
+Definition x := 0.
+End NS100. End NS100. Export NS100.
+
+Module NS101. Module NS101.
+Definition x := 0.
+End NS101. End NS101. Export NS101.
+
+Module NS102. Module NS102.
+Definition x := 0.
+End NS102. End NS102. Export NS102.
+
+Module NS103. Module NS103.
+Definition x := 0.
+End NS103. End NS103. Export NS103.
+
+Module NS104. Module NS104.
+Definition x := 0.
+End NS104. End NS104. Export NS104.
+
+Module NS105. Module NS105.
+Definition x := 0.
+End NS105. End NS105. Export NS105.
+
+Module NS106. Module NS106.
+Definition x := 0.
+End NS106. End NS106. Export NS106.
+
+Module NS107. Module NS107.
+Definition x := 0.
+End NS107. End NS107. Export NS107.
+
+Module NS108. Module NS108.
+Definition x := 0.
+End NS108. End NS108. Export NS108.
+
+Module NS109. Module NS109.
+Definition x := 0.
+End NS109. End NS109. Export NS109.
+
+Module NS110. Module NS110.
+Definition x := 0.
+End NS110. End NS110. Export NS110.
+
+Module NS111. Module NS111.
+Definition x := 0.
+End NS111. End NS111. Export NS111.
+
+Module NS112. Module NS112.
+Definition x := 0.
+End NS112. End NS112. Export NS112.
+
+Module NS113. Module NS113.
+Definition x := 0.
+End NS113. End NS113. Export NS113.
+
+Module NS114. Module NS114.
+Definition x := 0.
+End NS114. End NS114. Export NS114.
+
+Module NS115. Module NS115.
+Definition x := 0.
+End NS115. End NS115. Export NS115.
+
+Module NS116. Module NS116.
+Definition x := 0.
+End NS116. End NS116. Export NS116.
+
+Module NS117. Module NS117.
+Definition x := 0.
+End NS117. End NS117. Export NS117.
+
+Module NS118. Module NS118.
+Definition x := 0.
+End NS118. End NS118. Export NS118.
+
+Module NS119. Module NS119.
+Definition x := 0.
+End NS119. End NS119. Export NS119.
+
+Module NS120. Module NS120.
+Definition x := 0.
+End NS120. End NS120. Export NS120.
+
+Module NS121. Module NS121.
+Definition x := 0.
+End NS121. End NS121. Export NS121.
+
+Module NS122. Module NS122.
+Definition x := 0.
+End NS122. End NS122. Export NS122.
+
+Module NS123. Module NS123.
+Definition x := 0.
+End NS123. End NS123. Export NS123.
+
+Module NS124. Module NS124.
+Definition x := 0.
+End NS124. End NS124. Export NS124.
+
+Module NS125. Module NS125.
+Definition x := 0.
+End NS125. End NS125. Export NS125.
+
+Module NS126. Module NS126.
+Definition x := 0.
+End NS126. End NS126. Export NS126.
+
+Module NS127. Module NS127.
+Definition x := 0.
+End NS127. End NS127. Export NS127.
+
+Module NS128. Module NS128.
+Definition x := 0.
+End NS128. End NS128. Export NS128.
+
+Module NS129. Module NS129.
+Definition x := 0.
+End NS129. End NS129. Export NS129.
+
+Module NS130. Module NS130.
+Definition x := 0.
+End NS130. End NS130. Export NS130.
+
+Module NS131. Module NS131.
+Definition x := 0.
+End NS131. End NS131. Export NS131.
+
+Module NS132. Module NS132.
+Definition x := 0.
+End NS132. End NS132. Export NS132.
+
+Module NS133. Module NS133.
+Definition x := 0.
+End NS133. End NS133. Export NS133.
+
+Module NS134. Module NS134.
+Definition x := 0.
+End NS134. End NS134. Export NS134.
+
+Module NS135. Module NS135.
+Definition x := 0.
+End NS135. End NS135. Export NS135.
+
+Module NS136. Module NS136.
+Definition x := 0.
+End NS136. End NS136. Export NS136.
+
+Module NS137. Module NS137.
+Definition x := 0.
+End NS137. End NS137. Export NS137.
+
+Module NS138. Module NS138.
+Definition x := 0.
+End NS138. End NS138. Export NS138.
+
+Module NS139. Module NS139.
+Definition x := 0.
+End NS139. End NS139. Export NS139.
+
+Module NS140. Module NS140.
+Definition x := 0.
+End NS140. End NS140. Export NS140.
+
+Module NS141. Module NS141.
+Definition x := 0.
+End NS141. End NS141. Export NS141.
+
+Module NS142. Module NS142.
+Definition x := 0.
+End NS142. End NS142. Export NS142.
+
+Module NS143. Module NS143.
+Definition x := 0.
+End NS143. End NS143. Export NS143.
+
+Module NS144. Module NS144.
+Definition x := 0.
+End NS144. End NS144. Export NS144.
+
+Module NS145. Module NS145.
+Definition x := 0.
+End NS145. End NS145. Export NS145.
+
+Module NS146. Module NS146.
+Definition x := 0.
+End NS146. End NS146. Export NS146.
+
+Module NS147. Module NS147.
+Definition x := 0.
+End NS147. End NS147. Export NS147.
+
+Module NS148. Module NS148.
+Definition x := 0.
+End NS148. End NS148. Export NS148.
+
+Module NS149. Module NS149.
+Definition x := 0.
+End NS149. End NS149. Export NS149.
+
+Module NS150. Module NS150.
+Definition x := 0.
+End NS150. End NS150. Export NS150.
+
+Module NS151. Module NS151.
+Definition x := 0.
+End NS151. End NS151. Export NS151.
+
+Module NS152. Module NS152.
+Definition x := 0.
+End NS152. End NS152. Export NS152.
+
+Module NS153. Module NS153.
+Definition x := 0.
+End NS153. End NS153. Export NS153.
+
+Module NS154. Module NS154.
+Definition x := 0.
+End NS154. End NS154. Export NS154.
+
+Module NS155. Module NS155.
+Definition x := 0.
+End NS155. End NS155. Export NS155.
+
+Module NS156. Module NS156.
+Definition x := 0.
+End NS156. End NS156. Export NS156.
+
+Module NS157. Module NS157.
+Definition x := 0.
+End NS157. End NS157. Export NS157.
+
+Module NS158. Module NS158.
+Definition x := 0.
+End NS158. End NS158. Export NS158.
+
+Module NS159. Module NS159.
+Definition x := 0.
+End NS159. End NS159. Export NS159.
+
+Module NS160. Module NS160.
+Definition x := 0.
+End NS160. End NS160. Export NS160.
+
+Module NS161. Module NS161.
+Definition x := 0.
+End NS161. End NS161. Export NS161.
+
+Module NS162. Module NS162.
+Definition x := 0.
+End NS162. End NS162. Export NS162.
+
+Module NS163. Module NS163.
+Definition x := 0.
+End NS163. End NS163. Export NS163.
+
+Module NS164. Module NS164.
+Definition x := 0.
+End NS164. End NS164. Export NS164.
+
+Module NS165. Module NS165.
+Definition x := 0.
+End NS165. End NS165. Export NS165.
+
+Module NS166. Module NS166.
+Definition x := 0.
+End NS166. End NS166. Export NS166.
+
+Module NS167. Module NS167.
+Definition x := 0.
+End NS167. End NS167. Export NS167.
+
+Module NS168. Module NS168.
+Definition x := 0.
+End NS168. End NS168. Export NS168.
+
+Module NS169. Module NS169.
+Definition x := 0.
+End NS169. End NS169. Export NS169.
+
+Module NS170. Module NS170.
+Definition x := 0.
+End NS170. End NS170. Export NS170.
+
+Module NS171. Module NS171.
+Definition x := 0.
+End NS171. End NS171. Export NS171.
+
+Module NS172. Module NS172.
+Definition x := 0.
+End NS172. End NS172. Export NS172.
+
+Module NS173. Module NS173.
+Definition x := 0.
+End NS173. End NS173. Export NS173.
+
+Module NS174. Module NS174.
+Definition x := 0.
+End NS174. End NS174. Export NS174.
+
+Module NS175. Module NS175.
+Definition x := 0.
+End NS175. End NS175. Export NS175.
+
+Module NS176. Module NS176.
+Definition x := 0.
+End NS176. End NS176. Export NS176.
+
+Module NS177. Module NS177.
+Definition x := 0.
+End NS177. End NS177. Export NS177.
+
+Module NS178. Module NS178.
+Definition x := 0.
+End NS178. End NS178. Export NS178.
+
+Module NS179. Module NS179.
+Definition x := 0.
+End NS179. End NS179. Export NS179.
+
+Module NS180. Module NS180.
+Definition x := 0.
+End NS180. End NS180. Export NS180.
+
+Module NS181. Module NS181.
+Definition x := 0.
+End NS181. End NS181. Export NS181.
+
+Module NS182. Module NS182.
+Definition x := 0.
+End NS182. End NS182. Export NS182.
+
+Module NS183. Module NS183.
+Definition x := 0.
+End NS183. End NS183. Export NS183.
+
+Module NS184. Module NS184.
+Definition x := 0.
+End NS184. End NS184. Export NS184.
+
+Module NS185. Module NS185.
+Definition x := 0.
+End NS185. End NS185. Export NS185.
+
+Module NS186. Module NS186.
+Definition x := 0.
+End NS186. End NS186. Export NS186.
+
+Module NS187. Module NS187.
+Definition x := 0.
+End NS187. End NS187. Export NS187.
+
+Module NS188. Module NS188.
+Definition x := 0.
+End NS188. End NS188. Export NS188.
+
+Module NS189. Module NS189.
+Definition x := 0.
+End NS189. End NS189. Export NS189.
+
+Module NS190. Module NS190.
+Definition x := 0.
+End NS190. End NS190. Export NS190.
+
+Module NS191. Module NS191.
+Definition x := 0.
+End NS191. End NS191. Export NS191.
+
+Module NS192. Module NS192.
+Definition x := 0.
+End NS192. End NS192. Export NS192.
+
+Module NS193. Module NS193.
+Definition x := 0.
+End NS193. End NS193. Export NS193.
+
+Module NS194. Module NS194.
+Definition x := 0.
+End NS194. End NS194. Export NS194.
+
+Module NS195. Module NS195.
+Definition x := 0.
+End NS195. End NS195. Export NS195.
+
+Module NS196. Module NS196.
+Definition x := 0.
+End NS196. End NS196. Export NS196.
+
+Module NS197. Module NS197.
+Definition x := 0.
+End NS197. End NS197. Export NS197.
+
+Module NS198. Module NS198.
+Definition x := 0.
+End NS198. End NS198. Export NS198.
+
+Module NS199. Module NS199.
+Definition x := 0.
+End NS199. End NS199. Export NS199.
+
+Module NS200. Module NS200.
+Definition x := 0.
+End NS200. End NS200. Export NS200.
+
+Module NS201. Module NS201.
+Definition x := 0.
+End NS201. End NS201. Export NS201.
+
+Module NS202. Module NS202.
+Definition x := 0.
+End NS202. End NS202. Export NS202.
+
+Module NS203. Module NS203.
+Definition x := 0.
+End NS203. End NS203. Export NS203.
+
+Module NS204. Module NS204.
+Definition x := 0.
+End NS204. End NS204. Export NS204.
+
+Module NS205. Module NS205.
+Definition x := 0.
+End NS205. End NS205. Export NS205.
+
+Module NS206. Module NS206.
+Definition x := 0.
+End NS206. End NS206. Export NS206.
+
+Module NS207. Module NS207.
+Definition x := 0.
+End NS207. End NS207. Export NS207.
+
+Module NS208. Module NS208.
+Definition x := 0.
+End NS208. End NS208. Export NS208.
+
+Module NS209. Module NS209.
+Definition x := 0.
+End NS209. End NS209. Export NS209.
+
+Module NS210. Module NS210.
+Definition x := 0.
+End NS210. End NS210. Export NS210.
+
+Module NS211. Module NS211.
+Definition x := 0.
+End NS211. End NS211. Export NS211.
+
+Module NS212. Module NS212.
+Definition x := 0.
+End NS212. End NS212. Export NS212.
+
+Module NS213. Module NS213.
+Definition x := 0.
+End NS213. End NS213. Export NS213.
+
+Module NS214. Module NS214.
+Definition x := 0.
+End NS214. End NS214. Export NS214.
+
+Module NS215. Module NS215.
+Definition x := 0.
+End NS215. End NS215. Export NS215.
+
+Module NS216. Module NS216.
+Definition x := 0.
+End NS216. End NS216. Export NS216.
+
+Module NS217. Module NS217.
+Definition x := 0.
+End NS217. End NS217. Export NS217.
+
+Module NS218. Module NS218.
+Definition x := 0.
+End NS218. End NS218. Export NS218.
+
+Module NS219. Module NS219.
+Definition x := 0.
+End NS219. End NS219. Export NS219.
+
+Module NS220. Module NS220.
+Definition x := 0.
+End NS220. End NS220. Export NS220.
+
+Module NS221. Module NS221.
+Definition x := 0.
+End NS221. End NS221. Export NS221.
+
+Module NS222. Module NS222.
+Definition x := 0.
+End NS222. End NS222. Export NS222.
+
+Module NS223. Module NS223.
+Definition x := 0.
+End NS223. End NS223. Export NS223.
+
+Module NS224. Module NS224.
+Definition x := 0.
+End NS224. End NS224. Export NS224.
+
+Module NS225. Module NS225.
+Definition x := 0.
+End NS225. End NS225. Export NS225.
+
+Module NS226. Module NS226.
+Definition x := 0.
+End NS226. End NS226. Export NS226.
+
+Module NS227. Module NS227.
+Definition x := 0.
+End NS227. End NS227. Export NS227.
+
+Module NS228. Module NS228.
+Definition x := 0.
+End NS228. End NS228. Export NS228.
+
+Module NS229. Module NS229.
+Definition x := 0.
+End NS229. End NS229. Export NS229.
+
+Module NS230. Module NS230.
+Definition x := 0.
+End NS230. End NS230. Export NS230.
+
+Module NS231. Module NS231.
+Definition x := 0.
+End NS231. End NS231. Export NS231.
+
+Module NS232. Module NS232.
+Definition x := 0.
+End NS232. End NS232. Export NS232.
+
+Module NS233. Module NS233.
+Definition x := 0.
+End NS233. End NS233. Export NS233.
+
+Module NS234. Module NS234.
+Definition x := 0.
+End NS234. End NS234. Export NS234.
+
+Module NS235. Module NS235.
+Definition x := 0.
+End NS235. End NS235. Export NS235.
+
+Module NS236. Module NS236.
+Definition x := 0.
+End NS236. End NS236. Export NS236.
+
+Module NS237. Module NS237.
+Definition x := 0.
+End NS237. End NS237. Export NS237.
+
+Module NS238. Module NS238.
+Definition x := 0.
+End NS238. End NS238. Export NS238.
+
+Module NS239. Module NS239.
+Definition x := 0.
+End NS239. End NS239. Export NS239.
+
+Module NS240. Module NS240.
+Definition x := 0.
+End NS240. End NS240. Export NS240.
+
+Module NS241. Module NS241.
+Definition x := 0.
+End NS241. End NS241. Export NS241.
+
+Module NS242. Module NS242.
+Definition x := 0.
+End NS242. End NS242. Export NS242.
+
+Module NS243. Module NS243.
+Definition x := 0.
+End NS243. End NS243. Export NS243.
+
+Module NS244. Module NS244.
+Definition x := 0.
+End NS244. End NS244. Export NS244.
+
+Module NS245. Module NS245.
+Definition x := 0.
+End NS245. End NS245. Export NS245.
+
+Module NS246. Module NS246.
+Definition x := 0.
+End NS246. End NS246. Export NS246.
+
+Module NS247. Module NS247.
+Definition x := 0.
+End NS247. End NS247. Export NS247.
+
+Module NS248. Module NS248.
+Definition x := 0.
+End NS248. End NS248. Export NS248.
+
+Module NS249. Module NS249.
+Definition x := 0.
+End NS249. End NS249. Export NS249.
+
+Module NS250. Module NS250.
+Definition x := 0.
+End NS250. End NS250. Export NS250.
+
+Module NS251. Module NS251.
+Definition x := 0.
+End NS251. End NS251. Export NS251.
+
+Module NS252. Module NS252.
+Definition x := 0.
+End NS252. End NS252. Export NS252.
+
+Module NS253. Module NS253.
+Definition x := 0.
+End NS253. End NS253. Export NS253.
+
+Module NS254. Module NS254.
+Definition x := 0.
+End NS254. End NS254. Export NS254.
+
+Module NS255. Module NS255.
+Definition x := 0.
+End NS255. End NS255. Export NS255.
+
+Module NS256. Module NS256.
+Definition x := 0.
+End NS256. End NS256. Export NS256.
+
+Module NS257. Module NS257.
+Definition x := 0.
+End NS257. End NS257. Export NS257.
+
+Module NS258. Module NS258.
+Definition x := 0.
+End NS258. End NS258. Export NS258.
+
+Module NS259. Module NS259.
+Definition x := 0.
+End NS259. End NS259. Export NS259.
+
+Module NS260. Module NS260.
+Definition x := 0.
+End NS260. End NS260. Export NS260.
+
+Module NS261. Module NS261.
+Definition x := 0.
+End NS261. End NS261. Export NS261.
+
+Module NS262. Module NS262.
+Definition x := 0.
+End NS262. End NS262. Export NS262.
+
+Module NS263. Module NS263.
+Definition x := 0.
+End NS263. End NS263. Export NS263.
+
+Module NS264. Module NS264.
+Definition x := 0.
+End NS264. End NS264. Export NS264.
+
+Module NS265. Module NS265.
+Definition x := 0.
+End NS265. End NS265. Export NS265.
+
+Module NS266. Module NS266.
+Definition x := 0.
+End NS266. End NS266. Export NS266.
+
+Module NS267. Module NS267.
+Definition x := 0.
+End NS267. End NS267. Export NS267.
+
+Module NS268. Module NS268.
+Definition x := 0.
+End NS268. End NS268. Export NS268.
+
+Module NS269. Module NS269.
+Definition x := 0.
+End NS269. End NS269. Export NS269.
+
+Module NS270. Module NS270.
+Definition x := 0.
+End NS270. End NS270. Export NS270.
+
+Module NS271. Module NS271.
+Definition x := 0.
+End NS271. End NS271. Export NS271.
+
+Module NS272. Module NS272.
+Definition x := 0.
+End NS272. End NS272. Export NS272.
+
+Module NS273. Module NS273.
+Definition x := 0.
+End NS273. End NS273. Export NS273.
+
+Module NS274. Module NS274.
+Definition x := 0.
+End NS274. End NS274. Export NS274.
+
+Module NS275. Module NS275.
+Definition x := 0.
+End NS275. End NS275. Export NS275.
+
+Module NS276. Module NS276.
+Definition x := 0.
+End NS276. End NS276. Export NS276.
+
+Module NS277. Module NS277.
+Definition x := 0.
+End NS277. End NS277. Export NS277.
+
+Module NS278. Module NS278.
+Definition x := 0.
+End NS278. End NS278. Export NS278.
+
+Module NS279. Module NS279.
+Definition x := 0.
+End NS279. End NS279. Export NS279.
+
+Module NS280. Module NS280.
+Definition x := 0.
+End NS280. End NS280. Export NS280.
+
+Module NS281. Module NS281.
+Definition x := 0.
+End NS281. End NS281. Export NS281.
+
+Module NS282. Module NS282.
+Definition x := 0.
+End NS282. End NS282. Export NS282.
+
+Module NS283. Module NS283.
+Definition x := 0.
+End NS283. End NS283. Export NS283.
+
+Module NS284. Module NS284.
+Definition x := 0.
+End NS284. End NS284. Export NS284.
+
+Module NS285. Module NS285.
+Definition x := 0.
+End NS285. End NS285. Export NS285.
+
+Module NS286. Module NS286.
+Definition x := 0.
+End NS286. End NS286. Export NS286.
+
+Module NS287. Module NS287.
+Definition x := 0.
+End NS287. End NS287. Export NS287.
+
+Module NS288. Module NS288.
+Definition x := 0.
+End NS288. End NS288. Export NS288.
+
+Module NS289. Module NS289.
+Definition x := 0.
+End NS289. End NS289. Export NS289.
+
+Module NS290. Module NS290.
+Definition x := 0.
+End NS290. End NS290. Export NS290.
+
+Module NS291. Module NS291.
+Definition x := 0.
+End NS291. End NS291. Export NS291.
+
+Module NS292. Module NS292.
+Definition x := 0.
+End NS292. End NS292. Export NS292.
+
+Module NS293. Module NS293.
+Definition x := 0.
+End NS293. End NS293. Export NS293.
+
+Module NS294. Module NS294.
+Definition x := 0.
+End NS294. End NS294. Export NS294.
+
+Module NS295. Module NS295.
+Definition x := 0.
+End NS295. End NS295. Export NS295.
+
+Module NS296. Module NS296.
+Definition x := 0.
+End NS296. End NS296. Export NS296.
+
+Module NS297. Module NS297.
+Definition x := 0.
+End NS297. End NS297. Export NS297.
+
+Module NS298. Module NS298.
+Definition x := 0.
+End NS298. End NS298. Export NS298.
+
+Module NS299. Module NS299.
+Definition x := 0.
+End NS299. End NS299. Export NS299.
+
+Module NS300. Module NS300.
+Definition x := 0.
+End NS300. End NS300. Export NS300.
+
+Module NS301. Module NS301.
+Definition x := 0.
+End NS301. End NS301. Export NS301.
+
+Module NS302. Module NS302.
+Definition x := 0.
+End NS302. End NS302. Export NS302.
+
+Module NS303. Module NS303.
+Definition x := 0.
+End NS303. End NS303. Export NS303.
+
+Module NS304. Module NS304.
+Definition x := 0.
+End NS304. End NS304. Export NS304.
+
+Module NS305. Module NS305.
+Definition x := 0.
+End NS305. End NS305. Export NS305.
+
+Module NS306. Module NS306.
+Definition x := 0.
+End NS306. End NS306. Export NS306.
+
+Module NS307. Module NS307.
+Definition x := 0.
+End NS307. End NS307. Export NS307.
+
+Module NS308. Module NS308.
+Definition x := 0.
+End NS308. End NS308. Export NS308.
+
+Module NS309. Module NS309.
+Definition x := 0.
+End NS309. End NS309. Export NS309.
+
+Module NS310. Module NS310.
+Definition x := 0.
+End NS310. End NS310. Export NS310.
+
+Module NS311. Module NS311.
+Definition x := 0.
+End NS311. End NS311. Export NS311.
+
+Module NS312. Module NS312.
+Definition x := 0.
+End NS312. End NS312. Export NS312.
+
+Module NS313. Module NS313.
+Definition x := 0.
+End NS313. End NS313. Export NS313.
+
+Module NS314. Module NS314.
+Definition x := 0.
+End NS314. End NS314. Export NS314.
+
+Module NS315. Module NS315.
+Definition x := 0.
+End NS315. End NS315. Export NS315.
+
+Module NS316. Module NS316.
+Definition x := 0.
+End NS316. End NS316. Export NS316.
+
+Module NS317. Module NS317.
+Definition x := 0.
+End NS317. End NS317. Export NS317.
+
+Module NS318. Module NS318.
+Definition x := 0.
+End NS318. End NS318. Export NS318.
+
+Module NS319. Module NS319.
+Definition x := 0.
+End NS319. End NS319. Export NS319.
+
+Module NS320. Module NS320.
+Definition x := 0.
+End NS320. End NS320. Export NS320.
+
+Module NS321. Module NS321.
+Definition x := 0.
+End NS321. End NS321. Export NS321.
+
+Module NS322. Module NS322.
+Definition x := 0.
+End NS322. End NS322. Export NS322.
+
+Module NS323. Module NS323.
+Definition x := 0.
+End NS323. End NS323. Export NS323.
+
+Module NS324. Module NS324.
+Definition x := 0.
+End NS324. End NS324. Export NS324.
+
+Module NS325. Module NS325.
+Definition x := 0.
+End NS325. End NS325. Export NS325.
+
+Module NS326. Module NS326.
+Definition x := 0.
+End NS326. End NS326. Export NS326.
+
+Module NS327. Module NS327.
+Definition x := 0.
+End NS327. End NS327. Export NS327.
+
+Module NS328. Module NS328.
+Definition x := 0.
+End NS328. End NS328. Export NS328.
+
+Module NS329. Module NS329.
+Definition x := 0.
+End NS329. End NS329. Export NS329.
+
+Module NS330. Module NS330.
+Definition x := 0.
+End NS330. End NS330. Export NS330.
+
+Module NS331. Module NS331.
+Definition x := 0.
+End NS331. End NS331. Export NS331.
+
+Module NS332. Module NS332.
+Definition x := 0.
+End NS332. End NS332. Export NS332.
+
+Module NS333. Module NS333.
+Definition x := 0.
+End NS333. End NS333. Export NS333.
+
+Module NS334. Module NS334.
+Definition x := 0.
+End NS334. End NS334. Export NS334.
+
+Module NS335. Module NS335.
+Definition x := 0.
+End NS335. End NS335. Export NS335.
+
+Module NS336. Module NS336.
+Definition x := 0.
+End NS336. End NS336. Export NS336.
+
+Module NS337. Module NS337.
+Definition x := 0.
+End NS337. End NS337. Export NS337.
+
+Module NS338. Module NS338.
+Definition x := 0.
+End NS338. End NS338. Export NS338.
+
+Module NS339. Module NS339.
+Definition x := 0.
+End NS339. End NS339. Export NS339.
+
+Module NS340. Module NS340.
+Definition x := 0.
+End NS340. End NS340. Export NS340.
+
+Module NS341. Module NS341.
+Definition x := 0.
+End NS341. End NS341. Export NS341.
+
+Module NS342. Module NS342.
+Definition x := 0.
+End NS342. End NS342. Export NS342.
+
+Module NS343. Module NS343.
+Definition x := 0.
+End NS343. End NS343. Export NS343.
+
+Module NS344. Module NS344.
+Definition x := 0.
+End NS344. End NS344. Export NS344.
+
+Module NS345. Module NS345.
+Definition x := 0.
+End NS345. End NS345. Export NS345.
+
+Module NS346. Module NS346.
+Definition x := 0.
+End NS346. End NS346. Export NS346.
+
+Module NS347. Module NS347.
+Definition x := 0.
+End NS347. End NS347. Export NS347.
+
+Module NS348. Module NS348.
+Definition x := 0.
+End NS348. End NS348. Export NS348.
+
+Module NS349. Module NS349.
+Definition x := 0.
+End NS349. End NS349. Export NS349.
+
+Module NS350. Module NS350.
+Definition x := 0.
+End NS350. End NS350. Export NS350.
+
+Module NS351. Module NS351.
+Definition x := 0.
+End NS351. End NS351. Export NS351.
+
+Module NS352. Module NS352.
+Definition x := 0.
+End NS352. End NS352. Export NS352.
+
+Module NS353. Module NS353.
+Definition x := 0.
+End NS353. End NS353. Export NS353.
+
+Module NS354. Module NS354.
+Definition x := 0.
+End NS354. End NS354. Export NS354.
+
+Module NS355. Module NS355.
+Definition x := 0.
+End NS355. End NS355. Export NS355.
+
+Module NS356. Module NS356.
+Definition x := 0.
+End NS356. End NS356. Export NS356.
+
+Module NS357. Module NS357.
+Definition x := 0.
+End NS357. End NS357. Export NS357.
+
+Module NS358. Module NS358.
+Definition x := 0.
+End NS358. End NS358. Export NS358.
+
+Module NS359. Module NS359.
+Definition x := 0.
+End NS359. End NS359. Export NS359.
+
+Module NS360. Module NS360.
+Definition x := 0.
+End NS360. End NS360. Export NS360.
+
+Module NS361. Module NS361.
+Definition x := 0.
+End NS361. End NS361. Export NS361.
+
+Module NS362. Module NS362.
+Definition x := 0.
+End NS362. End NS362. Export NS362.
+
+Module NS363. Module NS363.
+Definition x := 0.
+End NS363. End NS363. Export NS363.
+
+Module NS364. Module NS364.
+Definition x := 0.
+End NS364. End NS364. Export NS364.
+
+Module NS365. Module NS365.
+Definition x := 0.
+End NS365. End NS365. Export NS365.
+
+Module NS366. Module NS366.
+Definition x := 0.
+End NS366. End NS366. Export NS366.
+
+Module NS367. Module NS367.
+Definition x := 0.
+End NS367. End NS367. Export NS367.
+
+Module NS368. Module NS368.
+Definition x := 0.
+End NS368. End NS368. Export NS368.
+
+Module NS369. Module NS369.
+Definition x := 0.
+End NS369. End NS369. Export NS369.
+
+Module NS370. Module NS370.
+Definition x := 0.
+End NS370. End NS370. Export NS370.
+
+Module NS371. Module NS371.
+Definition x := 0.
+End NS371. End NS371. Export NS371.
+
+Module NS372. Module NS372.
+Definition x := 0.
+End NS372. End NS372. Export NS372.
+
+Module NS373. Module NS373.
+Definition x := 0.
+End NS373. End NS373. Export NS373.
+
+Module NS374. Module NS374.
+Definition x := 0.
+End NS374. End NS374. Export NS374.
+
+Module NS375. Module NS375.
+Definition x := 0.
+End NS375. End NS375. Export NS375.
+
+Module NS376. Module NS376.
+Definition x := 0.
+End NS376. End NS376. Export NS376.
+
+Module NS377. Module NS377.
+Definition x := 0.
+End NS377. End NS377. Export NS377.
+
+Module NS378. Module NS378.
+Definition x := 0.
+End NS378. End NS378. Export NS378.
+
+Module NS379. Module NS379.
+Definition x := 0.
+End NS379. End NS379. Export NS379.
+
+Module NS380. Module NS380.
+Definition x := 0.
+End NS380. End NS380. Export NS380.
+
+Module NS381. Module NS381.
+Definition x := 0.
+End NS381. End NS381. Export NS381.
+
+Module NS382. Module NS382.
+Definition x := 0.
+End NS382. End NS382. Export NS382.
+
+Module NS383. Module NS383.
+Definition x := 0.
+End NS383. End NS383. Export NS383.
+
+Module NS384. Module NS384.
+Definition x := 0.
+End NS384. End NS384. Export NS384.
+
+Module NS385. Module NS385.
+Definition x := 0.
+End NS385. End NS385. Export NS385.
+
+Module NS386. Module NS386.
+Definition x := 0.
+End NS386. End NS386. Export NS386.
+
+Module NS387. Module NS387.
+Definition x := 0.
+End NS387. End NS387. Export NS387.
+
+Module NS388. Module NS388.
+Definition x := 0.
+End NS388. End NS388. Export NS388.
+
+Module NS389. Module NS389.
+Definition x := 0.
+End NS389. End NS389. Export NS389.
+
+Module NS390. Module NS390.
+Definition x := 0.
+End NS390. End NS390. Export NS390.
+
+Module NS391. Module NS391.
+Definition x := 0.
+End NS391. End NS391. Export NS391.
+
+Module NS392. Module NS392.
+Definition x := 0.
+End NS392. End NS392. Export NS392.
+
+Module NS393. Module NS393.
+Definition x := 0.
+End NS393. End NS393. Export NS393.
+
+Module NS394. Module NS394.
+Definition x := 0.
+End NS394. End NS394. Export NS394.
+
+Module NS395. Module NS395.
+Definition x := 0.
+End NS395. End NS395. Export NS395.
+
+Module NS396. Module NS396.
+Definition x := 0.
+End NS396. End NS396. Export NS396.
+
+Module NS397. Module NS397.
+Definition x := 0.
+End NS397. End NS397. Export NS397.
+
+Module NS398. Module NS398.
+Definition x := 0.
+End NS398. End NS398. Export NS398.
+
+Module NS399. Module NS399.
+Definition x := 0.
+End NS399. End NS399. Export NS399.
+
+Module NS400. Module NS400.
+Definition x := 0.
+End NS400. End NS400. Export NS400.
+
+Module NS401. Module NS401.
+Definition x := 0.
+End NS401. End NS401. Export NS401.
+
+Module NS402. Module NS402.
+Definition x := 0.
+End NS402. End NS402. Export NS402.
+
+Module NS403. Module NS403.
+Definition x := 0.
+End NS403. End NS403. Export NS403.
+
+Module NS404. Module NS404.
+Definition x := 0.
+End NS404. End NS404. Export NS404.
+
+Module NS405. Module NS405.
+Definition x := 0.
+End NS405. End NS405. Export NS405.
+
+Module NS406. Module NS406.
+Definition x := 0.
+End NS406. End NS406. Export NS406.
+
+Module NS407. Module NS407.
+Definition x := 0.
+End NS407. End NS407. Export NS407.
+
+Module NS408. Module NS408.
+Definition x := 0.
+End NS408. End NS408. Export NS408.
+
+Module NS409. Module NS409.
+Definition x := 0.
+End NS409. End NS409. Export NS409.
+
+Module NS410. Module NS410.
+Definition x := 0.
+End NS410. End NS410. Export NS410.
+
+Module NS411. Module NS411.
+Definition x := 0.
+End NS411. End NS411. Export NS411.
+
+Module NS412. Module NS412.
+Definition x := 0.
+End NS412. End NS412. Export NS412.
+
+Module NS413. Module NS413.
+Definition x := 0.
+End NS413. End NS413. Export NS413.
+
+Module NS414. Module NS414.
+Definition x := 0.
+End NS414. End NS414. Export NS414.
+
+Module NS415. Module NS415.
+Definition x := 0.
+End NS415. End NS415. Export NS415.
+
+Module NS416. Module NS416.
+Definition x := 0.
+End NS416. End NS416. Export NS416.
+
+Module NS417. Module NS417.
+Definition x := 0.
+End NS417. End NS417. Export NS417.
+
+Module NS418. Module NS418.
+Definition x := 0.
+End NS418. End NS418. Export NS418.
+
+Module NS419. Module NS419.
+Definition x := 0.
+End NS419. End NS419. Export NS419.
+
+Module NS420. Module NS420.
+Definition x := 0.
+End NS420. End NS420. Export NS420.
+
+Module NS421. Module NS421.
+Definition x := 0.
+End NS421. End NS421. Export NS421.
+
+Module NS422. Module NS422.
+Definition x := 0.
+End NS422. End NS422. Export NS422.
+
+Module NS423. Module NS423.
+Definition x := 0.
+End NS423. End NS423. Export NS423.
+
+Module NS424. Module NS424.
+Definition x := 0.
+End NS424. End NS424. Export NS424.
+
+Module NS425. Module NS425.
+Definition x := 0.
+End NS425. End NS425. Export NS425.
+
+Module NS426. Module NS426.
+Definition x := 0.
+End NS426. End NS426. Export NS426.
+
+Module NS427. Module NS427.
+Definition x := 0.
+End NS427. End NS427. Export NS427.
+
+Module NS428. Module NS428.
+Definition x := 0.
+End NS428. End NS428. Export NS428.
+
+Module NS429. Module NS429.
+Definition x := 0.
+End NS429. End NS429. Export NS429.
+
+Module NS430. Module NS430.
+Definition x := 0.
+End NS430. End NS430. Export NS430.
+
+Module NS431. Module NS431.
+Definition x := 0.
+End NS431. End NS431. Export NS431.
+
+Module NS432. Module NS432.
+Definition x := 0.
+End NS432. End NS432. Export NS432.
+
+Module NS433. Module NS433.
+Definition x := 0.
+End NS433. End NS433. Export NS433.
+
+Module NS434. Module NS434.
+Definition x := 0.
+End NS434. End NS434. Export NS434.
+
+Module NS435. Module NS435.
+Definition x := 0.
+End NS435. End NS435. Export NS435.
+
+Module NS436. Module NS436.
+Definition x := 0.
+End NS436. End NS436. Export NS436.
+
+Module NS437. Module NS437.
+Definition x := 0.
+End NS437. End NS437. Export NS437.
+
+Module NS438. Module NS438.
+Definition x := 0.
+End NS438. End NS438. Export NS438.
+
+Module NS439. Module NS439.
+Definition x := 0.
+End NS439. End NS439. Export NS439.
+
+Module NS440. Module NS440.
+Definition x := 0.
+End NS440. End NS440. Export NS440.
+
+Module NS441. Module NS441.
+Definition x := 0.
+End NS441. End NS441. Export NS441.
+
+Module NS442. Module NS442.
+Definition x := 0.
+End NS442. End NS442. Export NS442.
+
+Module NS443. Module NS443.
+Definition x := 0.
+End NS443. End NS443. Export NS443.
+
+Module NS444. Module NS444.
+Definition x := 0.
+End NS444. End NS444. Export NS444.
+
+Module NS445. Module NS445.
+Definition x := 0.
+End NS445. End NS445. Export NS445.
+
+Module NS446. Module NS446.
+Definition x := 0.
+End NS446. End NS446. Export NS446.
+
+Module NS447. Module NS447.
+Definition x := 0.
+End NS447. End NS447. Export NS447.
+
+Module NS448. Module NS448.
+Definition x := 0.
+End NS448. End NS448. Export NS448.
+
+Module NS449. Module NS449.
+Definition x := 0.
+End NS449. End NS449. Export NS449.
+
+Module NS450. Module NS450.
+Definition x := 0.
+End NS450. End NS450. Export NS450.
+
+Module NS451. Module NS451.
+Definition x := 0.
+End NS451. End NS451. Export NS451.
+
+Module NS452. Module NS452.
+Definition x := 0.
+End NS452. End NS452. Export NS452.
+
+Module NS453. Module NS453.
+Definition x := 0.
+End NS453. End NS453. Export NS453.
+
+Module NS454. Module NS454.
+Definition x := 0.
+End NS454. End NS454. Export NS454.
+
+Module NS455. Module NS455.
+Definition x := 0.
+End NS455. End NS455. Export NS455.
+
+Module NS456. Module NS456.
+Definition x := 0.
+End NS456. End NS456. Export NS456.
+
+Module NS457. Module NS457.
+Definition x := 0.
+End NS457. End NS457. Export NS457.
+
+Module NS458. Module NS458.
+Definition x := 0.
+End NS458. End NS458. Export NS458.
+
+Module NS459. Module NS459.
+Definition x := 0.
+End NS459. End NS459. Export NS459.
+
+Module NS460. Module NS460.
+Definition x := 0.
+End NS460. End NS460. Export NS460.
+
+Module NS461. Module NS461.
+Definition x := 0.
+End NS461. End NS461. Export NS461.
+
+Module NS462. Module NS462.
+Definition x := 0.
+End NS462. End NS462. Export NS462.
+
+Module NS463. Module NS463.
+Definition x := 0.
+End NS463. End NS463. Export NS463.
+
+Module NS464. Module NS464.
+Definition x := 0.
+End NS464. End NS464. Export NS464.
+
+Module NS465. Module NS465.
+Definition x := 0.
+End NS465. End NS465. Export NS465.
+
+Module NS466. Module NS466.
+Definition x := 0.
+End NS466. End NS466. Export NS466.
+
+Module NS467. Module NS467.
+Definition x := 0.
+End NS467. End NS467. Export NS467.
+
+Module NS468. Module NS468.
+Definition x := 0.
+End NS468. End NS468. Export NS468.
+
+Module NS469. Module NS469.
+Definition x := 0.
+End NS469. End NS469. Export NS469.
+
+Module NS470. Module NS470.
+Definition x := 0.
+End NS470. End NS470. Export NS470.
+
+Module NS471. Module NS471.
+Definition x := 0.
+End NS471. End NS471. Export NS471.
+
+Module NS472. Module NS472.
+Definition x := 0.
+End NS472. End NS472. Export NS472.
+
+Module NS473. Module NS473.
+Definition x := 0.
+End NS473. End NS473. Export NS473.
+
+Module NS474. Module NS474.
+Definition x := 0.
+End NS474. End NS474. Export NS474.
+
+Module NS475. Module NS475.
+Definition x := 0.
+End NS475. End NS475. Export NS475.
+
+Module NS476. Module NS476.
+Definition x := 0.
+End NS476. End NS476. Export NS476.
+
+Module NS477. Module NS477.
+Definition x := 0.
+End NS477. End NS477. Export NS477.
+
+Module NS478. Module NS478.
+Definition x := 0.
+End NS478. End NS478. Export NS478.
+
+Module NS479. Module NS479.
+Definition x := 0.
+End NS479. End NS479. Export NS479.
+
+Module NS480. Module NS480.
+Definition x := 0.
+End NS480. End NS480. Export NS480.
+
+Module NS481. Module NS481.
+Definition x := 0.
+End NS481. End NS481. Export NS481.
+
+Module NS482. Module NS482.
+Definition x := 0.
+End NS482. End NS482. Export NS482.
+
+Module NS483. Module NS483.
+Definition x := 0.
+End NS483. End NS483. Export NS483.
+
+Module NS484. Module NS484.
+Definition x := 0.
+End NS484. End NS484. Export NS484.
+
+Module NS485. Module NS485.
+Definition x := 0.
+End NS485. End NS485. Export NS485.
+
+Module NS486. Module NS486.
+Definition x := 0.
+End NS486. End NS486. Export NS486.
+
+Module NS487. Module NS487.
+Definition x := 0.
+End NS487. End NS487. Export NS487.
+
+Module NS488. Module NS488.
+Definition x := 0.
+End NS488. End NS488. Export NS488.
+
+Module NS489. Module NS489.
+Definition x := 0.
+End NS489. End NS489. Export NS489.
+
+Module NS490. Module NS490.
+Definition x := 0.
+End NS490. End NS490. Export NS490.
+
+Module NS491. Module NS491.
+Definition x := 0.
+End NS491. End NS491. Export NS491.
+
+Module NS492. Module NS492.
+Definition x := 0.
+End NS492. End NS492. Export NS492.
+
+Module NS493. Module NS493.
+Definition x := 0.
+End NS493. End NS493. Export NS493.
+
+Module NS494. Module NS494.
+Definition x := 0.
+End NS494. End NS494. Export NS494.
+
+Module NS495. Module NS495.
+Definition x := 0.
+End NS495. End NS495. Export NS495.
+
+Module NS496. Module NS496.
+Definition x := 0.
+End NS496. End NS496. Export NS496.
+
+Module NS497. Module NS497.
+Definition x := 0.
+End NS497. End NS497. Export NS497.
+
+Module NS498. Module NS498.
+Definition x := 0.
+End NS498. End NS498. Export NS498.
+
+Module NS499. Module NS499.
+Definition x := 0.
+End NS499. End NS499. Export NS499.
+
+Module NS500. Module NS500.
+Definition x := 0.
+End NS500. End NS500. Export NS500.

--- a/apps/NES/theories/NES.v
+++ b/apps/NES/theories/NES.v
@@ -8,6 +8,7 @@ open-ns _ _ :- fail.
 
 typeabbrev path (list string).
 
+:index (2)
 pred ns o:path, o:modpath.
 
 }}.
@@ -32,7 +33,7 @@ Elpi Accumulate Db NES.db.
 Elpi Accumulate File "elpi/nes.elpi".
 Elpi Accumulate lp:{{
 
-  main [str NS] :- nes.begin-path {nes.string->ns NS}.
+  main [str NS] :- std.time (nes.begin-path {nes.string->ns NS}) T, coq.say "B" T.
   main _ :- coq.error "usage: NES.Begin <DotSeparatedPath>".
 
 }}.
@@ -44,7 +45,7 @@ Elpi Accumulate Db NES.db.
 Elpi Accumulate File "elpi/nes.elpi".
 Elpi Accumulate lp:{{
 
-  main [str NS] :- nes.end-path {nes.string->ns NS}.
+  main [str NS] :- std.time (nes.end-path {nes.string->ns NS}) T, coq.say "E" T.
   main _ :- coq.error "usage: NES.End <DotSeparatedPath>".
 
 }}.

--- a/apps/NES/theories/NES.v
+++ b/apps/NES/theories/NES.v
@@ -29,26 +29,26 @@ Elpi Typecheck.
 Elpi Export NES.Status.
 
 Elpi Command NES.Begin.
-Elpi Accumulate Db NES.db.
 Elpi Accumulate File "elpi/nes.elpi".
 Elpi Accumulate lp:{{
 
-  main [str NS] :- std.time (nes.begin-path {nes.string->ns NS}) T, coq.say "B" T.
+  main [str NS] :- nes.begin-path {nes.string->ns NS}.
   main _ :- coq.error "usage: NES.Begin <DotSeparatedPath>".
 
 }}.
+Elpi Accumulate Db NES.db.
 Elpi Typecheck.
 Elpi Export NES.Begin.
 
 Elpi Command NES.End.
-Elpi Accumulate Db NES.db.
 Elpi Accumulate File "elpi/nes.elpi".
 Elpi Accumulate lp:{{
 
-  main [str NS] :- std.time (nes.end-path {nes.string->ns NS}) T, coq.say "E" T.
+  main [str NS] :- nes.end-path {nes.string->ns NS}.
   main _ :- coq.error "usage: NES.End <DotSeparatedPath>".
 
 }}.
+Elpi Accumulate Db NES.db.
 Elpi Typecheck.
 Elpi Export NES.End.
 

--- a/src/coq_elpi_HOAS.ml
+++ b/src/coq_elpi_HOAS.ml
@@ -419,39 +419,9 @@ let show_coq_engine = Format.asprintf "%a" pp_coq_engine
 
  let from_env env = from_env_sigma env (Evd.from_env env)
 
- (* copy of UState.t *)
- type hack_UState_demote_global_univs_missin_API_in_811_t = {
-   uctx_names : UnivNames.universe_binders * uinfo Univ.LMap.t;
-   uctx_local : Univ.ContextSet.t; (** The local context of variables *)
-   uctx_seff_univs : Univ.LSet.t; (** Local universes used through private constants *)
-   uctx_univ_variables : UnivSubst.universe_opt_subst;
-   (** The local universes that are unification variables *)
-   uctx_univ_algebraic : Univ.LSet.t;
-   (** The subset of unification variables that can be instantiated with
-        algebraic universes as they appear in inferred types only. *)
-   uctx_universes : UGraph.t; (** The current graph extended with the local constraints *)
-   uctx_universes_lbound : Univ.Level.t; (** The lower bound on universes (e.g. Set or Prop) *)
-   uctx_initial_universes : UGraph.t; (** The graph at the creation of the evar_map *)
-   uctx_weak_constraints : UnivMinim.UPairSet.t
- } and uinfo = {
-  uname : Id.t option;
-  uloc : Loc.t option;
- }
-
-let hack_UState_demote_global_univs_missin_API_in_811 env (uctx : UState.t) =
-  let uctx : hack_UState_demote_global_univs_missin_API_in_811_t = Obj.magic uctx in
-  let open Univ in
-  let env_ugraph = Environ.universes env in
-  let global_univs = UGraph.domain env_ugraph in
-  let global_constraints, _ = UGraph.constraints_of_universes env_ugraph in
-  let promoted_uctx =
-    ContextSet.(of_set global_univs |> add_constraints global_constraints) in
-  let uctx = { uctx with uctx_local = ContextSet.diff uctx.uctx_local promoted_uctx } in
-  (Obj.magic uctx : UState.t)
-
  let from_env_keep_univ_of_sigma env sigma0 =
    let sigma = Evd.update_sigma_env sigma0 env in
-   let sigma = Evd.from_ctx (hack_UState_demote_global_univs_missin_API_in_811 env (Evd.evar_universe_context sigma)) in
+   let sigma = Evd.from_ctx (UState.demote_global_univs env (Evd.evar_universe_context sigma)) in
    from_env_sigma env sigma
  let init () = from_env (Global.env ())
 

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -413,7 +413,7 @@ The name and the grafting specification can be left unspecified.|};
 } |> CConv.(!<)
 
 let set_accumulate_to_db, get_accumulate_to_db =
-  let f = ref ((fun () -> assert false),(fun _ _ ~local:_ -> assert false)) in
+  let f = ref ((fun () -> assert false),(fun _ _ ~local:_ -> assert false),(fun () -> assert false)) in
   (fun x -> f := x),
   (fun () -> !f)
 
@@ -2050,8 +2050,8 @@ Supported attributes:
          State.update clauses_for_later state (fun l ->
            (dbname,clause,local) :: l), (), []
      | Given CurrentModule ->
-          let elpi, f = get_accumulate_to_db () in
-          f dbname API.(Compile.unit ~elpi:(elpi ()) ~flags:Compile.default_flags clause) ~local;
+          let elpi, f, cur_program = get_accumulate_to_db () in
+          f dbname API.(Compile.unit ~follows:(cur_program ()) ~elpi:(elpi ()) ~flags:Compile.default_flags clause) ~local;
           state, (), []
      )),
   DocAbove);

--- a/src/coq_elpi_builtins.mli
+++ b/src/coq_elpi_builtins.mli
@@ -10,7 +10,7 @@ val coq_builtins : BuiltIn.declaration list
 
 val clauses_for_later :
   (string list * Ast.program * bool) list State.component
-val set_accumulate_to_db : ((unit -> Setup.elpi) * (string list -> Compile.compilation_unit -> local:bool -> unit)) -> unit
+val set_accumulate_to_db : ((unit -> Setup.elpi) * (string list -> Compile.compilation_unit -> local:bool -> unit) * (unit -> Compile.program)) -> unit
 
 val attribute : (string * Attributes.vernac_flag_value) Conversion.t
 

--- a/src/coq_elpi_vernacular.ml
+++ b/src/coq_elpi_vernacular.ml
@@ -15,7 +15,7 @@ let cc_flags () =
   { EC.default_flags with EC.defined_variables = !debug_vars }
 
 let unit_from_file ~elpi x =
-  try EC.unit ~elpi ~flags:(cc_flags ()) (EP.program ~elpi ~print_accumulated_files:false x)
+  try EC.unit ~elpi ~flags:(cc_flags ()) (EP.program ~elpi ~print_accumulated_files:false [x])
   with
   | EP.ParseError(loc, msg) ->
     let loc = Coq_elpi_utils.to_coq_loc loc in
@@ -43,6 +43,12 @@ let parse_goal loc x =
 
 let assemble_units ~elpi units =
   try EC.assemble ~elpi units
+  with EC.CompileError(oloc, msg) ->
+    let loc = Option.map Coq_elpi_utils.to_coq_loc oloc in
+    CErrors.user_err ?loc ~hdr:"elpi" (Pp.str msg)
+
+let extend_w_units ~base units =
+  try EC.extend ~base units
   with EC.CompileError(oloc, msg) ->
     let loc = Option.map Coq_elpi_utils.to_coq_loc oloc in
     CErrors.user_err ?loc ~hdr:"elpi" (Pp.str msg)
@@ -285,7 +291,7 @@ and src_string = {
   sast : Compile.compilation_unit
 }
 
-  val get : qualified_name -> Compile.compilation_unit list
+  val get : qualified_name -> Compile.compilation_unit list * Compile.compilation_unit list (* code , db *)
 
   val create_program : program_name -> src -> unit
   val create_db : program_name -> src -> unit
@@ -342,10 +348,14 @@ let db_name_src : (KSet.t * (Names.KerName.t * EC.compilation_unit list) list) S
 let db_exists name = SLMap.mem name !db_name_src
 
 let ast_of_src = function
-  | File { fast = a } -> [a]
-  | EmbeddedString { sast = a } -> [a]
+  | File { fast = a } -> [`Static,a]
+  | EmbeddedString { sast = a } -> [`Static,a]
   | Database name ->
-     try List.(flatten (map snd (snd (SLMap.find name !db_name_src))))
+     try
+       match List.(flatten (map snd (snd (SLMap.find name !db_name_src)))) with
+       | header :: clauses ->
+           (`Static,header) :: List.map (fun x -> `Dynamic,x) clauses
+       | [] -> assert false
      with Not_found ->
        CErrors.user_err Pp.(str "Unknown Db " ++ str (show_qualified_name name))
 
@@ -462,7 +472,7 @@ let load_command s =
   let elpi = ensure_initialized () in
   let ast = File {
     fname = s;
-    fast = unit_from_file ~elpi [s]
+    fast = unit_from_file ~elpi s
   } in
   lp_command_ast := Some ast;
   Lib.add_anonymous_leaf (in_lp_command_src ast)
@@ -480,7 +490,7 @@ let load_tactic s =
   let elpi = ensure_initialized () in
   let ast = File {
     fname = s;
-    fast = unit_from_file ~elpi [s]
+    fast = unit_from_file ~elpi s
   } in
   lp_tactic_ast := Some ast;
   Lib.add_anonymous_leaf (in_lp_tactic_ast ast)
@@ -499,7 +509,7 @@ let create_db (loc,qualid) init =
   if program_exists qualid || db_exists qualid then
     CErrors.user_err Pp.(str "Program/Tactic/Db " ++ pr_qualified_name qualid ++ str " already exists")
   else
-    add_to_db qualid (ast_of_src init) false
+    add_to_db qualid (List.map snd @@ ast_of_src init) false
 ;;
 
 let set_current_program n =
@@ -511,8 +521,14 @@ let current_program () =
   | None -> CErrors.user_err Pp.(str "No current Elpi Program")
   | Some x -> x
 
+let rec static_prefix acc = function
+  | [] -> List.rev acc, []
+  | (`Static,l) :: rest -> static_prefix (l :: acc) rest
+  | rest -> List.rev acc, List.map snd rest
+
 let get x =
-  List.(flatten (map ast_of_src (snd (get ~fail_if_not_exists:true x))))
+  let chunks = List.(flatten @@ map ast_of_src (snd (get ~fail_if_not_exists:true x))) in
+  static_prefix [] chunks
 
 let lp_checker_ast = Summary.ref ~name:"elpi-lp-checker" None
 let in_lp_checker_ast : EC.compilation_unit list -> Libobject.obj =
@@ -522,7 +538,7 @@ let in_lp_checker_ast : EC.compilation_unit list -> Libobject.obj =
 let load_checker s =
   let elpi = ensure_initialized () in
   let basic_checker = unit_from_string ~elpi (Elpi.API.Ast.Loc.initial "(elpi-checker)") Elpi.Builtin_checker.code in
-  let coq_checker = unit_from_file ~elpi [s] in
+  let coq_checker = unit_from_file ~elpi s in
   let p = [basic_checker;coq_checker] in
   Lib.add_anonymous_leaf (in_lp_checker_ast p)
 let checker () =
@@ -537,7 +553,7 @@ let in_lp_printer_ast : EC.compilation_unit -> Libobject.obj =
 }
 let load_printer s =
   let elpi = ensure_initialized () in
-  let ast = unit_from_file ~elpi [s] in
+  let ast = unit_from_file ~elpi s in
   lp_printer_ast := Some ast;
   Lib.add_anonymous_leaf (in_lp_printer_ast ast)
 let printer () =
@@ -557,7 +573,9 @@ let accumulate_to_db p v ~local =
 
 end
 
-let () = Coq_elpi_builtins.set_accumulate_to_db (Programs.ensure_initialized, (fun n x ~local -> Programs.accumulate_to_db n [x] ~local))
+let current_program_begin_run = ref None
+
+let () = Coq_elpi_builtins.set_accumulate_to_db (Programs.ensure_initialized, (fun n x ~local -> Programs.accumulate_to_db n [x] ~local), (fun () -> Option.get !current_program_begin_run))
 open Programs
 
 let load_command = load_command
@@ -589,27 +607,41 @@ let create_db n ~init:(loc,s) =
   let init = EmbeddedString { sloc = loc; sdata = s; sast = unit} in
   create_db n init
 
-let run_static_check query =
-  let elpi = ensure_initialized () in
-  (* We turn a failure into a proper error in etc/coq-elpi_typechecker.elpi *)
-  let checker = assemble_units ~elpi (checker ()) in
-  ignore (EC.static_check ~checker query)
-
 let default_max_step = max_int
 
 let trace_options = Summary.ref ~name:"elpi-trace" []
 let max_steps = Summary.ref ~name:"elpi-steps" default_max_step
 
-let debug vl = debug_vars := List.fold_right EC.StrSet.add vl EC.StrSet.empty 
+let debug vl = debug_vars := List.fold_right EC.StrSet.add vl EC.StrSet.empty
 
 let bound_steps n =
   if n <= 0 then max_steps := default_max_step else max_steps := n
 
+let compiler_cache = ref SLMap.empty
 
-let run ~tactic_mode ~static_check program_ast query =
-  let elpi = ensure_initialized () in
-  let t0 = Unix.gettimeofday () in
-  let program = assemble_units ~elpi program_ast in
+let compile name baseul extra =
+  try
+    let units, base = SLMap.find name !compiler_cache in
+    if List.for_all2 (==) units baseul then extend_w_units ~base extra
+    else raise Not_found
+  with Not_found ->
+    let elpi = ensure_initialized () in
+    let program = assemble_units ~elpi baseul in
+    compiler_cache := SLMap.add name (baseul,program) !compiler_cache;
+    extend_w_units ~base:program extra
+
+let get_and_compile name =
+  let core_units, extra_units = get name in
+  let prog = compile name core_units extra_units in
+  prog
+
+let run_static_check query =
+  let checker = compile ["Elpi";"Typecheck"] (checker()) [] in
+  (* We turn a failure into a proper error in etc/coq-elpi_typechecker.elpi *)
+  ignore (EC.static_check ~checker query)
+
+let run ~tactic_mode ~static_check program query =
+  current_program_begin_run := Some program;
   let t1 = Unix.gettimeofday () in
   let query =
     match query with
@@ -626,8 +658,8 @@ let run ~tactic_mode ~static_check program_ast query =
   let rc = API.Execute.once ~max_steps:!max_steps exe in
   let t5 = Unix.gettimeofday () in
   if !Flags.debug then
-    Feedback.msg_notice (Pp.str @@ Printf.sprintf "Elpi: assembling:%1.4f query-compilation:%1.4f static-check:%1.4f optimization:%1.4f runtime:%1.4f\n"
-      (t1 -. t0) (t2 -. t1) (t3 -. t2) (t4 -. t3) (t5 -. t4));
+    Feedback.msg_notice (Pp.str @@ Printf.sprintf "Elpi: query-compilation:%1.4f static-check:%1.4f optimization:%1.4f runtime:%1.4f\n"
+      (t2 -. t1) (t3 -. t2) (t4 -. t3) (t5 -. t4));
   rc
 ;;
 
@@ -672,16 +704,14 @@ let run_and_print ~tactic_mode ~print ~static_check program_ast query_ast =
 
 let run_in_program ?(program = current_program ()) (loc, query) =
   let _ = ensure_initialized () in
-  let program_ast = get program in
+  let program = get_and_compile program in
   let query_ast = `Ast (parse_goal loc query) in
-  run_and_print ~tactic_mode:false ~print:true ~static_check:true program_ast query_ast
+  run_and_print ~tactic_mode:false ~print:true ~static_check:true program query_ast
 ;;
 
 let typecheck_program ?(program = current_program ()) () =
-  let program_ast = get program in
+  let program = get_and_compile program in
   let query_ast = parse_goal (API.Ast.Loc.initial "(typecheck)") "true." in
-  let elpi = ensure_initialized () in
-  let program = assemble_units ~elpi program_ast in
   let query = EC.query program query_ast in
   API.Setup.trace !trace_options;
   run_static_check query
@@ -715,8 +745,8 @@ let run_program loc name ~atts args =
       state args in
     let atts = ET.mkApp attributesc (EU.list_to_lp_list atts) [] in
     state, (Coq_elpi_utils.of_coq_loc loc, ET.mkApp ET.Constants.implc atts [ET.mkApp mainc (EU.list_to_lp_list args) []]) in
-  let program_ast = get name in
-  run_and_print ~tactic_mode:false ~print:false ~static_check:false program_ast (`Fun query)
+  let program = get_and_compile name in
+  run_and_print ~tactic_mode:false ~print:false ~static_check:false program (`Fun query)
 ;;
 
 let mk_trace_opts start stop preds =
@@ -744,10 +774,8 @@ let print name args =
     | [x] -> default_blacklist, x
     | x :: xs -> xs, x in
   let args = List.map API.RawOpaqueData.of_string args in
-  let program_ast = get name in
+  let program = get_and_compile name in
   let query_ast = parse_goal (API.Ast.Loc.initial "(print)") "true." in
-  let elpi = ensure_initialized () in
-  let program = assemble_units ~elpi program_ast in
   let query = EC.query program query_ast in
   let loc = { API.Ast.Loc.
     source_name = "(Elpi Print)";
@@ -762,7 +790,7 @@ let print name args =
       (EU.list_to_lp_list quotedP)
       [API.RawOpaqueData.of_string fname; EU.list_to_lp_list args] in
     state, (loc,q) in
-  run_and_print ~tactic_mode:false ~print:false ~static_check:false [printer ()] (`Fun q)
+  run_and_print ~tactic_mode:false ~print:false ~static_check:false (compile ["Elpi";"Print"] [printer ()] []) (`Fun q)
 ;;
 
 open Proofview
@@ -776,8 +804,8 @@ let run_tactic loc program ist args =
   tclBIND tclENV begin fun env -> 
   let k = Goal.goal gl in
   let query = `Fun (Coq_elpi_HOAS.goal2query env sigma k loc ?main:None args ~in_elpi_arg:Coq_elpi_goal_HOAS.in_elpi_arg) in
-  let program_ast = get program in
-  match run ~tactic_mode:true ~static_check:false program_ast query with
+  let program = get_and_compile program in
+  match run ~tactic_mode:true ~static_check:false program query with
   | API.Execute.Success solution ->
        Coq_elpi_HOAS.tclSOLUTION2EVD solution
   | API.Execute.NoMoreSteps -> tclZEROMSG Pp.(str "elpi run out of steps")
@@ -791,8 +819,8 @@ let run_in_tactic ?(program = current_program ()) (loc,query) ist args =
   tclBIND tclENV begin fun env -> 
   let k = Goal.goal gl in
   let query = `Fun (Coq_elpi_HOAS.goal2query env ~main:query sigma k loc args ~in_elpi_arg:Coq_elpi_goal_HOAS.in_elpi_arg) in
-  let program_ast = get program in
-  match run ~tactic_mode:true ~static_check:true program_ast query with
+  let program = get_and_compile program in
+  match run ~tactic_mode:true ~static_check:true program query with
   | API.Execute.Success solution ->
        Coq_elpi_HOAS.tclSOLUTION2EVD solution
   | API.Execute.NoMoreSteps -> tclZEROMSG Pp.(str "elpi run out of steps")
@@ -806,7 +834,7 @@ let accumulate_files ?(program=current_program()) s =
     let new_src_ast = List.map (fun fname ->
       File {
         fname;
-        fast = unit_from_file ~elpi [fname];
+        fast = unit_from_file ~elpi fname;
       }) s in
     accumulate program new_src_ast
   with Failure s ->  CErrors.user_err Pp.(str s)


### PR DESCRIPTION
The test_NES_perf file runs Elpi 1000 times. It takes 32 seconds vs 0.5 seconds running "the same" Coq code. The speed of Elpi does not seem to be the culprit. Some API are way slower than their ML counterpart (this overhead is repeated 2K times for begin-module, 2K times for end-module).

Investigation:
- `UState.demote_global_univs` takes 0.0007s on top of APIs taking 0.00007s (around 3s total I guess)
- Elpi's `compiler` (23s in total)
  - on the initial program
    - assembling: 0.0089
    - optimization:0.0062
  - on the last program (500+ ns clauses/compilation units)
    - assembling:0.0406
    - optimization:0.0033
- Elpi's `runtime` (7s in total, including the 3s API overhead)