### PR TITLE
fix installation of tc

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -29,7 +29,7 @@
 -I apps/coercion/src
 
 # Type classes
--R apps/tc/theories       elpi.apps
+-R apps/tc/theories       elpi.apps.tc
 -R apps/tc/tests          elpi.apps.tc.tests
 -R apps/tc/elpi           elpi.apps.tc
 -I apps/tc/src

--- a/apps/tc/Makefile.coq.local
+++ b/apps/tc/Makefile.coq.local
@@ -1,3 +1,7 @@
 CAMLPKGS+= -package coq-elpi.elpi
 OCAMLPATH:=../../src/:$(OCAMLPATH)
 export OCAMLPATH
+
+install-extra::
+	df="`$(COQMKFILE) -destination-of theories/tc.vo $(COQLIBS)`";\
+	install -m 0644 $(wildcard elpi/*.elpi) "$(COQLIBINSTALL)/$$df"

--- a/apps/tc/_CoqProject
+++ b/apps/tc/_CoqProject
@@ -3,7 +3,7 @@
 -I ../../src
 -docroot elpi.apps
 
--R theories   elpi.apps
+-R theories   elpi.apps.tc
 -R elpi       elpi.apps.tc
 -R tests      elpi.apps.tc.tests
 

--- a/apps/tc/_CoqProject.test
+++ b/apps/tc/_CoqProject.test
@@ -5,7 +5,7 @@
 -I ../../src
 
 -Q elpi     elpi.apps.tc
--R theories elpi.apps
+-R theories elpi.apps.tc
 -R tests    elpi.apps.tc.tests
 -I src
 


### PR DESCRIPTION
Modifies the `_CoqProject` files and `apps/tc/Makefile.coq.local` so that tc is installed in the `elpi/apps/tc` folder of the library.