### PR TITLE
Adapt to coq/coq#15754

### DIFF
--- a/apps/derive/tests/test_derive_stdlib.v
+++ b/apps/derive/tests/test_derive_stdlib.v
@@ -1,5 +1,5 @@
 (* Some standard data types using different features *)
-From Coq Require Int63.
+From Coq Require Uint63.
 From Coq Require Floats.
 
 Module Coverage.
@@ -62,7 +62,7 @@ Inductive large :=
 | K25(_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) 
 | K26(_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit) (_ : unit).
 
-Inductive prim_int := PI (i : Int63.int).
+Inductive prim_int := PI (i : Uint63.int).
 Inductive prim_float := PF (f : PrimFloat.float).
 
 Record fo_record := { f1 : peano; f2 : unit; }.

--- a/apps/derive/theories/derive/eqcorrect.v
+++ b/apps/derive/theories/derive/eqcorrect.v
@@ -8,11 +8,11 @@ From elpi.apps.derive Extra Dependency "eqcorrect.elpi" as eqcorrect.
 From elpi Require Export elpi.
 From elpi.apps Require Export  derive.eq derive.map derive.induction derive.eqK.
 
-From Coq Require Import ssreflect Int63.
+From Coq Require Import ssreflect Uint63.
 
 Lemma uint63_eq_correct i : is_uint63 i -> eq_axiom_at PrimInt63.int PrimInt63.eqb i.
 Proof.
-move=> _ j; case: (Int63.eqb_spec i j); case: PrimInt63.eqb => [-> // _|_ abs];
+move=> _ j; case: (Uint63.eqb_spec i j); case: PrimInt63.eqb => [-> // _|_ abs];
   [ by constructor | by constructor=> /abs ].
 Qed.
 Register uint63_eq_correct as elpi.derive.uint63_eq_correct.

--- a/examples/tutorial_coq_elpi_tactic.v
+++ b/examples/tutorial_coq_elpi_tactic.v
@@ -1024,8 +1024,8 @@ Elpi Accumulate default lp:{{
 }}.
 Elpi Typecheck.
 
-From Coq Require Import  Int63.
-Open Scope int63_scope.
+From Coq Require Import  Uint63.
+Open Scope uint63_scope.
 
 Fail Definition baz : list nat := default 1.  (* .fails *)
 

--- a/tests/test_API2.v
+++ b/tests/test_API2.v
@@ -71,9 +71,9 @@ main X :- coq.error "not a primitive-value" X.
 }}.
 Elpi Typecheck.
 
-From Coq Require Import PrimFloat Int63.
+From Coq Require Import PrimFloat Uint63.
 
-Open Scope int63_scope.
+Open Scope uint63_scope.
 
 Elpi pv (1).
 Fail Elpi pv (4611686018427387904). (* max_int + 1 *)

--- a/tests/test_elaborator.v
+++ b/tests/test_elaborator.v
@@ -150,10 +150,10 @@ Elpi Query lp:{{get-option "of:coerce" tt =>
 }}.
 
 (* primitive *)
-From Coq Require Import Int63.
-Elpi Query lp:{{ of {{ 99%int63 }} T X }}.
+From Coq Require Import Uint63.
+Elpi Query lp:{{ of {{ 99%uint63 }} T X }}.
 From Coq Require Import Floats.
 Elpi Query lp:{{ of {{ 99.3e4%float }} T X }}.
-Elpi Query lp:{{ whd1 {{ (99 + 1)%int63 }} {{ 100%int63 }} }}.
-Elpi Query lp:{{ not(whd1 {{ (99 + _)%int63 }} _) }}.
+Elpi Query lp:{{ whd1 {{ (99 + 1)%uint63 }} {{ 100%uint63 }} }}.
+Elpi Query lp:{{ not(whd1 {{ (99 + _)%uint63 }} _) }}.
 


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/15754 (removal of Int63)

This should be backward compatible.