### PR TITLE
Add coq.notice and coq.info

### DIFF
--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -505,7 +505,13 @@ type off coercion-status.
 
 % -- Misc ---------------------------------------------------------
 
-% [coq.say ...] Prints an info message
+% [coq.info ...] Prints an info message
+external type coq.info variadic any prop.
+
+% [coq.notice ...] Prints a notice message
+external type coq.notice variadic any prop.
+
+% [coq.say ...] Prints a notice message
 external type coq.say variadic any prop.
 
 % [coq.warn ...] Prints a generic warning message

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1214,8 +1214,24 @@ let coq_builtins =
 
   LPDoc "-- Misc ---------------------------------------------------------";
 
-  MLCode(Pred("coq.say",
+  MLCode(Pred("coq.info",
     VariadicIn(unit_ctx, !> B.any, "Prints an info message"),
+  (fun args ~depth _hyps _constraints state ->
+     let pp = pp ~depth in
+     Feedback.msg_info Pp.(str (pp2string (P.list ~boxed:true pp " ") args));
+     state, ())),
+  DocAbove);
+
+  MLCode(Pred("coq.notice",
+    VariadicIn(unit_ctx, !> B.any, "Prints a notice message"),
+  (fun args ~depth _hyps _constraints state ->
+     let pp = pp ~depth in
+     Feedback.msg_notice Pp.(str (pp2string (P.list ~boxed:true pp " ") args));
+     state, ())),
+  DocAbove);
+
+  MLCode(Pred("coq.say",
+    VariadicIn(unit_ctx, !> B.any, "Prints a notice message"),
   (fun args ~depth _hyps _constraints state ->
      let pp = pp ~depth in
      Feedback.msg_notice Pp.(str (pp2string (P.list ~boxed:true pp " ") args));

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1168,6 +1168,12 @@ let dep1 ?inside sigma gr =
 let universe_level_set, universe_level_set_decl =
   B.ocaml_set_conv ~name:"coq.univ.variable.set" universe_level_variable (module UnivLevelSet)
 
+let coq_print pp msg_f =
+  (fun args ~depth _hyps _constraints state ->
+     let pp = pp ~depth in
+     msg_f Pp.(str (pp2string (P.list ~boxed:true pp " ") args));
+     state, ())
+
 (*****************************************************************************)
 (*****************************************************************************)
 (*****************************************************************************)
@@ -1216,26 +1222,20 @@ let coq_builtins =
 
   MLCode(Pred("coq.info",
     VariadicIn(unit_ctx, !> B.any, "Prints an info message"),
-  (fun args ~depth _hyps _constraints state ->
-     let pp = pp ~depth in
-     Feedback.msg_info Pp.(str (pp2string (P.list ~boxed:true pp " ") args));
-     state, ())),
+    coq_print pp Feedback.msg_info
+  ),
   DocAbove);
 
   MLCode(Pred("coq.notice",
     VariadicIn(unit_ctx, !> B.any, "Prints a notice message"),
-  (fun args ~depth _hyps _constraints state ->
-     let pp = pp ~depth in
-     Feedback.msg_notice Pp.(str (pp2string (P.list ~boxed:true pp " ") args));
-     state, ())),
+    coq_print pp Feedback.msg_notice
+  ),
   DocAbove);
 
   MLCode(Pred("coq.say",
     VariadicIn(unit_ctx, !> B.any, "Prints a notice message"),
-  (fun args ~depth _hyps _constraints state ->
-     let pp = pp ~depth in
-     Feedback.msg_notice Pp.(str (pp2string (P.list ~boxed:true pp " ") args));
-     state, ())),
+    coq_print pp Feedback.msg_notice
+  ),
   DocAbove);
 
   MLCode(Pred("coq.warn",


### PR DESCRIPTION
`coq.say` uses `msg_notice`. Sometimes `msg_info` is useful.

This commit adds `coq.notice` and `coq.info`, and now `coq.say` is a synonym of coq.notice.

It's a draft because I haven't built or tested this.