### PR TITLE
Fix a few typos

### DIFF
--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -969,7 +969,7 @@ type never simplification_strategy. % Arguments foo : simpl never
 type when list int -> option int ->
           simplification_strategy. % Arguments foo .. / .. ! ..
 type when-nomatch list int -> option int ->
-                  simplification_strategy. % Arguments foo .. / .. ! .. : simpl moatch
+                  simplification_strategy. % Arguments foo .. / .. ! .. : simpl nomatch
 
 % [coq.arguments.simplification GR Strategy] reads the behavior of the
 % simplification tactics. Positions are 0 based. See also the ! and /

--- a/examples/tutorial_coq_elpi_HOAS.v
+++ b/examples/tutorial_coq_elpi_HOAS.v
@@ -109,7 +109,7 @@ Elpi Query lp:{{
   % destruct GR to obtain its constant part C
   GR = const C,
 
-  % constans may have a body, do have a type
+  % constants may have a body, do have a type
   coq.env.const C (some Bo) TyC
 
 }}.
@@ -381,7 +381,7 @@ Elpi Query lp:{{
 (*|
    
 It is quite frequent to put Coq variables in the scope of an Elpi
-unification variable, and this can be done by sinmply writing
+unification variable, and this can be done by simply writing
 `lp:(X a b)` which is a shorhand for `lp:{{ X {{ a }} {{ b }} }}`.
 
 .. warning:: writing `lp:X a b` (without parentheses) would result in a

--- a/examples/tutorial_coq_elpi_command.v
+++ b/examples/tutorial_coq_elpi_command.v
@@ -346,7 +346,7 @@ Elpi Accumulate lp:{{
     NewDecl = parameter "A" explicit PTy Decl',
 
     % let's make a copy, capturing all occurrences of P with a
-    % (which stands for the paramter)
+    % (which stands for the parameter)
     (pi a\ copy P a => copy-indt-decl Decl (Decl' a)),
 
     % to avoid name clashes, we rename the type and its constructors
@@ -426,7 +426,7 @@ the right number of binders for them, and finally use :lib:`copy` to capture the
 Using DBs to store data across calls
 ====================================
 
-A Db can be create with the command:
+A Db can be created with the command:
 
 |*)
 
@@ -441,9 +441,9 @@ A Db is pretty much like a regular program but can be *shared* among
 other programs and is accumulated *by name*.
 Since is a Db is accumulated *when a program runs* the *current
 contents of the Db are used*.
-Moreover the Db and can be extended by Elpi programs themselves
+Moreover the Db can be extended by Elpi programs themselves
 thanks to the API :builtin:`coq.elpi.accumulate`, enabling code to save a state
-which is then vasible at subsequent runs.
+which is then visible at subsequent runs.
 
 The initial contents of a Db, `some code` in the example
 above, is usually just the type declaration for the predicates part of the Db,
@@ -542,7 +542,7 @@ setting. See the :type:`scope` and :type:`clause` data types for more info.
 Inspecting a Db
 ---------------
 
-So far we did query a Db but sometimes one needs to inspct the whole
+So far we did query a Db but sometimes one needs to inspect the whole
 contents.
 
 |*)

--- a/examples/tutorial_elpi_lang.v
+++ b/examples/tutorial_elpi_lang.v
@@ -94,7 +94,7 @@ is a mode declaration, which we will explain later (ignore it for now).
 
 .. note:: :stdtype:`int` is the built-in data type of integers
 
-   Integers come with usual arithemtic operators, see the :stdlib:`calc` built-in.
+   Integers come with usual arithmetic operators, see the :stdlib:`calc` built-in.
 
 In order to run our program we have to write a query,
 i.e. a predicate expression containing variables such as:
@@ -563,11 +563,11 @@ Elpi Bound Steps 0.
 -----------------------
 
 We have seen how to implement subtitution using the binders of λProlog.
-More often then not we need to move under binders rather than remove them by
+More often than not we need to move under binders rather than remove them by
 substituting some term in place of the bound variable. 
 
 In order to move under a binder and inspect the body of a function λProlog
-provides the :e:`pi` quatifier and the :e:`=>` connective.
+provides the :e:`pi` quantifier and the :e:`=>` connective.
 
 A good showcase for these features is to implement a type checker
 for the simply typed lambda calculus.
@@ -984,7 +984,7 @@ Fail Elpi Query lp:{{ even (s X), odd (s X) }}.  (* .fails *)
 .. note:: :e:`fail` is a predicate with no solution
 
 See also the Wikipedia page on `Constraint Handling Rules <https://en.wikipedia.org/wiki/Constraint_Handling_Rules>`_
-for an introduction to the sub language to manipualte constraints.
+for an introduction to the sub language to manipulate constraints.
 
 .. _functional-style:
 
@@ -1243,7 +1243,7 @@ in the scope:
 
 * quantify the unification variable under the bound one (first formula)
 * pass the bound variable to the unification variable explicitly: in this
-  the case the unification variable needs to have a functional type.
+  case the unification variable needs to have a functional type.
   Indeed :math:`∃Y, ∀x, (Y x) = x` has a solution: :e:`Y` can be
   the identity function.
 
@@ -1282,7 +1282,7 @@ programming language.
 
 A slogan to keep in mind is that:
 
-.. important::  There is not such as thing as a free variable!
+.. important::  There is no such thing as a free variable!
 
 Indeed the variable bound by the λ-abstraction (of our data) is
 replaced by a fresh variable bound by the context (of our program). This is

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -598,7 +598,7 @@ let simplification_strategy = let open API.AlgebraicData in let open Reductionop
     K("when","Arguments foo .. / .. ! ..",A(B.list B.int, A(B.option B.int, N)),
       B (fun recargs nargs -> UnfoldWhen { recargs; nargs }),
       M (fun ~ok ~ko -> function UnfoldWhen { recargs; nargs } -> ok recargs nargs | _ -> ko ()));
-    K("when-nomatch","Arguments foo .. / .. ! .. : simpl moatch",A(B.list B.int, A(B.option B.int, N)),
+    K("when-nomatch","Arguments foo .. / .. ! .. : simpl nomatch",A(B.list B.int, A(B.option B.int, N)),
       B (fun recargs nargs -> UnfoldWhenNoMatch { recargs; nargs }),
       M (fun ~ok ~ko -> function UnfoldWhenNoMatch { recargs; nargs } -> ok recargs nargs | _ -> ko ()));
   ]


### PR DESCRIPTION
Other strange things that I don't know how to patch include:
- in "tutorial_coq_elpi_HOAS.html", the  block "Note: the precedence of lambda abstraction [...]" spans on the next excerpt of Elpi code. I find this strange, but I am not sure this is not done on purpose.
- in "tutorial_coq_elpi_command.html", I am not even sure of the intended meaning of the sentence "Since is a Db is accumulated when a program runs the current contents of the Db are used", so I don't know how to correct it (I think adding a comma would help).
- in "tutorial_coq_elpi_command.html", "use the list to postulate" -> I don't understand either. Should it be "populate"? Or is it a meaning of "postulate" that I don't know?
- in "tutorial_elpi_lang.html", in the explanation of the behaviour of input arguments using the example of "sum", I would at least say a word about why the second argument is also marked as input (even just something like "likewise" or "symmetrically")