### PR TITLE
derive: set implicits globally

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,10 @@
   the spilling of a predicate `{p}` needs to be accumulated after the
   type or mode of `p` is declared
 
+### APPS
+- `derive Inductive i {A}` now sets `A` implicit status globally
+- `lock Definition f {A}` now sets `A` implicit status globally
+
 ## [1.17.1] - 09/03/2023
 
 Requires Elpi 1.16.5 and Coq 8.17.

--- a/Changelog.md
+++ b/Changelog.md
@@ -286,8 +286,8 @@ Requires Elpi 1.14.1 and Coq 8.15.
 Requires Elpi 1.13.6 and Coq 8.15.
 
 ### APPS
-- `derive Inductive i {A}` now correctly sets `A` implicit status (XXX)
-- `lock Definition f {A}` now correctly sets `A` implicit status (XXX)
+- `derive Inductive i {A}` now correctly sets `A` implicit status
+- `lock Definition f {A}` now correctly sets `A` implicit status
 
 ### API
 - New `coq.arity->implicits`

--- a/Changelog.md
+++ b/Changelog.md
@@ -286,8 +286,8 @@ Requires Elpi 1.14.1 and Coq 8.15.
 Requires Elpi 1.13.6 and Coq 8.15.
 
 ### APPS
-- `derive Inductive i {A}` now correctly sets `A` implicit status
-- `lock Definition f {A}` now correctly sets `A` implicit status
+- `derive Inductive i {A}` now correctly sets `A` implicit status (XXX)
+- `lock Definition f {A}` now correctly sets `A` implicit status (XXX)
 
 ### API
 - New `coq.arity->implicits`

--- a/apps/derive/elpi/derive.elpi
+++ b/apps/derive/elpi/derive.elpi
@@ -139,11 +139,11 @@ decl+main DS :- std.do! [
 
   coq.indt-decl->implicits DS IndImpls KsImpls,
   if (coq.any-implicit? IndImpls)
-     (coq.arguments.set-implicit (indt I) [IndImpls])
+     (@global! => coq.arguments.set-implicit (indt I) [IndImpls])
      true,
   std.forall2 KsImpls KS (i\k\
     if (coq.any-implicit? i)
-       (coq.arguments.set-implicit (indc k) [i])
+       (@global! => coq.arguments.set-implicit (indc k) [i])
        true
     ),
   std.map-filter CL export? P,

--- a/apps/derive/tests/test_derive.v
+++ b/apps/derive/tests/test_derive.v
@@ -159,8 +159,11 @@ Inductive Pred : RoseTree -> Type :=
 Check Pred.Pred_to_Predinv : forall T, Pred T -> Pred.Predinv T.
 
 (* #286 *)
+Module Import derive_container.
+Unset Implicit Arguments.
 derive
 Inductive wimpls {A} `{rtree A} := Kwi (x:A) (y : x = x) : wimpls | Kwa.
+End derive_container.
 About wimpls.wimpls.
 About wimpls.Kwi.
 Check Kwi _ (refl_equal 3).

--- a/apps/derive/tests/test_derive.v
+++ b/apps/derive/tests/test_derive.v
@@ -1,7 +1,7 @@
 From elpi.apps Require Import derive.std derive.legacy derive.experimental.
 From elpi.apps Require Import test_derive_stdlib.
 
-Elpi derive Coverage.empty. 
+Elpi derive Coverage.empty.
 Elpi derive Coverage.unit.
 Elpi derive Coverage.peano.
 Elpi derive Coverage.option.
@@ -39,12 +39,12 @@ Check is_nat_functor : forall x, is_nat x -> is_nat x.
 Check nat_induction : forall P, P 0 -> (forall n, P n -> P (S n)) -> forall x, is_nat x -> P x.
 
 Check nat_tag : nat -> Numbers.BinNums.positive.
-Check nat_fields_t : Numbers.BinNums.positive -> Type. 
-Check nat_fields : forall (n:nat), nat_fields_t (nat_tag n). 
+Check nat_fields_t : Numbers.BinNums.positive -> Type.
+Check nat_fields : forall (n:nat), nat_fields_t (nat_tag n).
 Check nat_construct : forall (p: Numbers.BinNums.positive),  nat_fields_t p -> option nat.
 Check nat_constructP : forall (n:nat), nat_construct (nat_tag n) (nat_fields n) = Some n.
 Check nat_eqb : nat -> nat -> bool.
-Check nat_eqb_correct. 
+Check nat_eqb_correct.
 Check nat_eqb_refl.
 (* ---------------------------------------------------- *)
 
@@ -58,13 +58,13 @@ Check is_cons : forall A P x (Px : P x) tl (Ptl : is_list A P tl), is_list A P (
 Check is_list_functor : forall A P Q, (forall x, P x -> Q x) -> forall l, is_list A P l -> is_list A Q l.
 Check list_induction : forall A PA P, P nil -> (forall x, PA x -> forall xs, P xs -> P (cons x xs)) -> forall l, is_list A PA l -> P l.
 Check list_tag : forall A, list A -> Numbers.BinNums.positive.
-Check list_fields_t : (Type -> Numbers.BinNums.positive -> Type). 
-Check list_fields : forall (A:Type) (l:list A), list_fields_t A (list_tag A l). 
+Check list_fields_t : (Type -> Numbers.BinNums.positive -> Type).
+Check list_fields : forall (A:Type) (l:list A), list_fields_t A (list_tag A l).
 Check list_construct : forall (A:Type) (p: Numbers.BinNums.positive),  list_fields_t A p -> option (list A).
 Check list_constructP : forall (A:Type) (l:list A), list_construct A (list_tag A l) (list_fields A l) = Some l.
 Check list_eqb : forall A, (A -> A -> bool) -> list A -> list A -> bool.
-Check list_eqb_correct.   
-Check list_eqb_refl.      
+Check list_eqb_correct.
+Check list_eqb_refl.
 (* ---------------------------------------------------- *)
 
 Require Vector.
@@ -76,7 +76,7 @@ End Vector.
 
 Check Vector.t_eq : forall A, (A -> A -> bool) -> forall n, Vector.t A n -> Vector.t A n -> bool.
 Check Vector.t_isk_nil : forall A n, Vector.t A n -> bool.
-Check Vector.t_isk_cons : forall A n, Vector.t A n -> bool. 
+Check Vector.t_isk_cons : forall A n, Vector.t A n -> bool.
 Check Vector.t_map : forall A B, (A -> B) -> forall n, Vector.t A n -> Vector.t B n.
 Check Vector.t_getk_cons1 : forall A n, A -> forall m, Vector.t A m -> Vector.t A n -> A.
 Check Vector.t_getk_cons2 : forall A n, A -> forall m, Vector.t A m -> Vector.t A n -> nat.
@@ -88,8 +88,8 @@ Check Vector.is_cons : forall A (PA : A -> Type) (a : A), PA a -> forall n (Pn :
 Check Vector.is_t_functor : forall A PA QA (H : forall x, PA x -> QA x), forall n nR v, Vector.is_t A PA n nR v -> Vector.is_t A QA n nR v.
 Check Vector.t_induction : forall A PA (P : forall n, is_nat n -> Vector.t A n -> Type), P 0 is_O (Vector.nil A) -> (forall a, PA a -> forall m mR, forall (v : Vector.t A m), P m mR v -> P (S m) (is_S m mR) (Vector.cons A a m v)) -> forall n nR v, Vector.is_t A PA n nR v -> P n nR v.
 Check Vector.t_tag : forall A i, Vector.t A i -> Numbers.BinNums.positive.
-Fail Check Vector.t_fields_t : (Type -> Numbers.BinNums.positive -> Type). 
-Fail Check Vector.t_fields : forall (A:Type) (n:nat) (l:Vector.t A n), Vector.t_fields_t A (Vector.t_tag A l). 
+Fail Check Vector.t_fields_t : (Type -> Numbers.BinNums.positive -> Type).
+Fail Check Vector.t_fields : forall (A:Type) (n:nat) (l:Vector.t A n), Vector.t_fields_t A (Vector.t_tag A l).
 Fail Check Vector.t_construct : forall (A:Type) (p: Numbers.BinNums.positive),  Vector.t_fields_t A p -> option (Vector.t A).
 Fail Check Vector.t_constructP : forall (A:Type) (l:Vector.t A), Vector.t_construct A (Vector.t_tag A l) (Vector.t_fields A l) = Some l.
 Fail Check Vector.t_eqb : forall A, (A -> A -> bool) -> forall n, Vector.t A n -> Vector.t A n -> bool.
@@ -97,15 +97,15 @@ Fail Check Vector.t_eqb : forall A, (A -> A -> bool) -> forall n, Vector.t A n -
 (* ---------------------------------------------------- *)
 
 Inductive W A := B (f : A -> W).
- 
+
 Elpi derive W.
 (* Not implemented yet :-/ *)
 Fail Check W_induction : forall A (P : W A -> Type),
        (forall f, (forall x, UnitPred A x -> P (f x)) -> P (B A f)) ->
        forall x, P x.
 Check W_tag : forall A, W A -> Numbers.BinNums.positive.
-Fail Check W_fields_t : (Type -> Numbers.BinNums.positive -> Type). 
-Fail Check W_fields : forall (A:Type) (l:W A), W_fields_t A (W_tag A l). 
+Fail Check W_fields_t : (Type -> Numbers.BinNums.positive -> Type).
+Fail Check W_fields : forall (A:Type) (l:W A), W_fields_t A (W_tag A l).
 Fail Check W_construct : forall (A:Type) (p: Numbers.BinNums.positive),  W_fields_t A p -> option (W A).
 Fail Check W_constructP : forall (A:Type) (l:W A), W_construct A (W_tag A l) (W_fields A l) = Some l.
 
@@ -126,8 +126,8 @@ End XXX.
 
 Fail Check XXX.rtree_is_rtree_map.
 Check XXX.rtree_tag : forall A, rtree A -> Numbers.BinNums.positive.
-Check XXX.rtree_fields_t : (Type -> Numbers.BinNums.positive -> Type). 
-Check XXX.rtree_fields : forall (A:Type) (l:rtree A), XXX.rtree_fields_t A (XXX.rtree_tag A l). 
+Check XXX.rtree_fields_t : (Type -> Numbers.BinNums.positive -> Type).
+Check XXX.rtree_fields : forall (A:Type) (l:rtree A), XXX.rtree_fields_t A (XXX.rtree_tag A l).
 Check XXX.rtree_construct : forall (A:Type) (p: Numbers.BinNums.positive),  XXX.rtree_fields_t A p -> option (rtree A).
 Check XXX.rtree_constructP : forall (A:Type) (l:rtree A), XXX.rtree_construct A (XXX.rtree_tag A l) (XXX.rtree_fields A l) = Some l.
 Check XXX.rtree_eqb : forall (A:Type), (A -> A -> bool) -> rtree A -> rtree A -> bool.
@@ -142,7 +142,7 @@ Check triv.induction :
        (forall t (Pt : is_unit t), P t Pt (one t)) ->
        (forall x (Px : is_unit x), P x Px (more x)) ->
        forall u (p : is_unit u) (s : triv u), triv.is_triv u p s -> P u p s.
-     
+
 (* #271 *)
 derive
 Inductive RoseTree : Type :=

--- a/apps/locker/tests/test_locker.v
+++ b/apps/locker/tests/test_locker.v
@@ -36,19 +36,6 @@ Proof. rewrite unlock. match goal with |- 3 = 3 => by [] end. Qed.
 Lemma test_3_1 : d3 = 3.
 Proof. Fail unfold d3. rewrite d3.unlock. by []. Qed.
 
-Module test_global_implicits.
-  Module mlock_container.
-    mlock Definition def {A} (a : A) := a.
-  End mlock_container.
-
-  Fail Definition user1 {A} (a : A) := mlock_container.def _ a.
-  Definition user1 {A} (a : A) := mlock_container.def a.
-
-  Import mlock_container.
-  Fail Definition user2 {A} (a : A) := def _ a.
-  Definition user2 {A} (a : A) := def a.
-End test_global_implicits.
-
 (* ----------------------- *)
 
 Section S2.
@@ -68,6 +55,19 @@ lock Definition cons3 [A] `{EqDecision A} x xs := @cons A x xs.
 Definition foo3 := cons3 0 nil.
 About cons3.
 End Bug_286.
+
+Module test_286_global_implicits.
+  Module mlock_container.
+    mlock Definition def {A} (a : A) := a.
+  End mlock_container.
+
+  Fail Definition user1 {A} (a : A) := mlock_container.def _ a.
+  Definition user1 {A} (a : A) := mlock_container.def a.
+
+  Import mlock_container.
+  Fail Definition user2 {A} (a : A) := def _ a.
+  Definition user2 {A} (a : A) := def a.
+End test_286_global_implicits.
 
 (* https://coq.zulipchat.com/#narrow/stream/253928-Elpi-users-.26-devs/topic/Reifying.20terms.20with.20ltac.20.2F.20if-then-else.20.2F.20complex.20match *)
 

--- a/apps/locker/tests/test_locker.v
+++ b/apps/locker/tests/test_locker.v
@@ -45,18 +45,23 @@ End S2.
 (* #286 ----------------------- *)
 
 Module Bug_286.
+Module Import lock_container.
 Unset Implicit Arguments.
 lock Definition cons2 {A} x xs := @cons A x xs.
+End lock_container.
 About cons2.
 Definition foo := cons2 0 nil.
 Class EqDecision (A : Type) := { f : A -> A -> bool }.
 #[local] Instance xx : EqDecision nat := {| f := (fun _ _ => true) |}.
+Module Import lock_container2.
 lock Definition cons3 [A] `{EqDecision A} x xs := @cons A x xs.
+End lock_container2.
 Definition foo3 := cons3 0 nil.
 About cons3.
 End Bug_286.
 
 Module test_286_global_implicits.
+  Unset Implicit Arguments.
   Module mlock_container.
     mlock Definition def {A} (a : A) := a.
   End mlock_container.


### PR DESCRIPTION
Same bugfix as in #450, now extended to all remaining uses; this other use was introduced in #328 with the same bug.

~~Completely untested.~~ Now checks for this problem in all tests from #328.