### PR TITLE
Do not escape quotes in verbatim LPDoc documentation.

### DIFF
--- a/src/coq_elpi_builtins.ml
+++ b/src/coq_elpi_builtins.ml
@@ -1507,7 +1507,7 @@ let coq_locate_builtins =
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%|};
     LPDoc "-- Environment: names -----------------------------------------------";
     LPDoc {|To make the API more precise we use different data types for the names of global objects.
-Note: [ctype \"bla\"] is an opaque data type and by convention it is written [@bla].|};
+Note: [ctype "bla"] is an opaque data type and by convention it is written [@bla].|};
   
     MLData constant;
     MLData inductive;


### PR DESCRIPTION
This confuses my text editor and I think this is actually useless. Indeed, looking at the code of Elpi seems to indicate that we do not need one additional level of escaping there.

@gares please check that this analysis is correct.