### PR TITLE
Adapting to Coq PR #14692: UContext now includes the names by default

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -812,7 +812,7 @@ let add_axiom_or_variable api id sigma ty local =
     if local then begin
       let uctx =
         let context_set_of_entry = function
-          | Entries.Polymorphic_entry (_,uctx) -> Univ.ContextSet.of_context uctx
+          | Entries.Polymorphic_entry uctx -> Univ.ContextSet.of_context uctx
           | Entries.Monomorphic_entry uctx -> uctx in
         context_set_of_entry uentry in
       DeclareUctx.declare_universe_context ~poly:false uctx;


### PR DESCRIPTION
This leads to a slight simplication of the code.

This has to be merged synchrounously with coq/coq#14692. Thanks in advance.