### PR TITLE
Adapt to removal of first argument of PrivatePolymorphic in Coq #14727

### DIFF
--- a/src/coq_elpi_HOAS.ml
+++ b/src/coq_elpi_HOAS.ml
@@ -1023,7 +1023,7 @@ let body_of_constant state c = S.update_return engine state (fun x ->
      let sigma = Evd.merge_context_set Evd.univ_rigid x.sigma ctx in
      let sigma = match priv with
      | Opaqueproof.PrivateMonomorphic () -> sigma
-     | Opaqueproof.PrivatePolymorphic (_, ctx) ->
+     | Opaqueproof.PrivatePolymorphic ctx ->
       let ctx = Util.on_snd (Univ.subst_univs_level_constraints (Univ.make_instance_subst inst)) ctx in
       Evd.merge_context_set Evd.univ_rigid sigma ctx
      in


### PR DESCRIPTION
The first argument of PrivatePolymorphic happened to be useless. It is removed as a side product of the reworking of cooking in #14727. To be merged synchronously.