### PR TITLE
Adapt to Coq PR#18397: Change of ComAssumption.declare_variable and ComAssumption.declare_axiom

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -865,19 +865,19 @@ let add_axiom_or_variable api id ty local options state =
   let kind = Decls.Logical in
   let impargs = [] in
   let loc = to_coq_loc @@ State.get invocation_site_loc state in
-  let variable = CAst.(make ~loc @@ Id.of_string id) in
+  let id = Id.of_string id in
+  let variable = CAst.(make ~loc id) in
   if not (is_ground sigma ty) then
     err Pp.(str"coq.env.add-const: the type must be ground. Did you forge to call coq.typecheck-indt-decl?");
   let gr, _ =
     if local then begin
-      ComAssumption.declare_variable Vernacexpr.NoCoercion ~kind (EConstr.to_constr sigma ty) uentry impargs Glob_term.Explicit variable;
       Dumpglob.dump_definition variable true "var";
-      GlobRef.VarRef(Id.of_string id), UVars.Instance.empty
+      ComAssumption.declare_variable Vernacexpr.NoCoercion ~kind (EConstr.to_constr sigma ty) uentry impargs Glob_term.Explicit id
     end else begin
       Dumpglob.dump_definition variable false "ax";
       ComAssumption.declare_axiom Vernacexpr.NoCoercion ~local:Locality.ImportDefaultBehavior ~kind (EConstr.to_constr sigma ty)
         uentry impargs options.inline
-        variable
+        id
     end
   in
   gr


### PR DESCRIPTION
In the PR, `ComAssumption.declare_variable` takes a location-free name and returns the pair of a ref and an instance. `ComAssumption.declare_axiom` also takes a location-free name.

To be considered synchronously with coq/coq#18397.