### PR TITLE
Adapt to Coq #13025: fix printing of custom entries with no explicit level

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -2849,7 +2849,7 @@ Supported attributes:
                { nenv with Notation_term.ninterp_var_type =
                    Id.Map.add id (Notation_term.NtnInternTypeAny None)
                      nenv.Notation_term.ninterp_var_type },
-               (id, ((Constrexpr.InConstrEntrySomeLevel,([],[])),Notation_term.NtnTypeConstr)) :: vars in
+               (id, ((Constrexpr.(InConstrEntry,(LevelSome,None)),([],[])),Notation_term.NtnTypeConstr)) :: vars in
              let env = EConstr.push_rel (Context.Rel.Declaration.LocalAssum(name,ty)) env in
              aux vars nenv env (n-1) t
          | _ ->


### PR DESCRIPTION
There is now a new specific type `notation_entry_relative_level` for remembering the level or absence of explicit level of the variables of a grammar rule.

The type `notation_entry_level` still exists but is only for characterizing the level (and custom entry name) in which a rule lives.

To be merged concomitantly with coq/coq#17117.