### PR TITLE
Don't run tests in build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build-apps:
 .PHONY: build-apps
 
 build:
-	$(call dune,build) @install
+	$(call dune,build) -p coq-elpi @install
 .PHONY: build
 
 test-core:


### PR DESCRIPTION
This "breaks" Coq CI which has two jobs, one for building coq-elpi, the second one for tests. Currently, they both run tests.