### PR TITLE
Mention Coqtail in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,24 +63,7 @@ in a place where CoqIDE can find it.  Then you can select `coq-elpi`
 from the menu `Edit -> Preferences -> Colors`.
 
 For Vim users, [Coqtail](https://github.com/whonore/Coqtail) provides syntax
-highlighting and handles quotations. Alternatively, to get only syntax
-highlighting one could add the following lines to `~/.vimrc` (in addition to the
-ones for [elpi](https://github.com/LPCIC/elpi#syntax-highlight-in-vim)).
-<details><summary>(click to expand)</summary>
-<p>
-
-```vim
-"coq-elpi
-autocmd FileType lprolog syn keyword coqElpiSpecial fun prod sort let match fix axiom indc indt const prop app
-autocmd FileType lprolog syn cluster elpiAntiQuotation contains=elpiAntiQuotationVar,elpiAntiQuotationBound,elpiAntiQuotationTerm
-autocmd FileType lprolog syn region elpiAntiQuotationTerm start=+lp:"+ end=+"+ contains=elpiQuotation,lprologVariable,coqElpiSpecial,elpiMacro,lprologSpecial
-autocmd FileType lprolog syn match elpiAntiQuotationVar "lp:[A-Z_-]\+"ms=s+3
-autocmd FileType lprolog syn match elpiAntiQuotationBound "lp:[a-z_-]\+"
-autocmd FileType lprolog hi def link elpiAntiQuotationVar Keyword
-autocmd FileType lprolog hi def link elpiAntiQuotationBound Normal
-autocmd FileType lprolog hi def link coqElpiSpecial Special
-```
-</p></details>
+highlighting and handles quotations.
 
 </p></details>
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ CoqIDE does not handle quotations correctly. The installation process puts
 in a place where CoqIDE can find it.  Then you can select `coq-elpi`
 from the menu `Edit -> Preferences -> Colors`.
 
-If you use Vim, we recommend to add the following lines to `~/.vimrc` (in addition to the ones
-for [elpi](https://github.com/LPCIC/elpi#syntax-highlight-in-vim))
+For Vim users, [Coqtail](https://github.com/whonore/Coqtail) provides syntax
+highlighting and handles quotations. Alternatively, to get only syntax
+highlighting one could add the following lines to `~/.vimrc` (in addition to the
+ones for [elpi](https://github.com/LPCIC/elpi#syntax-highlight-in-vim)).
 <details><summary>(click to expand)</summary>
 <p>
 


### PR DESCRIPTION
As of whonore/Coqtail#278, Coqtail provides syntax highlighting for embedded Elpi code and the related vernacular commands (e.g., `Elpi Command`), and correctly parses `lp:{{ ... }}` blocks. I also left the old syntax highlighting suggestion as an alternative, although it seems pretty incomplete.