### PR TITLE
Adapt to Coq PR #14846: references to inductive types in the type of constructors are directly Ind rather than Rel nodes

### DIFF
--- a/src/coq_elpi_HOAS.ml
+++ b/src/coq_elpi_HOAS.ml
@@ -2331,7 +2331,7 @@ let safe_chop n l =
   in
     aux n [] l
 
-let inductive_decl2lp ~depth coq_ctx constraints state ((mind,ind),(i_impls,k_impls)) =
+let inductive_decl2lp ~depth coq_ctx constraints state (mutind,(mind,ind),(i_impls,k_impls)) =
   let calldepth = depth in
   let allparams = List.map EConstr.of_rel_decl mind.Declarations.mind_params_ctxt in
   let kind = inductive_kind_of_recursivity_kind mind.Declarations.mind_finite in
@@ -2363,7 +2363,12 @@ let inductive_decl2lp ~depth coq_ctx constraints state ((mind,ind),(i_impls,k_im
      drop_nparams_from_term allparamsno
        (Inductive.type_of_inductive ((mind,ind),Univ.Instance.empty)) in
   let knames = CArray.map_to_list (fun x -> Name x) ind.Declarations.mind_consnames in
+  let ntyps = mind.Declarations.mind_ntypes in
   let ktys = CArray.map_to_list (fun (ctx,x) ->
+    let (ctx,x) =
+      Term.it_mkProd_or_LetIn x ctx |>
+      Inductive.abstract_constructor_type_relatively_to_inductive_types_context ntyps mutind |>
+      Term.decompose_prod_assum in
     let ctx = drop_nparams_from_ctx paramsno @@ List.map EConstr.of_rel_decl ctx in
     move_allbutnparams_from_ctx_to nuparamsno ctx @@ EConstr.of_constr x) ind.Declarations.mind_nf_lc in
   (* Relocation to match Coq's API.

--- a/src/coq_elpi_HOAS.mli
+++ b/src/coq_elpi_HOAS.mli
@@ -92,7 +92,7 @@ val lp2inductive_entry :
   State.t * (Entries.mutual_inductive_entry * (bool * record_field_spec list) option * DeclareInd.one_inductive_impls list) * Conversion.extra_goals
 
 val inductive_decl2lp :
-  depth:int -> empty coq_context -> constraints -> State.t -> ((Declarations.mutual_inductive_body * Declarations.one_inductive_body) * (Glob_term.binding_kind list * Glob_term.binding_kind list list)) ->
+  depth:int -> empty coq_context -> constraints -> State.t -> (Names.MutInd.t * (Declarations.mutual_inductive_body * Declarations.one_inductive_body) * (Glob_term.binding_kind list * Glob_term.binding_kind list list)) ->
     State.t * term * Conversion.extra_goals
 
 val in_elpi_id : Names.Name.t -> term

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1180,7 +1180,7 @@ It's a fatal error if Name cannot be located.|})),
      let k_impls = List.map hd k_impls in
      let i_impls = Impargs.extract_impargs_data @@ Impargs.implicits_of_global (GlobRef.IndRef i) in
      let i_impls = hd i_impls in
-     state, !: ((mind,indbo), (i_impls,k_impls)), [])),
+     state, !: (fst i, (mind,indbo), (i_impls,k_impls)), [])),
   DocNext);
 
   MLCode(Pred("coq.env.indc",


### PR DESCRIPTION
For one part, we insert a translation function which emulates the previous behavior.

There is another part, in file `example_fuzzer.v` (written in Elpi) that I don't know how fix though (I don't see there where it matters that the type is an `Ind` rather than a `Rel`).

This is to be merged synchronously with coq/coq#14846.