### PR TITLE
Do not depend on Pretyping.known_glob_level.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,5 +28,6 @@ jobs:
         coq_version: ${{ matrix.coq_version }}
         ocaml_version: ${{ matrix.ocaml_version }}
         export: 'OPAMWITHTEST'
+        pre_install: 'opam depext camlp5 || true'
       env:
         OPAMWITHTEST: 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,12 @@ jobs:
         coq_version: ${{ matrix.coq_version }}
         ocaml_version: ${{ matrix.ocaml_version }}
         export: 'OPAMWITHTEST'
-        pre_install: 'opam depext camlp5 || true'
+        install: |
+          startGroup "Install dependencies"
+            opam pin add -n -y -k path $PACKAGE $WORKDIR
+            opam update -y
+            opam depext -y -u camlp5
+            opam install -y -j 2 $PACKAGE --deps-only
+          endGroup
       env:
         OPAMWITHTEST: 'true'


### PR DESCRIPTION
This function was used internally to Coq for constraint computations but was making other assumptions unrelated to the full generality of elpi.

The alternative is to export the `sort` function that is properly defined in Pretyping after #15863 but the advantage of this PR is that it is backwards compatible.