### PR TITLE
[derive] Open scope only locally

### DIFF
--- a/apps/derive/theories/derive/eqb_core_defs.v
+++ b/apps/derive/theories/derive/eqb_core_defs.v
@@ -5,7 +5,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Open Scope positive_scope.
+Local Open Scope positive_scope.
 
 Section Section.
 Context {A:Type}.


### PR DESCRIPTION
Avoids messing with the scopes opened by the client.

```
Require Import ZArith.
From elpi.apps Require Import derive.std.

Check forall p, p < p.
```
Before
```
forall p : positive, p < p
     : Prop
```
After
```
forall p : nat, p < p
     : Prop
```