### PR TITLE
Adapt to Coq PR #18007: Proof_using.definition_using takes names of fixpoints being built

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1960,7 +1960,7 @@ Supported attributes:
           let sigma = get_sigma state in
           let types = Option.List.cons types [] in
           let using = using_from_string s in
-          definition_using (get_global_env state) sigma ~using ~terms:types)
+          definition_using (get_global_env state) sigma ~fixnames:[] ~using ~terms:types)
          options.using in
        let cinfo = Declare.CInfo.make ?using ~name:(Id.of_string id) ~typ:types ~impargs:[] () in
        let info = Declare.Info.make ~scope ~kind ~poly ~udecl () in


### PR DESCRIPTION
This PR is to adapt to Coq [PR #18007](https://github.com/coq/coq/pull/18007). Its purpose is to ensure that the kernel does not receive names that are not available in the section.

When building fixpoints, the named context contains the name of the fixpoints being built (not sure this is a good way to do but it is how it is done now). So, we need to tell Proof_using.definition_using to exclude these variables.

Afaiu, the call to Proof_using.definition_using in coq-elpi is about a regular (non-recursive) definition, so the list of fixpoints names is []. I hope I did not misunderstand.

In any case, this is to be merged synchronously with coq/coq#18007.