### PR TITLE
API: coq.hints.opaque

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### API
+- New `coq.hints.opaque`
+- New `coq.hints.set-opaque`
+
 ## [1.12.1] - 20-01-2021
 
 Requires Elpi 1.13.6 and Coq 8.15.

--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -903,7 +903,8 @@ type mode-output hint-mode. % Anything
 % [coq.hints.add-mode GR DB Mode] Adds a mode declaration to DB about
 % GR.
 % Supported attributes:
-% - @local! (default: false)
+% - @local! (default is export)
+% - @global! (deprecated)
 external pred coq.hints.add-mode i:gref, i:string, i:list hint-mode.
 
 % [coq.hints.modes GR DB Modes] Gets all the mode declarations in DB about
@@ -913,10 +914,11 @@ external pred coq.hints.modes i:gref, i:string, o:list (list hint-mode).
 % [coq.hints.set-opaque C DB Opaque] Like Hint Opaque C : DB (or Hint
 % Transparent, if the boolean is ff).
 % Supported attributes:
-% - @local! (default: false)
+% - @local! (default is export)
+% - @global! (deprecated)
 external pred coq.hints.set-opaque i:constant, i:string, i:bool.
 
-% [coq.hints.opaque C DB Opaque] Reads if constant C is opauqe (tt) or
+% [coq.hints.opaque C DB Opaque] Reads if constant C is opaque (tt) or
 % transparent (ff) in DB
 external pred coq.hints.opaque i:constant, i:string, o:bool.
 

--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -910,6 +910,16 @@ external pred coq.hints.add-mode i:gref, i:string, i:list hint-mode.
 % GR
 external pred coq.hints.modes i:gref, i:string, o:list (list hint-mode).
 
+% [coq.hints.set-opaque C DB Opaque] Like Hint Opaque C : DB (or Hint
+% Transparent, if the boolean is ff).
+% Supported attributes:
+% - @local! (default: false)
+external pred coq.hints.set-opaque i:constant, i:string, i:bool.
+
+% [coq.hints.opaque C DB Opaque] Reads if constant C is opauqe (tt) or
+% transparent (ff) in DB
+external pred coq.hints.opaque i:constant, i:string, o:bool.
+
 % -- Coq's notational mechanisms -------------------------------------
 
 % Implicit status of an argument

--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -894,6 +894,18 @@ coq.CS.canonical-projections I L :-
 
 % -- Coq's Hint DB -------------------------------------
 
+% Locality of hints is a delicate matter since the Coq default
+% is, in some cases, to make an hint active even if the module it belongs
+% to is not imported (just merely required, which can happen
+% transitively).
+% Coq is aiming at changing the default to #[export], that makes an
+% hint active only when its enclosing module is imported.
+% See:
+% https://coq.discourse.group/t/change-of-default-locality-for-hint-commands-in-coq-8-13/1140
+% 
+% This old behavior is available via the @global! flag, but is discouraged.
+% 
+
 % Hint Mode
 kind hint-mode type.
 type mode-ground hint-mode. % No Evar
@@ -904,7 +916,7 @@ type mode-output hint-mode. % Anything
 % GR.
 % Supported attributes:
 % - @local! (default is export)
-% - @global! (deprecated)
+% - @global! (discouraged, may become deprecated)
 external pred coq.hints.add-mode i:gref, i:string, i:list hint-mode.
 
 % [coq.hints.modes GR DB Modes] Gets all the mode declarations in DB about
@@ -915,7 +927,7 @@ external pred coq.hints.modes i:gref, i:string, o:list (list hint-mode).
 % Transparent, if the boolean is ff).
 % Supported attributes:
 % - @local! (default is export)
-% - @global! (deprecated)
+% - @global! (discouraged, may become deprecated)
 external pred coq.hints.set-opaque i:constant, i:string, i:bool.
 
 % [coq.hints.opaque C DB Opaque] Reads if constant C is opaque (tt) or

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -2013,8 +2013,8 @@ Supported attributes:
       | Some true -> Hints.Local
       | Some false -> Hints.SuperGlobal
       | None -> Hints.Export in
-    let transparent = if opaque then false else true in
-     let r = match c with
+    let transparent = not opaque in
+    let r = match c with
        | Variable v -> Tacred.EvalVarRef v
        | Constant c -> Tacred.EvalConstRef c in
      Hints.add_hints ~locality [db] Hints.(HintsTransparencyEntry(HintsReferences [r],transparent));

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1973,9 +1973,14 @@ coq.CS.canonical-projections I L :-
     In(B.list mode, "Mode",
     Full(global, {|Adds a mode declaration to DB about GR.
 Supported attributes:
-- @local! (default: false)|})))),
+- @local! (default is export)
+- @global! (deprecated)|})))),
   (fun gr (db,_) mode ~depth:_ {options} _ -> on_global_state "coq.hints.add-mode" (fun state ->
-     let locality = if options.local = Some true then Hints.Local else Hints.Export in
+     let locality =
+       match options.local with
+       | Some true -> Hints.Local
+       | Some false -> Hints.SuperGlobal
+       | None -> Hints.Export in
      Hints.add_hints ~locality [db] (Hints.HintsModeEntry(gr,mode));
      state, (), []
     ))),
@@ -2001,10 +2006,14 @@ Supported attributes:
     In(B.bool, "Opaque",
     Full(global,{|Like Hint Opaque C : DB (or Hint Transparent, if the boolean is ff).
 Supported attributes:
-- @local! (default: false)|})))),
-  (fun c (db,_) opaque ~depth:_ {options} _ -> on_global_state "coq.hints.set-opaque" (fun state ->
-     let locality = if options.local = Some true then Hints.Local else Hints.Export in
-     let transparent = if opaque then false else true in
+- @local! (default is export)
+- @global! (deprecated)|})))), (fun c (db,_) opaque ~depth:_ {options} _ -> on_global_state "coq.hints.set-opaque" (fun state ->
+    let locality =
+      match options.local with
+      | Some true -> Hints.Local
+      | Some false -> Hints.SuperGlobal
+      | None -> Hints.Export in
+    let transparent = if opaque then false else true in
      let r = match c with
        | Variable v -> Tacred.EvalVarRef v
        | Constant c -> Tacred.EvalConstRef c in

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -2017,7 +2017,7 @@ Supported attributes:
     In(constant, "C",
     In(hint_db, "DB",
     Out(B.bool, "Opaque",
-    Easy {|Reads if constant C is opauqe (tt) or transparent (ff) in DB|}))),
+    Easy {|Reads if constant C is opaque (tt) or transparent (ff) in DB|}))),
   (fun c (_,db) _ ~depth:_ ->
      let tr = Hints.Hint_db.transparent_state db in
      match c with

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1964,6 +1964,15 @@ coq.CS.canonical-projections I L :-
 |};
 
   LPDoc "-- Coq's Hint DB -------------------------------------";
+  LPDoc {|Locality of hints is a delicate matter since the Coq default
+is, in some cases, to make an hint active even if the module it belongs
+to is not imported (just merely required, which can happen transitively).
+Coq is aiming at changing the default to #[export], that makes an
+hint active only when its enclosing module is imported. See:
+https://coq.discourse.group/t/change-of-default-locality-for-hint-commands-in-coq-8-13/1140
+
+This old behavior is available via the @global! flag, but is discouraged.
+|};
 
   MLData mode;
 
@@ -1974,7 +1983,7 @@ coq.CS.canonical-projections I L :-
     Full(global, {|Adds a mode declaration to DB about GR.
 Supported attributes:
 - @local! (default is export)
-- @global! (deprecated)|})))),
+- @global! (discouraged, may become deprecated)|})))),
   (fun gr (db,_) mode ~depth:_ {options} _ -> on_global_state "coq.hints.add-mode" (fun state ->
      let locality =
        match options.local with
@@ -2007,7 +2016,7 @@ Supported attributes:
     Full(global,{|Like Hint Opaque C : DB (or Hint Transparent, if the boolean is ff).
 Supported attributes:
 - @local! (default is export)
-- @global! (deprecated)|})))), (fun c (db,_) opaque ~depth:_ {options} _ -> on_global_state "coq.hints.set-opaque" (fun state ->
+- @global! (discouraged, may become deprecated)|})))), (fun c (db,_) opaque ~depth:_ {options} _ -> on_global_state "coq.hints.set-opaque" (fun state ->
     let locality =
       match options.local with
       | Some true -> Hints.Local

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -989,6 +989,15 @@ let hint_db : (string * Hints.Hint_db.t) Conv.t = {
   embed = (fun ~depth _ _ -> assert false);
 }
 
+let hint_locality (options : options) =
+  match options.local with
+  | Some true -> Hints.Local
+  | Some false -> Hints.SuperGlobal
+  | None -> Hints.Export
+
+let hint_locality_doc = {|
+- @local! (default is export)
+- @global! (discouraged, may become deprecated)|}
 
 (*****************************************************************************)
 (*****************************************************************************)
@@ -1981,15 +1990,9 @@ This old behavior is available via the @global! flag, but is discouraged.
     In(hint_db, "DB",
     In(B.list mode, "Mode",
     Full(global, {|Adds a mode declaration to DB about GR.
-Supported attributes:
-- @local! (default is export)
-- @global! (discouraged, may become deprecated)|})))),
+Supported attributes:|} ^ hint_locality_doc)))),
   (fun gr (db,_) mode ~depth:_ {options} _ -> on_global_state "coq.hints.add-mode" (fun state ->
-     let locality =
-       match options.local with
-       | Some true -> Hints.Local
-       | Some false -> Hints.SuperGlobal
-       | None -> Hints.Export in
+     let locality = hint_locality options in
      Hints.add_hints ~locality [db] (Hints.HintsModeEntry(gr,mode));
      state, (), []
     ))),
@@ -2014,14 +2017,9 @@ Supported attributes:
     In(hint_db, "DB",
     In(B.bool, "Opaque",
     Full(global,{|Like Hint Opaque C : DB (or Hint Transparent, if the boolean is ff).
-Supported attributes:
-- @local! (default is export)
-- @global! (discouraged, may become deprecated)|})))), (fun c (db,_) opaque ~depth:_ {options} _ -> on_global_state "coq.hints.set-opaque" (fun state ->
-    let locality =
-      match options.local with
-      | Some true -> Hints.Local
-      | Some false -> Hints.SuperGlobal
-      | None -> Hints.Export in
+Supported attributes:|} ^ hint_locality_doc)))),
+  (fun c (db,_) opaque ~depth:_ {options} _ -> on_global_state "coq.hints.set-opaque" (fun state ->
+    let locality = hint_locality options in
     let transparent = not opaque in
     let r = match c with
        | Variable v -> Tacred.EvalVarRef v

--- a/tests/test_API2.v
+++ b/tests/test_API2.v
@@ -185,6 +185,19 @@ Elpi Query lp:{{
 
 }}.
 
+Hint Opaque x : core.
+
+Elpi Query lp:{{
+  std.do! [
+    {{ x }} = global (const C1),
+    coq.hints.opaque C1 "core" @opaque!,
+    coq.env.begin-module "xx3" none,
+    @global! => coq.hints.set-opaque C1 "core" @transparent!,
+    coq.env.end-module M,
+    coq.hints.opaque C1 "core" @transparent!,
+  ]
+
+}}.
 Fail Elpi Query lp:{{
 
   {{ x }} = global (const C1),

--- a/tests/test_API2.v
+++ b/tests/test_API2.v
@@ -125,3 +125,71 @@ Elpi Query lp:{{
   coq.option.get ["Foo", "Bar"] (coq.option.string none)
 
 }}.
+
+(* Hints transparent *)
+
+Hint Opaque plus : core.
+Definition times := plus.
+Hint Transparent times : core.
+
+Elpi Query lp:{{
+
+  {{ plus }} = global (const C1),
+  coq.hints.opaque C1 "core" X1,
+  std.assert!(X1 = @opaque!) "wrong opaque plus",
+  {{ times }} = global (const C2),
+  coq.hints.opaque C2 "core" X2,
+  std.assert!(X2 = @transparent!) "wrong opaque times"
+
+}}.
+
+Definition x := 3.
+
+Elpi Query lp:{{
+  std.do! [
+    {{ x }} = global (const C1),
+    coq.hints.opaque C1 "core" @opaque!,
+    coq.hints.set-opaque C1 "core" @transparent!,
+    coq.hints.opaque C1 "core" @transparent!,
+  ]
+
+}}.
+
+Hint Opaque x : core.
+
+Elpi Query lp:{{
+  std.do! [
+    {{ x }} = global (const C1),
+    coq.hints.opaque C1 "core" @opaque!,
+    coq.env.begin-module "xx" none,
+    @local! => coq.hints.set-opaque C1 "core" @transparent!,
+    coq.env.end-module M,
+    coq.hints.opaque C1 "core" @opaque!,
+    coq.env.import-module M,
+    coq.hints.opaque C1 "core" @opaque!,
+  ]
+
+}}.
+
+Elpi Query lp:{{
+  std.do! [
+    {{ x }} = global (const C1),
+    coq.hints.opaque C1 "core" @opaque!,
+    coq.env.begin-module "xx2" none,
+    coq.hints.set-opaque C1 "core" @transparent!,
+    coq.env.end-module M,
+    coq.hints.opaque C1 "core" @opaque!,
+    coq.env.import-module M,
+    coq.hints.opaque C1 "core" @transparent!,
+  ]
+
+}}.
+
+Fail Elpi Query lp:{{
+
+  {{ x }} = global (const C1),
+  coq.hints.opaque C1 "corexx" T
+
+}}.
+
+


### PR DESCRIPTION
Minimal API to declare opacity hints.

CC @gstew5 , please tell me if the API is sufficient for your use case

Fix #329 