### PR TITLE
Locker app

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -34,7 +34,7 @@ jobs:
         opam install coq-serapi .
         sudo apt-get update
         sudo apt-get install python3-pip -y
-        pip3 install git+https://github.com/cpitclaudel/alectryon.git@d7ec2b4af8b581cec7e4755f749f9b179c277767
+        pip3 install git+https://github.com/cpitclaudel/alectryon.git@v1.4.0
 
     - name: build doc
       run: opam exec -- make doc COQ_ELPI_ALREADY_INSTALLED=1

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## UNRELEASED
+
+### API
+- Fix globalization of arity inside a section
+- New `coq.option` type to access Coq's GOption system (Set/Unset vernaculars)
+- New `coq.option.add`
+- New `coq.option.get`
+- New `coq.option.set`
+- New `coq.option.available?`
+- New `coq.bind-ind-parameters`
+
 ## [1.11.2] - 24-09-2021
 
 Requires Elpi 1.13.6 and Coq 8.14.

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,9 @@
 - New `coq.option.available?`
 - New `coq.bind-ind-parameters`
 
+### APPS
+- New `locker` app providing `lock` and `mlock` commands
+
 ## [1.11.2] - 24-09-2021
 
 Requires Elpi 1.13.6 and Coq 8.14.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export ELPIDIR
 
 DEPS=$(ELPIDIR)/elpi.cmxa $(ELPIDIR)/elpi.cma
 
-APPS=$(addprefix apps/, derive eltac NES)
+APPS=$(addprefix apps/, derive eltac NES locker)
 
 ifeq "$(COQ_ELPI_ALREADY_INSTALLED)" ""
 DOCDEP=build

--- a/apps/README.md
+++ b/apps/README.md
@@ -12,3 +12,7 @@ A toy set of tactics implemented in Elpi.
 ### NES
 
 A Namespace Emulation System.
+
+### Locker
+
+A kit to lock definitions hard.

--- a/apps/locker/Makefile
+++ b/apps/locker/Makefile
@@ -1,0 +1,40 @@
+# detection of coq
+ifeq "$(COQBIN)" ""
+COQBIN := $(shell which coqc >/dev/null 2>&1 && dirname `which coqc`)
+endif
+ifeq "$(COQBIN)" ""
+$(error Coq not found, make sure it is installed in your PATH or set COQBIN)
+else
+$(info Using coq found in $(COQBIN), from COQBIN or PATH)
+endif
+export COQBIN := $(COQBIN)/
+
+all: build test
+
+build: Makefile.coq
+	@$(MAKE) --no-print-directory -f Makefile.coq
+
+test: Makefile.test.coq
+	@$(MAKE) --no-print-directory -f Makefile.test.coq
+
+theories/%.vo: force
+	@$(MAKE) --no-print-directory -f Makefile.coq $@
+tests/%.vo: force build Makefile.test.coq
+	@$(MAKE) --no-print-directory -f Makefile.test.coq $@
+examples/%.vo: force build Makefile.test.coq
+	@$(MAKE) --no-print-directory -f Makefile.test.coq $@
+
+Makefile.coq Makefile.coq.conf: _CoqProject
+	@$(COQBIN)/coq_makefile -f _CoqProject -o Makefile.coq
+	@$(MAKE) --no-print-directory -f Makefile.coq .merlin
+Makefile.test.coq Makefile.test.coq.conf: _CoqProject.test
+	@$(COQBIN)/coq_makefile -f _CoqProject.test -o Makefile.test.coq
+
+clean:
+	@$(MAKE) -f Makefile.coq $@
+	@$(MAKE) -f Makefile.test.coq $@
+
+.PHONY: force all build test
+
+install:
+	@$(MAKE) -f Makefile.coq $@

--- a/apps/locker/Makefile.coq.local
+++ b/apps/locker/Makefile.coq.local
@@ -1,0 +1,1 @@
+theories/locker.vo: elpi/locker.elpi

--- a/apps/locker/README.md
+++ b/apps/locker/README.md
@@ -49,8 +49,9 @@ by `3`.
 
 ## Limitations
 
-`mlock` uses a module based locking. The body is really sealed but
-cannot be used inside sections.
+`mlock` uses a module based locking. The body is really sealed but this
+command cannot be used inside sections (since modules cannot be declared
+inside sections).
 
 `lock` uses opaque key based locking. It can be used everywhere, even inside
 sections, but conversion (term comparison) may cross the lock (by congruence)

--- a/apps/locker/README.md
+++ b/apps/locker/README.md
@@ -56,4 +56,4 @@ cannot be used inside sections.
 sections, but conversion (term comparison) may cross the lock (by congruence)
 and hence compare possibly large terms.
 
-See also the section about locking in (ssereflect.v)[https://github.com/coq/coq/blob/master/theories/ssr/ssreflect.v].
+See also the section about locking in [ssereflect.v](https://github.com/coq/coq/blob/master/theories/ssr/ssreflect.v).

--- a/apps/locker/README.md
+++ b/apps/locker/README.md
@@ -1,0 +1,59 @@
+# Locker
+
+The `lock` and `mlock` commands let you lock definitions.
+
+## Example of `lock`
+
+```coq
+lock Definition x := 3.
+```
+
+is elaborated to
+
+```coq
+Lemma x_key_subproof : unit. Proof. exact: tt. Qed.
+Definition x := locked_with x_key_subproof 3.
+Canonical x_unlock_subterm := Unlock ... (* See SSR rewrite unlock idiom *)
+```
+
+Here `locked_with` comes from `ssreflect.v` and protects the body of `x`
+under a match on `x_key_subproof` which is `Qed` opaque.
+Hence `x` is provably equal to 3, but not computationally equal to it.
+
+Given the canonical structure registration, `rewrite unlock` will replace `x`
+by `3`.
+
+## Example of `mlock`
+
+```coq
+mlock Definition x := 3.
+```
+
+is elaborated to
+
+```coq
+Module Type x_Locked.
+Axiom body : nat.
+Axiom unlock : body = 3.
+End x_Locked.
+Module x : x_Locked. ... End x.
+Notation x := x.body.
+Canonical x_unlock_subterm := Unlock x.unlock.
+```
+
+Hence `x` (actually `x.body`) is a new symbol and `x.unlock` is its
+defining equation.
+
+Given the canonical structure registration, `rewrite unlock` will replace `x`
+by `3`.
+
+## Limitations
+
+`mlock` uses a module based locking. The body is really sealed but
+cannot be used inside sections.
+
+`lock` uses opaque key based locking. It can be used everywhere, even inside
+sections, but conversion (term comparison) may cross the lock (by congruence)
+and hence compare possibly large terms.
+
+See also the section about locking in (ssereflect.v)[https://github.com/coq/coq/blob/master/theories/ssr/ssreflect.v].

--- a/apps/locker/README.md
+++ b/apps/locker/README.md
@@ -13,7 +13,7 @@ is elaborated to
 ```coq
 Lemma x_key_subproof : unit. Proof. exact: tt. Qed.
 Definition x := locked_with x_key_subproof 3.
-Canonical x_unlock_subterm := Unlock ... (* See SSR rewrite unlock idiom *)
+Canonical x_unlock_subterm := Unlockable ...
 ```
 
 Here `locked_with` comes from `ssreflect.v` and protects the body of `x`
@@ -38,7 +38,7 @@ Axiom unlock : body = 3.
 End x_Locked.
 Module x : x_Locked. ... End x.
 Notation x := x.body.
-Canonical x_unlock_subterm := Unlock x.unlock.
+Canonical x_unlock_subterm := Unlockable x.unlock.
 ```
 
 Hence `x` (actually `x.body`) is a new symbol and `x.unlock` is its

--- a/apps/locker/_CoqProject
+++ b/apps/locker/_CoqProject
@@ -1,0 +1,7 @@
+# Hack to see Coq-Elpi even if it is not installed yet
+-Q ../../theories elpi
+-I ../../src
+
+-R theories elpi.apps
+
+theories/locker.v

--- a/apps/locker/_CoqProject.test
+++ b/apps/locker/_CoqProject.test
@@ -1,0 +1,8 @@
+# Hack to see Coq-Elpi even if it is not installed yet
+-Q ../../theories elpi
+-I ../../src
+
+-R theories elpi.apps
+-R tests    elpi.apps.locker.tests
+
+tests/test_locker.v

--- a/apps/locker/elpi/locker.elpi
+++ b/apps/locker/elpi/locker.elpi
@@ -5,13 +5,15 @@
 namespace locker {
 
 pred key-lock i:id, i:term, i:arity.
-key-lock ID BO ARITY :- std.do! [
+key-lock ID BoSkel AritySkel :- std.do! [
   make-key ID Key,
 
-  coq.arity->term ARITY Ty,
-  std.assert-ok! (coq.elaborate-skeleton {{ @locked_with lp:Key lp:Ty lp:BO }} DefTy Def)
+  coq.arity->term AritySkel TySkel,
+  std.assert-ok!
+    (coq.elaborate-skeleton
+      {{ @locked_with lp:Key lp:TySkel lp:BoSkel }} DefTy Def)
     "locker: illtyped definition",
-  coq.env.add-const ID Def DefTy _ C,
+  coq.env.add-const ID Def DefTy @transparent! C,
 
   make-key-unlockable ID Def DefTy (global (const C)) Key,
 ].
@@ -22,24 +24,28 @@ make-key ID (global (const C)) :- std.do! [
   coq.env.add-const KID {{ tt }} {{ unit }} @opaque! C,
 ].
 
+% -------------------------------------------------------------------------
+
 pred module-lock i:id, i:term, i:arity.
-module-lock Name BoSkel AritySkel :- std.do! [
-  std.assert-ok! (coq.elaborate-arity-skeleton AritySkel _ Arity) "locker: type illtyped",
+module-lock ID BoSkel AritySkel :- std.do! [
+  std.assert-ok! (coq.elaborate-arity-skeleton AritySkel _ Arity)
+    "locker: definition type illtyped",
   coq.arity->term Arity Ty,
-  std.assert-ok! (coq.elaborate-skeleton BoSkel Ty Bo) "locker: body illtyped",
+  std.assert-ok! (coq.elaborate-skeleton BoSkel Ty Bo)
+    "locker: definition body illtyped",
 
-  lock-module-type Name Ty Bo Signature,
-  lock-module-body Signature Name Ty Bo C Module,
+  lock-module-type ID Ty Bo Signature,
+  lock-module-body Signature ID Ty Bo Symbol Module,
 
-  @global! => coq.notation.add-abbreviation Name 0 (global (const C)) ff _,
+  @global! => coq.notation.add-abbreviation ID 0 Symbol ff _,
 
-  make-module-unlockable Name Module,
+  make-module-unlockable ID Module,
 ].
 
 pred lock-module-type i:id, i:term, i:term, o:modtypath.
 lock-module-type ID Ty Bo M :- std.do! [
-  Name is ID ^ "_Locked",
-  coq.env.begin-module-type Name,
+  Module is ID ^ "_Locked",
+  coq.env.begin-module-type Module,
   coq.env.add-axiom "body" Ty C, B = global (const C),
   PTY = {{ lp:B = lp:Bo }},
   std.assert-ok! (coq.typecheck-ty PTY _) "lock: unlock statement illtyped",
@@ -47,10 +53,11 @@ lock-module-type ID Ty Bo M :- std.do! [
   coq.env.end-module-type M,
 ].
 
-pred lock-module-body o:modtypath, i:id, i:term, i:term, o:constant, o:modpath.
-lock-module-body Signature Name Ty Bo C M :- std.do! [
-  coq.env.begin-module Name (some Signature),
-  coq.env.add-const "body" Bo Ty @transparent! C, B = global (const C),
+pred lock-module-body o:modtypath, i:id, i:term, i:term, o:term, o:modpath.
+lock-module-body Signature ID Ty Bo B M :- std.do! [
+  coq.env.begin-module ID (some Signature),
+  coq.env.add-const "body" Bo Ty @transparent! C,
+  B = global (const C),
   P = {{ @refl_equal lp:Ty lp:B }},
   std.assert-ok! (coq.typecheck P _) "locker: unlock proof illtyped",
   PTY = {{ lp:B = lp:Bo }},
@@ -59,11 +66,12 @@ lock-module-body Signature Name Ty Bo C M :- std.do! [
   coq.env.end-module M,
 ].
 
+% -------------------------------------------------------------------------
 % Unlocking via the ssreflect Unlockable interface (CS instance)
 
 pred make-key-unlockable i:string, i:term, i:term, i:term, i:term.
 make-key-unlockable ID DefBo DefTy LockedDef Key :- std.do! [
-  % we extract the read body in order to be precise in the unlocking equation
+  % we extract the real body in order to be precise in the unlocking equation
   DefBo = {{ @locked_with _ _ lp:Bo }},
   UnlockEQ = {{ @locked_withE lp:DefTy lp:Key lp:Bo }},
   Unlock = {{ @Unlockable _ _ lp:LockedDef lp:UnlockEQ }},
@@ -71,16 +79,16 @@ make-key-unlockable ID DefBo DefTy LockedDef Key :- std.do! [
 ].
 
 pred make-module-unlockable i:id, i:modpath.
-make-module-unlockable Name Module :- std.do! [
+make-module-unlockable ID Module :- std.do! [
   coq.env.module Module [_,UnlockEQ],
   Unlock = {{ Unlockable lp:{{ global UnlockEQ }} }},
-  make-unlockable Name Unlock,
+  make-unlockable ID Unlock,
 ].
 
 pred make-unlockable i:id, i:term.
-make-unlockable Name Unlock :- std.do! [
+make-unlockable ID Unlock :- std.do! [
   std.assert-ok! (coq.typecheck Unlock UnlockTy) "locker: unlocking instance illtyped",
-  UID is Name ^ "_unlock_subterm",
+  UID is ID ^ "_unlock_subterm",
   coq.env.add-const UID Unlock UnlockTy _ U,
   coq.CS.declare-instance (const U),
 ].

--- a/apps/locker/elpi/locker.elpi
+++ b/apps/locker/elpi/locker.elpi
@@ -20,7 +20,7 @@ key-lock ID BoSkel AritySkel :- std.do! [
 
 pred make-key i:id, o:term.
 make-key ID (global (const C)) :- std.do! [
-  KID is ID ^ "_key_subproof",
+  if (get-option "key" KID) true (KID is ID ^ "_key_subproof"),
   coq.env.add-const KID {{ tt }} {{ unit }} @opaque! C,
 ].
 

--- a/apps/locker/elpi/locker.elpi
+++ b/apps/locker/elpi/locker.elpi
@@ -1,0 +1,88 @@
+/* Locker                                                                    */
+/* license: GNU Lesser General Public License Version 2.1 or later           */
+/* ------------------------------------------------------------------------- */
+
+namespace locker {
+
+pred key-lock i:id, i:term, i:arity.
+key-lock ID BO ARITY :- std.do! [
+  make-key ID Key,
+
+  coq.arity->term ARITY Ty,
+  std.assert-ok! (coq.elaborate-skeleton {{ @locked_with lp:Key lp:Ty lp:BO }} DefTy Def)
+    "locker: illtyped definition",
+  coq.env.add-const ID Def DefTy _ C,
+
+  make-key-unlockable ID Def DefTy (global (const C)) Key,
+].
+
+pred make-key i:id, o:term.
+make-key ID (global (const C)) :- std.do! [
+  KID is ID ^ "_key_subproof",
+  coq.env.add-const KID {{ tt }} {{ unit }} @opaque! C,
+].
+
+pred module-lock i:id, i:term, i:arity.
+module-lock Name BoSkel AritySkel :- std.do! [
+  std.assert-ok! (coq.elaborate-arity-skeleton AritySkel _ Arity) "locker: type illtyped",
+  coq.arity->term Arity Ty,
+  std.assert-ok! (coq.elaborate-skeleton BoSkel Ty Bo) "locker: body illtyped",
+
+  lock-module-type Name Ty Bo Signature,
+  lock-module-body Signature Name Ty Bo C Module,
+
+  @global! => coq.notation.add-abbreviation Name 0 (global (const C)) ff _,
+
+  make-module-unlockable Name Module,
+].
+
+pred lock-module-type i:id, i:term, i:term, o:modtypath.
+lock-module-type ID Ty Bo M :- std.do! [
+  Name is ID ^ "_Locked",
+  coq.env.begin-module-type Name,
+  coq.env.add-axiom "body" Ty C, B = global (const C),
+  PTY = {{ lp:B = lp:Bo }},
+  std.assert-ok! (coq.typecheck-ty PTY _) "lock: unlock statement illtyped",
+  coq.env.add-axiom "unlock" PTY _,
+  coq.env.end-module-type M,
+].
+
+pred lock-module-body o:modtypath, i:id, i:term, i:term, o:constant, o:modpath.
+lock-module-body Signature Name Ty Bo C M :- std.do! [
+  coq.env.begin-module Name (some Signature),
+  coq.env.add-const "body" Bo Ty @transparent! C, B = global (const C),
+  P = {{ @refl_equal lp:Ty lp:B }},
+  std.assert-ok! (coq.typecheck P _) "locker: unlock proof illtyped",
+  PTY = {{ lp:B = lp:Bo }},
+  std.assert-ok! (coq.typecheck-ty PTY _) "locker: unlock statement illtyped",
+  coq.env.add-const "unlock" P PTY @opaque! _,
+  coq.env.end-module M,
+].
+
+% Unlocking via the ssreflect Unlockable interface (CS instance)
+
+pred make-key-unlockable i:string, i:term, i:term, i:term, i:term.
+make-key-unlockable ID DefBo DefTy LockedDef Key :- std.do! [
+  % we extract the read body in order to be precise in the unlocking equation
+  DefBo = {{ @locked_with _ _ lp:Bo }},
+  UnlockEQ = {{ @locked_withE lp:DefTy lp:Key lp:Bo }},
+  Unlock = {{ @Unlockable _ _ lp:LockedDef lp:UnlockEQ }},
+  make-unlockable ID Unlock,
+].
+
+pred make-module-unlockable i:id, i:modpath.
+make-module-unlockable Name Module :- std.do! [
+  coq.env.module Module [_,UnlockEQ],
+  Unlock = {{ Unlockable lp:{{ global UnlockEQ }} }},
+  make-unlockable Name Unlock,
+].
+
+pred make-unlockable i:id, i:term.
+make-unlockable Name Unlock :- std.do! [
+  std.assert-ok! (coq.typecheck Unlock UnlockTy) "locker: unlocking instance illtyped",
+  UID is Name ^ "_unlock_subterm",
+  coq.env.add-const UID Unlock UnlockTy _ U,
+  coq.CS.declare-instance (const U),
+].
+
+}

--- a/apps/locker/tests/test_locker.v
+++ b/apps/locker/tests/test_locker.v
@@ -18,11 +18,11 @@ Fail lock Axiom d2 : nat.
 
 Section S1.
 Variable T : Type.
-lock Definition d2 (x : T) := x.
+#[key="foo"] lock Definition d2 (x : T) := x.
 End S1.
 
 Lemma test_2_0 : d2 nat 3 = 3.
-Proof. unfold d2. match goal with |- locked_with d2_key_subproof (fun x => x) 3 = 3 => by rewrite unlock end. Qed.
+Proof. unfold d2. match goal with |- locked_with foo (fun x => x) 3 = 3 => by rewrite unlock end. Qed.
 
 
 (* ----------------------- *)

--- a/apps/locker/tests/test_locker.v
+++ b/apps/locker/tests/test_locker.v
@@ -1,0 +1,43 @@
+From Coq Require Import ssreflect.
+From elpi.apps Require Import locker.
+
+(* ----------------------- *)
+
+lock Definition d1 := 3.
+
+Lemma test_1_0 : d1 = 3.
+Proof. rewrite unlock. match goal with |- 3 = 3 => by [] end. Qed.
+Lemma test_1_1 : d1 = 3.
+Proof. unfold d1. match goal with |- locked_with d1_key_subproof 3 = 3 => by rewrite unlock end. Qed.
+
+(* ----------------------- *)
+
+Fail lock Axiom d2 : nat.
+
+(* ----------------------- *)
+
+Section S1.
+Variable T : Type.
+lock Definition d2 (x : T) := x.
+End S1.
+
+Lemma test_2_0 : d2 nat 3 = 3.
+Proof. unfold d2. match goal with |- locked_with d2_key_subproof (fun x => x) 3 = 3 => by rewrite unlock end. Qed.
+
+
+(* ----------------------- *)
+
+mlock Definition d3 := 3.
+
+Print Module d3.
+Print Module Type d3_Locked.
+Lemma test_3_0 : d3 = 3.
+Proof. rewrite unlock. match goal with |- 3 = 3 => by [] end. Qed.
+Lemma test_3_1 : d3 = 3.
+Proof. Fail unfold d3. rewrite d3.unlock. by []. Qed.
+
+(* ----------------------- *)
+
+Section S2.
+Fail mlock Definition d4 := 3.
+End S2.

--- a/apps/locker/theories/locker.v
+++ b/apps/locker/theories/locker.v
@@ -1,27 +1,67 @@
 (* Locking mechanisms.
 
-   * mlock: module based locking.
-     + hard locking (the body is really sealed) 
-     - cannot be used inside sections
-
-   * lock: opaque key based locking.
-     + can be used everywhere
-     - conversion may cross the lock (by congruence), while reduction will not
-
    license: GNU Lesser General Public License Version 2.1 or later
    ------------------------------------------------------------------------- *)
 
 From Coq Require Import ssreflect.
 From elpi Require Import elpi.
 
+(** [lock] locks a definition on an opaque key
+
+  + can be used everywhere
+  - conversion may cross the lock (by congruence), while reduction will not
+
+  Example:
+
+[[
+lock Definition foo : T := bo.
+]]
+
+  Synthesizes:
+  - [foo_key_subproof] an opaque term of type unit
+  - [foo] unfolds to [locked_with foo_key_subproof bo]
+  - [Canonical foo_unlock_subterm := Unlockable ...] so that [rewrite unlock]
+    exposes the real body
+
+  Supported attributes:
+  - [#[key]] lets one override the name of the key
+
+*)
+
 Elpi Command lock.
 Elpi Accumulate File "elpi/locker.elpi".
 Elpi Accumulate lp:{{
-  main [const-decl ID (some Bo) Ty] :- !, locker.key-lock ID Bo Ty.
+  main [const-decl ID (some Bo) Ty] :- !,
+    attributes A,
+    coq.parse-attributes A [
+      att "key" string,
+    ] Opts, !,
+    Opts => locker.key-lock ID Bo Ty.
   main _ :- coq.error "Usage: lock Definition ...".
 }}.
 Elpi Typecheck.
 Elpi Export lock.
+
+(** [mlock] locks a definition behind a module type
+
+  + hard locking (the body is really sealed) 
+  - cannot be used inside sections
+
+  Example:
+
+[[
+mlock Definition foo : T := bo.
+]]
+
+  Synthesizes:
+  - [Module Type foo_Locked] with fields [body] and [unlock] where
+    [body : T] and [unlock : body = bo]
+  - [Module foo : foo_Locked]
+  - [foo] a notation for [foo.body]
+  - [Canonical foo_unlock_subterm := Unlockable ...] so that [rewrite unlock]
+    exposes the real body
+
+*)
 
 Elpi Command mlock.
 Elpi Accumulate File "elpi/locker.elpi".

--- a/apps/locker/theories/locker.v
+++ b/apps/locker/theories/locker.v
@@ -1,0 +1,33 @@
+(* Locking mechanisms.
+
+   * mlock: module based locking.
+     + hard locking (the body is really sealed) 
+     - cannot be used inside sections
+
+   * lock: opaque key based locking.
+     + can be used everywhere
+     - conversion may cross the lock (by congruence), while reduction will not
+
+   license: GNU Lesser General Public License Version 2.1 or later
+   ------------------------------------------------------------------------- *)
+
+From Coq Require Import ssreflect.
+From elpi Require Import elpi.
+
+Elpi Command lock.
+Elpi Accumulate File "elpi/locker.elpi".
+Elpi Accumulate lp:{{
+  main [const-decl ID (some Bo) Ty] :- !, locker.key-lock ID Bo Ty.
+  main _ :- coq.error "Usage: lock Definition ...".
+}}.
+Elpi Typecheck.
+Elpi Export lock.
+
+Elpi Command mlock.
+Elpi Accumulate File "elpi/locker.elpi".
+Elpi Accumulate lp:{{
+  main [const-decl ID (some Bo) Ty] :- !, locker.module-lock ID Bo Ty.
+  main _ :- coq.error "Usage: mlock Definition ...".
+}}.
+Elpi Typecheck.
+Elpi Export mlock.

--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -1174,7 +1174,7 @@ type coq.option.string option string -> coq.option. % none means unset
 type coq.option.bool bool -> coq.option.
 
 % [coq.option.get Option Value] reads Option. Reading a non existing option
-% is fatal error.
+% is a fatal error.
 external pred coq.option.get i:list string, o:coq.option.
 
 % [coq.option.set Option Value] writes Option. Writing a non existing option

--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -485,6 +485,20 @@ coq.bind-ind-arity-no-let IT Arity F R :-
     bind-ind-arity.aux (let N T X B) F AccT AccTy IT K :- !,
       bind-ind-arity.aux (B X) F AccT AccTy IT K) =>
   bind-ind-arity.aux Arity R [] [] IT F.
+  
+pred coq.bind-ind-parameters i:inductive, i:(term -> list term -> list term -> term -> prop), o:term.
+coq.bind-ind-parameters I K O :-
+  coq.env.indt I _ _ N A _ _,
+  coq.bind-ind-parameters.aux N A [] [] K O.
+coq.bind-ind-parameters.aux 0 Ty Vars Tys K O :- !, K Ty {std.rev Vars} {std.rev Tys} O.
+coq.bind-ind-parameters.aux I (prod N T F) Vs Ts K (fun N T G) :- I > 0, !, J is I - 1,
+  @pi-decl N T x\
+    coq.bind-ind-parameters.aux J (F x) [x|Vs] [T|Ts] K (G x).
+coq.bind-ind-parameters.aux I (let N T B F) Vs Ts K (fun N T G) :- I > 0, !, J is I - 1,
+  @pi-def N T B x\
+    coq.bind-ind-parameters.aux J (F x) [x|Vs] [T|Ts] K (G x).
+coq.bind-ind-parameters.aux I T Vs Ts K O :- I > 0, whd1 T T', !,
+  coq.bind-ind-parameters.aux I T' Vs Ts K O.
 
 % coq.with-TC Class Instance->Clause Code: runs Code under a context augmented with
 % all instances for Class transformed by Instance->Clause.

--- a/etc/alectryon_elpi.py
+++ b/etc/alectryon_elpi.py
@@ -15,7 +15,7 @@ sys.path.insert(0, root)
 # SERAPI ######################################################################
 
 from alectryon.cli import main
-from alectryon.core import SerAPI
+from alectryon.serapi import SerAPI
 
 SerAPI.DEFAULT_PP_ARGS['pp_margin'] = 55
 

--- a/etc/tutorial_style.rst
+++ b/etc/tutorial_style.rst
@@ -1,6 +1,6 @@
 
-:alectryon/pygments/cmd: Elpi Command Tactic Program Accumulate Typecheck Export Db Query Trace Bound Steps
-:alectryon/pygments/tacn: elpi
+:alectryon/pygments/coq/cmd: Elpi Command Tactic Program Accumulate Typecheck Export Db Query Trace Bound Steps
+:alectryon/pygments/coq/tacn: elpi
 
 .. role:: elpi-api(ghref)
    :pattern: ^(% \[$name|(external )?pred $name)

--- a/src/coq_elpi_arg_HOAS.ml
+++ b/src/coq_elpi_arg_HOAS.ml
@@ -274,7 +274,7 @@ let expr_hole = CAst.make @@ Constrexpr.CHole(None,Namegen.IntroAnonymous,None)
 
 let intern_context_decl glob_sign fields =
   let _intern_env, fields = intern_global_context ~intern_env:Constrintern.empty_internalization_env glob_sign fields in
-  fields
+  List.rev fields
 
 let subst_context_decl s l =
   let subst = subst_global_constr s in

--- a/src/coq_elpi_arg_HOAS.ml
+++ b/src/coq_elpi_arg_HOAS.ml
@@ -192,15 +192,15 @@ let push_inductive_in_intern_env intern_env name params arity user_impls =
 
 let intern_tactic_constr = Ltac_plugin.Tacintern.intern_constr
 
-let intern_global_constr { Ltac_plugin.Tacintern.genv = env } ?(intern_env=Constrintern.empty_internalization_env) t =
+let intern_global_constr { Ltac_plugin.Tacintern.genv = env } ~intern_env t =
   let sigma = Evd.from_env env in
   Constrintern.intern_gen Pretyping.WithoutTypeConstraint env sigma ~impls:intern_env ~pattern_mode:false ~ltacvars:Constrintern.empty_ltac_sign t
 
-let intern_global_constr_ty { Ltac_plugin.Tacintern.genv = env } ?(intern_env=Constrintern.empty_internalization_env) t =
+let intern_global_constr_ty { Ltac_plugin.Tacintern.genv = env } ~intern_env t =
   let sigma = Evd.from_env env in
   Constrintern.intern_gen Pretyping.IsType env sigma ~impls:intern_env ~pattern_mode:false ~ltacvars:Constrintern.empty_ltac_sign t
 
-let intern_global_context { Ltac_plugin.Tacintern.genv = env } ?(intern_env=Constrintern.empty_internalization_env) ctx =
+let intern_global_context { Ltac_plugin.Tacintern.genv = env } ~intern_env ctx =
   Constrintern.intern_context env ~bound_univs:UnivNames.empty_binders intern_env ctx
 
 let subst_global_constr s t = Detyping.subst_glob_constr (Global.env()) s t
@@ -216,20 +216,25 @@ let intern_record_decl glob_sign { name; sort; parameters; constructor; fields }
   let sort = match sort with
     | Some x -> Constrexpr.CSort x
     | None -> Constrexpr.(CSort (Glob_term.UAnonymous {rigid=true})) in
-  let intern_env, params = intern_global_context glob_sign parameters in
+  let intern_env, params = intern_global_context glob_sign ~intern_env:Constrintern.empty_internalization_env parameters in
   let glob_sign_params = push_glob_ctx params glob_sign in
   let params = List.rev params in
-  let arity = intern_global_constr_ty glob_sign_params @@ CAst.make sort in
-  let _, fields =
-    List.fold_left (fun (gs,acc) -> function
+  let arity = intern_global_constr_ty ~intern_env glob_sign_params @@ CAst.make sort in
+  let _, _, fields =
+    List.fold_left (fun (gs,intern_env,acc) -> function
     | Vernacexpr.AssumExpr ({ CAst.v = name } as fn,bl,x), { Vernacexpr.rf_subclass = inst; rf_priority = pr; rf_notation = nots; rf_canonical = canon } ->
         if nots <> [] then Coq_elpi_utils.nYI "notation in record fields";
         if pr <> None then Coq_elpi_utils.nYI "priority in record fields";
         let atts = { Coq_elpi_HOAS.is_canonical = canon; is_coercion = inst <> Vernacexpr.NoInstance; name } in
         let x = if bl = [] then x else Constrexpr_ops.mkCProdN bl x in
-        push_name gs fn.CAst.v, (intern_global_constr_ty gs x, atts) :: acc
+        let intern_env, entry = intern_global_context ~intern_env gs [Constrexpr.CLocalAssum ([fn],Constrexpr.Default Glob_term.Explicit,x)] in
+        let x = match entry with
+          | [_,_,_,x] -> x
+          | _ -> assert false in
+        let gs = push_glob_ctx entry gs in
+        gs, intern_env, (x, atts) :: acc
     | Vernacexpr.DefExpr _, _ -> Coq_elpi_utils.nYI "DefExpr")
-        (glob_sign_params,[]) fields in
+        (glob_sign_params,intern_env,[]) fields in
   { name = (space, Names.Id.of_string name); arity; params; constructorname = constructor; fields = List.rev fields }
 
 let subst_record_decl s { name; arity; params; constructorname; fields } =
@@ -243,14 +248,14 @@ let intern_indt_decl glob_sign { finiteness; name; parameters; non_uniform_param
   let indexes = match arity with
     | Some x -> x
     | None -> CAst.make Constrexpr.(CSort (Glob_term.UAnonymous {rigid=true})) in
-  let intern_env, params = intern_global_context glob_sign parameters in
+  let intern_env, params = intern_global_context glob_sign ~intern_env:Constrintern.empty_internalization_env parameters in
   let intern_env, nuparams = intern_global_context glob_sign ~intern_env non_uniform_parameters in
   let params = List.rev params in
   let nuparams = List.rev nuparams in
   let allparams = params @ nuparams in
   let user_impls : Impargs.manual_implicits = List.map Coq_elpi_utils.manual_implicit_of_gdecl allparams in
   let glob_sign_params = push_glob_ctx allparams glob_sign in
-  let arity = intern_global_constr_ty glob_sign_params indexes in
+  let arity = intern_global_constr_ty ~intern_env glob_sign_params indexes in
   let glob_sign_params_self = push_name glob_sign_params (Names.Name name) in
   let intern_env = push_inductive_in_intern_env intern_env name allparams arity user_impls in
   let constructors =
@@ -267,24 +272,9 @@ let subst_indt_decl s { finiteness; name; arity; params; nuparams; constructors 
 
 let expr_hole = CAst.make @@ Constrexpr.CHole(None,Namegen.IntroAnonymous,None)
 
-let bk_of_bk = function
-  | Constrexpr.Default x -> x
-  | Constrexpr.Generalized _ -> Coq_elpi_utils.nYI "Constrexpr.Generalized"
-
 let intern_context_decl glob_sign fields =
-  let _, fields =
-    List.fold_left (fun (gs,acc) -> function
-      | Constrexpr.CLocalAssum (l,bk,ty) ->
-          let ty = intern_global_constr_ty gs ty in
-          List.fold_left push_name gs (List.map (fun x -> x.CAst.v) l),
-            (List.rev l |> List.map (fun { CAst.v = name } -> name, bk_of_bk bk, None, ty)) @ acc
-      | Constrexpr.CLocalDef ({ CAst.v = name } as fn,bo,ty) ->
-          let intern = intern_global_constr_ty gs in
-          let ty = Option.default expr_hole ty in
-          push_name gs fn.CAst.v, (name, Glob_term.Explicit, Some (intern bo), intern ty) :: acc
-      | Constrexpr.CLocalPattern _ -> Coq_elpi_utils.nYI "CLocalPattern")
-     (glob_sign,[]) fields in
-  List.rev fields
+  let _intern_env, fields = intern_global_context ~intern_env:Constrintern.empty_internalization_env glob_sign fields in
+  fields
 
 let subst_context_decl s l =
   let subst = subst_global_constr s in
@@ -292,12 +282,12 @@ let subst_context_decl s l =
 
 let intern_constant_decl glob_sign ({ name; typ = (params,typ); body } : raw_constant_decl) =
   let name, space = sep_last_qualid name in
-  let _intern_env, params = intern_global_context glob_sign params in
+  let intern_env, params = intern_global_context glob_sign ~intern_env:Constrintern.empty_internalization_env params in
   let glob_sign_params = push_glob_ctx params glob_sign in
   let params = List.rev params in
   let typ = Option.default expr_hole typ in
-  let typ = intern_global_constr_ty glob_sign_params typ in
-  let body = Option.map (intern_global_constr glob_sign_params) body in
+  let typ = intern_global_constr_ty ~intern_env glob_sign_params typ in
+  let body = Option.map (intern_global_constr ~intern_env glob_sign_params) body in
   { name = (space, Names.Id.of_string name); params; typ; body }
 
 let subst_constant_decl s { name; params; typ; body } =


### PR DESCRIPTION
# Locker

The `lock` and `mlock` commands let you lock definitions.

## Example of `lock`

```coq
lock Definition x := 3.
```

is elaborated to

```coq
Lemma x_key_subproof : unit. Proof. exact: tt. Qed.
Definition x := locked_with x_key_subproof 3.
Canonical x_unlock_subterm := Unlock ... (* See SSR rewrite unlock idiom *)
```

Here `locked_with` comes from `ssreflect.v` and protects the body of `x`
under a match on `x_key_subproof` which is `Qed` opaque.
Hence `x` is provably equal to 3, but not computationally equal to it.

Given the canonical structure registration, `rewrite unlock` will replace `x`
by `3`.

## Example of `mlock`

```coq
mlock Definition x := 3.
```

is elaborated to

```coq
Module Type x_Locked.
Axiom body : nat.
Axiom unlock : body = 3.
End x_Locked.
Module x : x_Locked. ... End x.
Notation x := x.body.
Canonical x_unlock_subterm := Unlock x.unlock.
```

Hence `x` (actually `x.body`) is a new symbol and `x.unlock` is its
defining equation.

Given the canonical structure registration, `rewrite unlock` will replace `x`
by `3`.

## Limitations

`mlock` uses a module based locking. The body is really sealed but
cannot be used inside sections.

`lock` uses opaque key based locking. It can be used everywhere, even inside
sections, but conversion (term comparison) may cross the lock (by congruence)
and hence compare possibly large terms.

See also the section about locking in [ssereflect.v](https://github.com/coq/coq/blob/master/theories/ssr/ssreflect.v).