### PR TITLE
Adapt to Coq PR #15344: renaming syntax def.ml to abbreviation.ml and related renamings

### DIFF
--- a/src/coq_elpi_HOAS.mli
+++ b/src/coq_elpi_HOAS.mli
@@ -142,7 +142,7 @@ val constructor : constructor Conversion.t
 val constant : global_constant Conversion.t
 val universe : Sorts.t Conversion.t
 val global_constant_of_globref : Names.GlobRef.t -> global_constant
-val abbreviation : Globnames.syndef_name Conversion.t
+val abbreviation : Globnames.abbreviation Conversion.t
 val implicit_kind : Glob_term.binding_kind Conversion.t
 val collect_term_variables : depth:int -> term -> Names.Id.t list
 type primitive_value =

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -355,7 +355,7 @@ type located =
   | LocGref of Names.GlobRef.t
   | LocModule of Names.ModPath.t
   | LocModuleType of Names.ModPath.t
-  | LocAbbreviation of Globnames.syndef_name
+  | LocAbbreviation of Globnames.abbreviation
 
 let located = let open Conv in let open API.AlgebraicData in declare {
   ty = TyName "located";
@@ -2065,7 +2065,7 @@ Supported attributes:
   (fun s _ ~depth ->
     let qualid = Libnames.qualid_of_string s in
     let sd =
-      try Nametab.locate_syndef qualid
+      try Nametab.locate_abbreviation qualid
       with Not_found -> err Pp.(str "Abbreviation not found: " ++ Libnames.pr_qualid qualid) in
     !:sd)),
   DocAbove);
@@ -2124,11 +2124,11 @@ Supported attributes:
      let vars, nenv, env, body = strip_n_lambas nargs env term in
      let gbody = Coq_elpi_utils.detype env sigma body in
      let pat, _ = Notation_ops.notation_constr_of_glob_constr nenv gbody in
-     Syntax_def.declare_syntactic_definition ~local ~onlyparsing options.deprecation name (vars,pat);
+     Abbreviation.declare_abbreviation ~local ~onlyparsing options.deprecation name (vars,pat);
      let qname = Libnames.qualid_of_string (Id.to_string name) in
      match Nametab.locate_extended qname with
      | Globnames.TrueGlobal _ -> assert false
-     | Globnames.SynDef sd -> state, !: sd, []))),
+     | Globnames.Abbrev sd -> state, !: sd, []))),
   DocAbove);
 
   MLCode(Pred("coq.notation.abbreviation",
@@ -2137,7 +2137,7 @@ Supported attributes:
     Out(B.poly "term","Body",
     Full(global, "Unfolds an abbreviation")))),
   (fun sd arglist _ ~depth {env} _ state ->
-    let args, _ = Syntax_def.search_syntactic_definition sd in
+    let args, _ = Abbreviation.search_abbreviation sd in
     let nargs = List.length args in
     let argno = List.length arglist in
     if nargs > argno then
@@ -2172,7 +2172,7 @@ Supported attributes:
     Out(B.poly "term","Body",
     Full(global, "Retrieves the body of an abbreviation")))),
   (fun sd _ _ ~depth {env} _ state ->
-    let args, _ = Syntax_def.search_syntactic_definition sd in
+    let args, _ = Abbreviation.search_abbreviation sd in
     let nargs = List.length args in
     let open Constrexpr in
     let binders, vars = List.split (CList.init nargs (fun i ->

--- a/src/coq_elpi_utils.ml
+++ b/src/coq_elpi_utils.ml
@@ -119,8 +119,8 @@ let locate_qualid qualid =
   try
     match Nametab.locate_extended qualid with
     | Globnames.TrueGlobal gr -> Some (`Gref gr)
-    | Globnames.SynDef sd ->
-       match Syntax_def.search_syntactic_definition sd with
+    | Globnames.Abbrev sd ->
+       match Abbreviation.search_abbreviation sd with
        | _, Notation_term.NRef(gr,_) -> Some (`Gref gr)
        | _ -> Some (`Abbrev sd)
   with Not_found -> None

--- a/src/coq_elpi_utils.mli
+++ b/src/coq_elpi_utils.mli
@@ -24,7 +24,7 @@ val manual_implicit_of_gdecl : Glob_term.glob_decl -> (Names.Name.t * bool) opti
 
 val lookup_inductive : Environ.env -> Names.inductive -> Declarations.mutual_inductive_body * Declarations.one_inductive_body
 val locate_gref : string -> Names.GlobRef.t
-val locate_qualid : Libnames.qualid -> [ `Gref of Names.GlobRef.t | `Abbrev of Globnames.syndef_name ] option
+val locate_qualid : Libnames.qualid -> [ `Gref of Names.GlobRef.t | `Abbrev of Globnames.abbreviation ] option
 
 val fold_elpi_term :
   (depth:int -> 'a -> Elpi.API.Data.term -> 'a) ->


### PR DESCRIPTION
The code was ready for it: the field for abbreviations was already called `LocAbbreviation`!

To be merged synchronously.