### PR TITLE
Adapt to coq/coq#17038 (drop -rectypes flag as coq_makefile default)

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,5 +1,5 @@
 CAMLPKGS+= -package elpi,stdlib-shims
-CAMLFLAGS+= -bin-annot -g
+CAMLFLAGS+= -rectypes -bin-annot -g
 OCAMLWARN+=-warn-error -32
 
 theories/elpi.vo: $(wildcard elpi/*.elpi)


### PR DESCRIPTION
Coq no longer depends on being compiled with the `-rectypes` flag, but this project does, so add flag explicitly. Should be backwards compatible.