### PR TITLE
Adapt to coq/coq#16930 (remove Flags.native_compiler)

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -3263,7 +3263,7 @@ Supported attributes:
          | B.Given ty -> sigma, ty
          | B.Unspec -> Typing.type_of proof_context.env sigma t in
        let t =
-         if Flags.get_native_compiler () then
+         if (Environ.typing_flags proof_context.env).enable_native_compiler then
            Nativenorm.native_norm proof_context.env sigma t ty
          else
            Vnorm.cbv_vm proof_context.env sigma t ty in
@@ -3272,7 +3272,7 @@ Supported attributes:
 
   MLCode(Pred("coq.reduction.native.available?",
     Easy "Is native compilation available on this system/configuration?",
-    (fun ~depth:_ -> if not (Flags.get_native_compiler ()) then raise No_clause)),
+    (fun ~depth:_ -> if not ((Global.typing_flags ()).enable_native_compiler) then raise No_clause)),
   DocAbove);
 
   LPCode {|% Deprecated, use coq.reduction.cbv.norm

--- a/src/coq_elpi_vernacular.ml
+++ b/src/coq_elpi_vernacular.ml
@@ -679,7 +679,7 @@ let atts2impl loc ~depth state atts q =
         match Pcoq.parse_string (Pvernac.main_entry None) (Printf.sprintf "#[%s] Qed." txt) |> Option.map (fun x -> x.CAst.v) with
         | None -> atts
         | Some { Vernacexpr.attrs ; _ } -> List.map (fun {CAst.v=(name,v)} -> convert_att_r ("elpi."^name,v)) attrs @ atts
-        | exception Stream.Error msg ->
+        | exception Gramlib.Stream.Error msg ->
             CErrors.user_err Pp.(str"Environment variable COQ_ELPI_ATTRIBUTES contains ill formed value:" ++ spc () ++ str txt ++ cut () ++ str msg) in
   let state, atts, _ = EU.map_acc (Coq_elpi_builtins.attribute.API.Conversion.embed ~depth) state atts in
   let atts = ET.mkApp attributesc (EU.list_to_lp_list atts) [] in


### PR DESCRIPTION
backwards compatible, please merge