### PR TITLE
arg_syntax: replace Pcoq.Entry.create with Pcoq.Entry.make

### DIFF
--- a/src/coq_elpi_arg_syntax.mlg
+++ b/src/coq_elpi_arg_syntax.mlg
@@ -99,9 +99,9 @@ END
 
 {
 
-let telescope = Pcoq.Entry.create "elpi:telescope"
-let colon_sort = Pcoq.Entry.create "elpi:colon_sort"
-let colon_constr = Pcoq.Entry.create "elpi:colon_constr"
+let telescope = Pcoq.Entry.make "elpi:telescope"
+let colon_sort = Pcoq.Entry.make "elpi:colon_sort"
+let colon_constr = Pcoq.Entry.make "elpi:colon_constr"
 
 let any_attribute : Attributes.vernac_flags Attributes.attribute =
   Attributes.make_attribute (fun x -> [],x)


### PR DESCRIPTION
We are removing the deprecated Pcoq.Entry.create. See coq/coq#17065.