### PR TITLE
Adapt w.r.t. coq/coq#17170.

### DIFF
--- a/src/coq_elpi_HOAS.ml
+++ b/src/coq_elpi_HOAS.ml
@@ -1213,7 +1213,7 @@ let restrict_coq_context live_db state { proof; proof_len; local; name2db; env; 
 
 let info_of_evar ~env ~sigma ~section k =
   let open Context.Named in
-  let EvarInfo evi = Evd.find sigma k in
+  let evi = Evd.find_undefined sigma k in
   let info = Evarutil.nf_evar_info sigma evi in
   let filtered_hyps = Evd.evar_filtered_hyps info in
   let ctx = EC.named_context_of_val filtered_hyps in


### PR DESCRIPTION
This assumes that info_of_evar is only ever called on undefined evars, but I am not really confident this is the case. The test-suite goes through, though.