### PR TITLE
Adapt to coq PR #18190 adding a whd form of the cbv reduction strategy

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -3466,7 +3466,7 @@ Supported attributes:
     (fun t _ ~depth proof_context constraints state ->
        let sigma = get_sigma state in
        let flags = Option.default RedFlags.all proof_context.options.redflags in
-       let t = Tacred.cbv_norm_flags flags proof_context.env sigma t in
+       let t = Tacred.cbv_norm_flags flags ~strong:true proof_context.env sigma t in
        !: t)),
   DocAbove);
 


### PR DESCRIPTION
The function `cbv_norm_flags` now needs to know if the reduction is expected to be weak or strong. We set it to strong:true preserving the previous semantics.

To be merged synchronously with coq/coq#18190.