### PR TITLE
fix make clean failure on fresh repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ src/coq_elpi_builtins_HOAS.ml: elpi/coq-HOAS.elpi Makefile.coq.local
 src/coq_elpi_config.ml:
 	echo "let elpi_dir = \"$(abspath $(ELPIDIR))\";;" > $@
 
-clean:
+clean: Makefile.coq Makefile.test.coq
 	@$(MAKE) -f Makefile.coq $@
 	@$(MAKE) -f Makefile.test.coq $@
 	@$(foreach app,$(APPS),$(MAKE) -C $(app) $@ &&) true

--- a/apps/NES/Makefile
+++ b/apps/NES/Makefile
@@ -30,7 +30,7 @@ Makefile.coq Makefile.coq.conf: _CoqProject
 Makefile.test.coq Makefile.test.coq.conf: _CoqProject.test
 	@$(COQBIN)/coq_makefile -f _CoqProject.test -o Makefile.test.coq
 
-clean:
+clean: Makefile.coq Makefile.test.coq
 	@$(MAKE) -f Makefile.coq $@
 	@$(MAKE) -f Makefile.test.coq $@
 

--- a/apps/derive/Makefile
+++ b/apps/derive/Makefile
@@ -30,7 +30,7 @@ Makefile.coq Makefile.coq.conf: _CoqProject
 Makefile.test.coq Makefile.test.coq.conf: _CoqProject.test
 	@$(COQBIN)/coq_makefile -f _CoqProject.test -o Makefile.test.coq
 
-clean:
+clean: Makefile.coq Makefile.test.coq
 	@$(MAKE) -f Makefile.coq $@
 	@$(MAKE) -f Makefile.test.coq $@
 

--- a/apps/eltac/Makefile
+++ b/apps/eltac/Makefile
@@ -30,7 +30,7 @@ Makefile.coq Makefile.coq.conf: _CoqProject
 Makefile.test.coq Makefile.test.coq.conf: _CoqProject.test
 	@$(COQBIN)/coq_makefile -f _CoqProject.test -o Makefile.test.coq
 
-clean:
+clean: Makefile.coq Makefile.test.coq
 	@$(MAKE) -f Makefile.coq $@
 	@$(MAKE) -f Makefile.test.coq $@
 

--- a/apps/locker/Makefile
+++ b/apps/locker/Makefile
@@ -30,7 +30,7 @@ Makefile.coq Makefile.coq.conf: _CoqProject
 Makefile.test.coq Makefile.test.coq.conf: _CoqProject.test
 	@$(COQBIN)/coq_makefile -f _CoqProject.test -o Makefile.test.coq
 
-clean:
+clean: Makefile.coq Makefile.test.coq
 	@$(MAKE) -f Makefile.coq $@
 	@$(MAKE) -f Makefile.test.coq $@
 


### PR DESCRIPTION
Launching `make clean` on fresh copy of repository results in error:
```
make[1]: Makefile.test.coq: No such file or directory
make[1]: *** No rule to make target 'Makefile.test.coq'.  Stop.
```
This problem prevents from using common idiom `make clean && make` in build scripts. This PR fixes this behaviour.