### PR TITLE
Adding NES.Snapshot

### DIFF
--- a/apps/NES/elpi/nes.elpi
+++ b/apps/NES/elpi/nes.elpi
@@ -120,4 +120,9 @@ open-super-path [P|PS] ACC :-
   open-path Cur,
   open-super-path PS Cur.
 
+pred snapshot i:list string.
+snapshot Path :- std.do! [
+  std.map {std.findall (ns Path M_)} nes.ns->modpath Mods,
+  std.forall Mods coq.env.export-module
+].
 }

--- a/apps/NES/examples/usage_NES.v
+++ b/apps/NES/examples/usage_NES.v
@@ -43,3 +43,15 @@ Fail Check nat_def.
 Fail Check @default _ : nat.
 (* This behavior requires Libobject to be aware of the role played by
    a module: if it is a namespace some "actions" have to be propagated upward *)
+
+(* NES Snapshot *)
+(* this allows to take a "snapshot" of a namespace at
+a given time in order to reuse it without using NES *)
+Module Snapshot.
+NES.Snapshot This.Is.A.Long.Namespace.
+End Snapshot.
+
+Section TestSnapshot.
+Import Snapshot.
+Check stuff.
+End TestSnapshot.

--- a/apps/NES/theories/NES.v
+++ b/apps/NES/theories/NES.v
@@ -64,3 +64,15 @@ Elpi Accumulate lp:{{
 }}.
 Elpi Typecheck.
 Elpi Export NES.Open.
+
+Elpi Command NES.Snapshot.
+Elpi Accumulate Db NES.db.
+Elpi Accumulate File "elpi/nes.elpi".
+Elpi Accumulate lp:{{
+
+  main [str NS] :- !, nes.snapshot {nes.string->ns NS}.
+  main _ :- coq.error "usage: NES.Snapshot <DotSeparatedPath>".
+
+}}.
+Elpi Typecheck.
+Elpi Export NES.Snapshot.


### PR DESCRIPTION
NES.Snapshot takes a "picture" of the current state of a Namespace,
for later reuse without the namespace commands.