### PR TITLE
Adapt to Coq PR #14563: new support for naming by default the inhabitant of a record

### DIFF
--- a/src/coq_elpi_arg_syntax.mlg
+++ b/src/coq_elpi_arg_syntax.mlg
@@ -163,7 +163,7 @@ let of_coq_record_definition id =
   let constructor, fields =
     match constructors with
     | Vernacexpr.Constructors _ -> CErrors.user_err Pp.(str "in order to declare an inductive type use Inductive, CoInductive or Variant")
-    | Vernacexpr.RecordDecl (constructor, fields) ->
+    | Vernacexpr.RecordDecl (constructor, fields, _) ->
         constructor |> Option.map (fun x -> x.CAst.v), fields in
   name, sort, parameters, constructor, fields
 


### PR DESCRIPTION
This adapts to coq/coq#14563.

I didn't know that to do with the extra field, and I just made a minimal fix so that it compiles. Tell me if you see more to do.

To be merged synchroneously.