### PR TITLE
avoid declaring options twice

### DIFF
--- a/apps/tc/theories/tc.v
+++ b/apps/tc/theories/tc.v
@@ -42,8 +42,10 @@ Elpi Accumulate File solver.
 Elpi Query lp:{{
   sigma Options\ 
     all-options Options,
-    std.forall Options (x\ sigma L\ x L, 
-      coq.option.add L (coq.option.bool ff) ff).
+    std.forall Options (x\ sigma L\ x L,
+      if (coq.option.available? L _)
+         true
+         (coq.option.add L (coq.option.bool ff) ff)).
 }}.
 Elpi Typecheck.
 

--- a/src/coq_elpi_arg_HOAS.ml
+++ b/src/coq_elpi_arg_HOAS.ml
@@ -960,6 +960,8 @@ let in_elpi_cmd ~depth ?calldepth coq_ctx state ~raw (x : Cmd.top) =
       let open Vernacentries.Preprocessed_Mind_decl in
       let { flags = { template; poly; cumulative; udecl; finite }; primitive_proj; kind; records } = raw_rdecl in
       let template = handle_template_polymorphism template in
+      (* Definitional type classes cannot be interpreted using this function (why?) *)
+      let kind = if kind = Vernacexpr.Class true then Vernacexpr.Class false else kind in
       let e = Record.interp_structure ~template udecl kind ~cumulative ~poly ~primitive_proj finite records in
       record_entry2lp ~depth coq_ctx E.no_constraints state ~loose_udecl:(udecl = None) e
   | IndtDecl (_ist,(glob_sign,raw_indt)) when raw ->

--- a/tests/test_arg_HOAS.v
+++ b/tests/test_arg_HOAS.v
@@ -245,6 +245,12 @@ End full_definition.
 
 (*****************************************)
 
+Module classes.
+Elpi declarations Class foo := bar : True.
+End classes.
+
+(*****************************************)
+
 Module copy.
 Import inductive_nup.
 

--- a/tests/test_quotation.v
+++ b/tests/test_quotation.v
@@ -83,3 +83,14 @@ Fail Elpi Query lp:{{ std.do! [
   std.assert-ok! (coq.typecheck T _) "does not typecheck",
 ]
 }}.
+
+Section A.
+Variable A : Type.
+Check 1.
+Elpi Accumulate lp:{{
+
+pred p i:term.
+p {{ A }}.
+
+}}.
+End A.


### PR DESCRIPTION
This can happen in a coq instance handling multiple files, eg vscoq