### PR TITLE
Add "coq.env.query-extra-dep" external predicate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Requires Elpi 1.16.5 and Coq 8.18.
 - Change `coq.ltac.call-ltac1` now accepts either a string (tactic name) or
   a tactic expression (of type `ltac1-tactic`)
 - New `ltac_tactic:(...)` syntax to pass tactic expressions to Elpi tactics
+- New `coq.extra-dep` predicate
 
 ## [1.19.1] - 30/08/2023
 

--- a/_CoqProject.test
+++ b/_CoqProject.test
@@ -52,3 +52,4 @@ tests/test_link_order_import0.v
 tests/test_link_order_import1.v
 tests/test_link_order_import2.v
 tests/test_link_order_import3.v
+tests/test_query_extra_dep.v

--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -1666,6 +1666,10 @@ external pred coq.term->string i:term, o:string.
 % - @holes! (default: false, prints evars as _)
 external pred coq.term->pp i:term, o:coq.pp.
 
+% [coq.extra-dep Identifier File Name] Resolve the file name of an Extra
+% Dependency
+external pred coq.extra-dep i:id, o:option id.
+
 % -- Access to Elpi's data --------------------------------------------
 
 % clauses

--- a/coq-builtin.elpi
+++ b/coq-builtin.elpi
@@ -1666,8 +1666,10 @@ external pred coq.term->string i:term, o:string.
 % - @holes! (default: false, prints evars as _)
 external pred coq.term->pp i:term, o:coq.pp.
 
-% [coq.extra-dep Identifier File Name] Resolve the file name of an Extra
-% Dependency
+% -- Extra Dependencies -----------------------------------------------
+
+% [coq.extra-dep Identifier FileName] Resolve the file name of an extra
+% dependency. See also Coq's From xxx Extra Dependency yyy as zzz.
 external pred coq.extra-dep i:id, o:option id.
 
 % -- Access to Elpi's data --------------------------------------------

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -3888,8 +3888,8 @@ Supported attributes:
 
   MLCode(Pred("coq.extra-dep",
     In(id, "Identifier",
-    Out(option id, "File Name",
-    Easy "Resolve the file name of an Extra Dependency")),
+    Out(option id, "FileName",
+    Easy "Resolve the file name of an extra dependency. See also Coq's From xxx Extra Dependency yyy as zzz.")),
   (fun id _ ~depth ->
     !: (try Some (ComExtraDeps.query_extra_dep (Names.Id.of_string id))
         with Not_found -> None))),

--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -3884,6 +3884,17 @@ Supported attributes:
      state, !: s, [])),
   DocAbove);
 
+  LPDoc "-- Extra Dependencies -----------------------------------------------";
+
+  MLCode(Pred("coq.extra-dep",
+    In(id, "Identifier",
+    Out(option id, "File Name",
+    Easy "Resolve the file name of an Extra Dependency")),
+  (fun id _ ~depth ->
+    !: (try Some (ComExtraDeps.query_extra_dep (Names.Id.of_string id))
+        with Not_found -> None))),
+  DocAbove);
+
   LPDoc "-- Access to Elpi's data --------------------------------------------";
 
    (* Self modification *)

--- a/tests/test_query_extra_dep.v
+++ b/tests/test_query_extra_dep.v
@@ -2,6 +2,8 @@ From elpi Require Import elpi.
 
 From unreleased Extra Dependency "elpi_elaborator.elpi" as elab.
 
-Elpi Query lp:{{ coq.extra-dep "elab" _ }}.
+Elpi Command test.
 
-Fail Elpi Query lp:{{ coq.extra-dep "foo" (some _) }}.
+Elpi Query lp:{{ coq.extra-dep "elab" (some P) }}.
+
+Elpi Query lp:{{ coq.extra-dep "foo" none }}.

--- a/tests/test_query_extra_dep.v
+++ b/tests/test_query_extra_dep.v
@@ -1,0 +1,7 @@
+From elpi Require Import elpi.
+
+From unreleased Extra Dependency "elpi_elaborator.elpi" as elab.
+
+Elpi Query lp:{{ coq.extra-dep "elab" _ }}.
+
+Fail Elpi Query lp:{{ coq.extra-dep "foo" (some _) }}.


### PR DESCRIPTION
As discussed on [Zulip](https://coq.zulipchat.com/#narrow/stream/253928-Elpi-users-.26-devs/topic/Resolving.20Extra.20Dependencies/near/396087392), this would allow for a predicate to resolve the real path behind a `Extra Dependency`.  As seen in the patch, this just amounts to wrapping `ComExtraDeps.query_extra_dep` in the right way.