### PR TITLE
Adapt to Coq PR #16935: asking for a strict check when not specified.

### DIFF
--- a/src/coq_elpi_vernacular.ml
+++ b/src/coq_elpi_vernacular.ml
@@ -691,7 +691,7 @@ let run_program loc name ~atts args =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let args = args
-    |> List.map (Coq_elpi_arg_HOAS.Cmd.glob (Genintern.empty_glob_sign env))
+    |> List.map (Coq_elpi_arg_HOAS.Cmd.glob (Genintern.empty_glob_sign ~strict:true env))
     |> List.map (Coq_elpi_arg_HOAS.Cmd.interp (Ltac_plugin.Tacinterp.default_ist ()) env sigma)
   in
   let query ~depth state =


### PR DESCRIPTION
This canonically adapts to the explicitation of the strict_check flag in Ltac done in coq/coq#16935.

To be merged synchronously.