### PR TITLE
arg_syntax: replace Pcoq.Entry.create with Pcoq.Entry.make

### DIFF
--- a/src/coq_elpi_arg_syntax.mlg
+++ b/src/coq_elpi_arg_syntax.mlg
@@ -132,7 +132,7 @@ let validate_attributes a flags =
   ignore_unknown_attributes extra;
   raw_args
 
-let coq_kwd_or_symbol = Pcoq.Entry.create "elpi:kwd_or_symbol"
+let coq_kwd_or_symbol = Pcoq.Entry.make "elpi:kwd_or_symbol"
 
 let opt2list = function None -> [] | Some l -> l
 


### PR DESCRIPTION
We are removing the deprecated Pcoq.Entry.create. See coq/coq#17065. This patch removes one more instance of Pcoq.Entry.create. (cc @ppedrot)