### PR TITLE
No stdlib

### DIFF
--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -558,8 +558,8 @@ external pred coq.version o:string, o:int, o:int, o:int.
 
 % To make the API more precise we use different data types for the names
 % of global objects.
-% Note: [ctype \"bla\"] is an opaque data type and by convention it is
-% written [@bla].
+% Note: [ctype "bla"] is an opaque data type and by convention it is written
+% [@bla].
 
 % Global constant name
 typeabbrev constant (ctype "constant").

--- a/builtin-doc/elpi-builtin.elpi
+++ b/builtin-doc/elpi-builtin.elpi
@@ -449,6 +449,9 @@ pred ignore-failure! i:prop.
 ignore-failure! P :- P, !.
 ignore-failure! _.
 
+pred once i:prop.
+once P :- P, !.
+
 % [assert! C M] takes the first success of C or fails with message M 
 pred assert! i:prop, i:string.
 assert! Cond Msg :- (Cond ; fatal-error-w-data Msg Cond), !.

--- a/elpi/coq-elaborator.elpi
+++ b/elpi/coq-elaborator.elpi
@@ -37,13 +37,13 @@ pred propagate-Prop-constraint-inward i:term.
 propagate-Prop-constraint-inward {{ forall x : lp:Ty, lp:(F x) }} :- !,
   @pi-decl `x` Ty x\
     propagate-Prop-constraint-inward (F x).
-propagate-Prop-constraint-inward {{ lp:A /\ lp:B }} :- !,
+propagate-Prop-constraint-inward {{ Logic.and lp:A lp:B }} :- !,
   propagate-Prop-constraint-inward A,
   propagate-Prop-constraint-inward B.
-propagate-Prop-constraint-inward {{ lp:A \/ lp:B }} :- !,
+propagate-Prop-constraint-inward {{ Logic.or lp:A lp:B }} :- !,
   propagate-Prop-constraint-inward A,
   propagate-Prop-constraint-inward B.
-propagate-Prop-constraint-inward {{ ~ lp:A }} :- !,
+propagate-Prop-constraint-inward {{ Logic.not lp:A }} :- !,
   propagate-Prop-constraint-inward A.
 propagate-Prop-constraint-inward (uvar as X) :- !,
   coq.typecheck X {{ Prop }} ok.

--- a/elpi/dune
+++ b/elpi/dune
@@ -1,6 +1,9 @@
 (coq.theory
  (name elpi_elpi) ; FIXME
- (package coq-elpi))
+ (package coq-elpi)
+ (stdlib no)
+ (theories Coq)
+ )
 
 (rule
  (target dummy.v)

--- a/examples/dune
+++ b/examples/dune
@@ -2,6 +2,8 @@
  (package coq-elpi)
  (name elpi_examples)
  (plugins coq-elpi.elpi)
- (theories elpi))
+ (theories elpi Coq)
+ (stdlib no)
+ )
 
 ; (include_subdirs qualified)

--- a/examples/example_abs_evars.v
+++ b/examples/example_abs_evars.v
@@ -1,3 +1,4 @@
+From Coq Require Import Prelude.
 From elpi Require Import elpi.
 
 (** Closing a term with holes with binders *)

--- a/examples/example_curry_howard_tactics.v
+++ b/examples/example_curry_howard_tactics.v
@@ -1,3 +1,4 @@
+From Coq Require Import Prelude.
 From elpi Require Import elpi.
 
 (* Tactics 

--- a/examples/example_fuzzer.v
+++ b/examples/example_fuzzer.v
@@ -1,3 +1,4 @@
+From Coq Require Import Prelude.
 From elpi Require Import elpi.
 
 (** Intrinsically typed data type and semantics, from software foundations.

--- a/examples/example_generalize.v
+++ b/examples/example_generalize.v
@@ -1,3 +1,4 @@
+From Coq Require Import Prelude.
 From elpi Require Import elpi.
 
 (** Abstract a term over something, like the generalize tactic *)

--- a/examples/example_import_projections.v
+++ b/examples/example_import_projections.v
@@ -1,3 +1,4 @@
+From Coq Require Import Prelude.
 From elpi Require Import elpi.
 
 (* "import" a record instance by naming it's applied projections *)

--- a/examples/example_record_expansion.v
+++ b/examples/example_record_expansion.v
@@ -1,3 +1,4 @@
+From Coq Require Import Datatypes Logic.
 From elpi Require Import elpi.
 
 (**

--- a/examples/example_record_to_sigma.v
+++ b/examples/example_record_to_sigma.v
@@ -1,3 +1,4 @@
+From Coq Require Import Datatypes Logic Specif.
 From elpi Require Import elpi.
 
 (* Define a command to turn records into nested sigma types, suggested

--- a/examples/example_reduction_surgery.v
+++ b/examples/example_reduction_surgery.v
@@ -3,6 +3,7 @@
    from a given module.
 *)
 
+From Coq Require Import Prelude.
 From elpi Require Import elpi.
 
 Elpi Tactic reduce.

--- a/examples/example_reflexive_tactic.v
+++ b/examples/example_reflexive_tactic.v
@@ -9,6 +9,7 @@
 
 *)
 
+From Coq Require Import Prelude.
 From elpi Require elpi.
 Require Arith ZArith Psatz List ssreflect.
 

--- a/examples/tutorial_coq_elpi_HOAS.v
+++ b/examples/tutorial_coq_elpi_HOAS.v
@@ -45,6 +45,7 @@ HOAS for Gallina
 
 |*)
 
+From Coq Require Import Prelude.  (* .none *)
 From elpi Require Import elpi.  (* .none *)
 
 Elpi Command tutorial_HOAS. (* .none *)

--- a/examples/tutorial_coq_elpi_command.v
+++ b/examples/tutorial_coq_elpi_command.v
@@ -44,6 +44,7 @@ Let's create a simple command, called "hello", which prints :e:`"Hello"`
 followed by the arguments we pass to it:
 
 |*)
+From Coq Require Import Prelude.
 From elpi Require Import elpi.
 
 Elpi Command hello.

--- a/examples/tutorial_coq_elpi_tactic.v
+++ b/examples/tutorial_coq_elpi_tactic.v
@@ -55,6 +55,7 @@ Let's define a simple tactic that prints the current goal.
 
 |*)
 
+From Coq Require Import Prelude.
 From elpi Require Import elpi.
 
 Elpi Tactic show.

--- a/theories/dune
+++ b/theories/dune
@@ -2,7 +2,9 @@
  (name elpi)
  (package coq-elpi)
  (plugins coq-elpi.elpi)
- (theories elpi_elpi))
+ (theories elpi_elpi Coq)
+ (stdlib no)
+ )
 
 (rule
  (target elpi.v)


### PR DESCRIPTION
This makes some changes throughout the build script to replace the automatic importing of the Prelude everywhere with an explicit, qualified importation, as part of an attempt to track down why `Require Elpi` has the effect of `Require Prelude`.

After changing the dune files it seems clear that we cannot remove the dependence on the `Prelude` without removing the dependence on the `String` module, so I will hold off on doing anything further until someone can suggest a workaround to using `String` in the build script.