### PR TITLE
command Elpi Trace Browser

### DIFF
--- a/src/coq_elpi_vernacular.ml
+++ b/src/coq_elpi_vernacular.ml
@@ -702,6 +702,15 @@ let trace start stop preds opts =
   if start = 0 && stop = 0 then trace_options := []
   else trace_options := mk_trace_opts start stop preds @ opts
 
+let trace_browser _opts =
+  trace_options :=
+    [ "-trace-on"; "json"; "/tmp/traced.tmp.json"
+    ; "-trace-at"; "run"; "0"; string_of_int max_int
+    ; "-trace-only"; "user"
+    ];
+  Feedback.msg_notice
+    Pp.(strbrk "Now click \"Start watching\" in the Elpi Trace Browser panel and then execute the Command/Tactic/Query you want to trace. Also try \"F1 Elpi\".")
+
 let main_quotedc = ET.Constants.declare_global_symbol "main-quoted"
 
 let print name args =

--- a/src/coq_elpi_vernacular.mli
+++ b/src/coq_elpi_vernacular.mli
@@ -31,6 +31,7 @@ val document_builtins : unit -> unit
 (* Debug *)
 val debug : string list -> unit
 val trace : int -> int -> string list -> string list -> unit
+val trace_browser : string list -> unit
 val bound_steps : int -> unit
 val print : qualified_name -> string list -> unit
 

--- a/src/coq_elpi_vernacular_syntax.mlg
+++ b/src/coq_elpi_vernacular_syntax.mlg
@@ -132,6 +132,9 @@ VERNAC COMMAND EXTEND Elpi CLASSIFIED AS SIDEFF
 | #[ atts = any_attribute ] [ "Elpi" "Debug" string_list(s) ] -> {
      let () = ignore_unknown_attributes atts in
      EV.debug s }
+| #[ atts = any_attribute ] [ "Elpi" "Trace" "Browser" string_list(s) ] -> {
+     let () = ignore_unknown_attributes atts in
+     EV.trace_browser s }
 | #[ atts = any_attribute ] [ "Elpi" "Trace" string_list(s) ] -> {
      let () = ignore_unknown_attributes atts in
      EV.trace 1 max_int s [] }


### PR DESCRIPTION
This PR adds a new command `Elpi Trace Browser`.

@jwintz If you compile this one (just make) then `ALT -> ` (coq: interpret to point) in file `examples/tutorial_elpi_lang.v` just after the new command, then start the trace watcher, then interpret the next Coq line, you should get a trace.

TODO:
- [ ] doc