### PR TITLE
call UState.demote_global_univ only when the environment really changes

### DIFF
--- a/_CoqProject.test
+++ b/_CoqProject.test
@@ -23,3 +23,4 @@ tests/test_elaborator.v
 tests/test_ltac.v
 tests/test_cache_async.v
 tests/test_COQ_ELPI_ATTRIBUTES.v
+tests/perf_calls.v

--- a/src/coq_elpi_HOAS.ml
+++ b/src/coq_elpi_HOAS.ml
@@ -1424,14 +1424,18 @@ let set_sigma state sigma = S.update engine state (fun x -> { x with sigma })
 (* We reset the evar map since it depends on the env in which it was created *)
 let grab_global_env state =
   let env = Global.env () in
-  let state = S.set engine state (CoqEngine_HOAS.from_env_keep_univ_of_sigma env (get_sigma state)) in
-  let state = S.set UVMap.uvmap state UVMap.empty in
-  state
+  if env == get_global_env state then state
+  else
+    let state = S.set engine state (CoqEngine_HOAS.from_env_keep_univ_of_sigma env (get_sigma state)) in
+    let state = S.set UVMap.uvmap state UVMap.empty in
+    state
 let grab_global_env_drop_univs state =
   let env = Global.env () in
-  let state = S.set engine state (CoqEngine_HOAS.from_env_sigma env (Evd.from_env env)) in
-  let state = S.set UVMap.uvmap state UVMap.empty in
-  state
+  if env == get_global_env state then state
+  else
+    let state = S.set engine state (CoqEngine_HOAS.from_env_sigma env (Evd.from_env env)) in
+    let state = S.set UVMap.uvmap state UVMap.empty in
+    state
 
 
 

--- a/tests/perf_calls.v
+++ b/tests/perf_calls.v
@@ -1,0 +1,22 @@
+From elpi Require Import elpi.
+
+Definition x := 3.
+
+Elpi Command perf.
+Elpi Accumulate lp:{{
+
+pred loop i:int, i:gref.
+loop 0 _.
+loop M GR :-
+  N is M - 1,
+  @local! => coq.arguments.set-implicit GR [[]],
+  loop N GR.
+
+main [int N] :-
+  loop N {coq.locate "x"}.
+
+}}.
+Elpi Typecheck.
+Elpi Export perf.
+
+Timeout 1 perf 3000.


### PR DESCRIPTION
Fix #219

With this silly optimization 3k calls to `coq.arguments.set-implicit` go from 3.44s to 0.01s.
`UState.demote_global_univs` is still slow, but we call it less often.
On ssralg we go from 60s time to 45s (out of which 7s are spent in `UState.demote_global_univs` calls which are probably needed, optimizing that code is maybe possible, but has to happen in Coq).

CC @CohenCyril 