### PR TITLE
Fix an error in the comment that explains copy

### DIFF
--- a/examples/tutorial_coq_elpi_command.v
+++ b/examples/tutorial_coq_elpi_command.v
@@ -384,7 +384,7 @@ An excerpt:
 
   copy X X :- name X.      % checks X is a bound variable
   copy (global _ as C) C.
-  copy (fun N T F) (fun N T1 F1).
+  copy (fun N T F) (fun N T1 F1) :-
     copy T T1, pi x\ copy (F x) (F1 x).
   copy (app L) (app L1) :- std.map L copy L1.
 


### PR DESCRIPTION
A "." should be replaced by a ":-" for this explanation to make sense (IMHO).