### PR TITLE
mlocker: set implicits globally

### DIFF
--- a/apps/locker/elpi/locker.elpi
+++ b/apps/locker/elpi/locker.elpi
@@ -19,7 +19,7 @@ key-lock ID Bo Arity UnivDecl :- std.do! [
 
   coq.arity->implicits Arity CImpls,
   if (coq.any-implicit? CImpls)
-     (coq.arguments.set-implicit (const C) [CImpls])
+     (@global! => coq.arguments.set-implicit (const C) [CImpls])
      true,
 
   make-key-unlockable ID Def Ty {coq.env.global (const C)} Key,
@@ -58,7 +58,7 @@ module-lock ID Bo Arity UnivDecl :- std.do! [
 
   coq.arity->implicits Arity CImpls,
   if (coq.any-implicit? CImpls)
-     (Symbol = global GR, coq.arguments.set-implicit GR [CImpls])
+     (Symbol = global GR, @global! => coq.arguments.set-implicit GR [CImpls])
      true,
 
   make-module-unlockable ID Module,

--- a/apps/locker/tests/test_locker.v
+++ b/apps/locker/tests/test_locker.v
@@ -36,6 +36,19 @@ Proof. rewrite unlock. match goal with |- 3 = 3 => by [] end. Qed.
 Lemma test_3_1 : d3 = 3.
 Proof. Fail unfold d3. rewrite d3.unlock. by []. Qed.
 
+Module test_global_implicits.
+  Module mlock_container.
+    mlock Definition def {A} (a : A) := a.
+  End mlock_container.
+
+  Fail Definition user1 {A} (a : A) := mlock_container.def _ a.
+  Definition user1 {A} (a : A) := mlock_container.def a.
+
+  Import mlock_container.
+  Fail Definition user2 {A} (a : A) := def _ a.
+  Definition user2 {A} (a : A) := def a.
+End test_global_implicits.
+
 (* ----------------------- *)
 
 Section S2.


### PR DESCRIPTION
I confirmed the behavior in the test fails with coq-elpi 1.16.0; I couldn't confirm the fix because coq-elpi doesn't build here (because of #428).

(Same patch works on 1.16.0: https://github.com/LPCIC/coq-elpi/compare/master...Blaisorblade:paolo/fix-locker-1.16.0).