### PR TITLE
apply tactic, similar to rewrite

### DIFF
--- a/apps/eltac/tests/test_apply.v
+++ b/apps/eltac/tests/test_apply.v
@@ -1,0 +1,11 @@
+From elpi.apps Require Import eltac.apply.
+Goal (forall (x y : nat), x + y = y + x) -> (forall y, 3 + y = y + 3).
+Proof.
+    intro H.
+    eltac.apply H.
+Qed.
+
+Goal (3 + 4 = 4 + 3).
+Proof.
+    eltac.apply PeanoNat.Nat.add_comm.
+Qed.

--- a/apps/eltac/theories/apply.v
+++ b/apps/eltac/theories/apply.v
@@ -7,7 +7,6 @@ Elpi Accumulate lp:{{
     apply T _ G GL :- refine T G GL.
 
     apply Term (prod _ A B) G GL :-
-        Hole = {{ _ }},
         coq.typecheck Hole A ok,
         whd (app [Term, Hole]) [] HD ARGS,
         unwind HD ARGS Term',
@@ -16,9 +15,7 @@ Elpi Accumulate lp:{{
     apply _ _ _ _ :- coq.ltac.fail _ "Couldn't unify type of term with goal".
         
     solve (goal Ctx _ _ _ [trm T] as G) GL :-
-        (% T is a direct reference to a global definition or axiom
-        T = global Gref, coq.env.typeof Gref Ty;
-        % T is a direct Gallina term and we will infer its type
+        (% T is a direct Gallina term and we will infer its type
         % from context
         coq.typecheck T Ty ok;
         % Eq is a reference to a declared variable in the context

--- a/apps/eltac/theories/apply.v
+++ b/apps/eltac/theories/apply.v
@@ -6,8 +6,7 @@ Elpi Accumulate lp:{{
 
     apply T _ G GL :- refine T G GL.
 
-    apply Term (prod _ A B) G GL :-
-        coq.typecheck Hole A ok,
+    apply Term (prod _ _ B) G GL :-
         whd (app [Term, Hole]) [] HD ARGS,
         unwind HD ARGS Term',
         apply Term' (B Hole) G GL.

--- a/apps/eltac/theories/apply.v
+++ b/apps/eltac/theories/apply.v
@@ -15,9 +15,7 @@ Elpi Accumulate lp:{{
     solve (goal Ctx _ _ _ [trm T] as G) GL :-
         (% T is a direct Gallina term and we will infer its type
         % from context
-        coq.typecheck T Ty ok;
-        % Eq is a reference to a declared variable in the context
-        std.mem Ctx (decl T _ Ty)),
+        std.assert-ok! (coq.typecheck T Ty) "Illtyped argument",
        
         apply T Ty G GL.
 }}.

--- a/apps/eltac/theories/apply.v
+++ b/apps/eltac/theories/apply.v
@@ -13,8 +13,6 @@ Elpi Accumulate lp:{{
     apply _ _ _ _ :- coq.ltac.fail _ "Couldn't unify type of term with goal".
 
     solve (goal Ctx _ _ _ [trm T] as G) GL :-
-        (% T is a direct Gallina term and we will infer its type
-        % from context
         std.assert-ok! (coq.typecheck T Ty) "Illtyped argument",
        
         apply T Ty G GL.

--- a/apps/eltac/theories/apply.v
+++ b/apps/eltac/theories/apply.v
@@ -4,15 +4,14 @@ Elpi Tactic apply.
 Elpi Accumulate lp:{{
     pred apply i:term, i:term, o:goal, o:list sealed-goal.
 
-    apply T _ G GL :- refine T G GL.
+    apply T _ G GL :- refine T G GL, !.
 
-    apply Term (prod _ _ B) G GL :-
-        whd (app [Term, Hole]) [] HD ARGS,
-        unwind HD ARGS Term',
-        apply Term' (B Hole) G GL.
+    apply Term Ty G GL :-
+        whd Ty [] (prod _ _ B) [],
+        apply {coq.mk-app Term [Hole]} (B Hole) G GL.
 
     apply _ _ _ _ :- coq.ltac.fail _ "Couldn't unify type of term with goal".
-        
+
     solve (goal Ctx _ _ _ [trm T] as G) GL :-
         (% T is a direct Gallina term and we will infer its type
         % from context

--- a/apps/eltac/theories/apply.v
+++ b/apps/eltac/theories/apply.v
@@ -1,0 +1,30 @@
+From elpi Require Export elpi.
+
+Elpi Tactic apply.
+Elpi Accumulate lp:{{
+    pred apply i:term, i:term, o:goal, o:list sealed-goal.
+
+    apply T _ G GL :- refine T G GL.
+
+    apply Term (prod _ A B) G GL :-
+        Hole = {{ _ }},
+        coq.typecheck Hole A ok,
+        whd (app [Term, Hole]) [] HD ARGS,
+        unwind HD ARGS Term',
+        apply Term' (B Hole) G GL.
+
+    apply _ _ _ _ :- coq.ltac.fail _ "Couldn't unify type of term with goal".
+        
+    solve (goal Ctx _ _ _ [trm T] as G) GL :-
+        (% T is a direct reference to a global definition or axiom
+        T = global Gref, coq.env.typeof Gref Ty;
+        % T is a direct Gallina term and we will infer its type
+        % from context
+        coq.typecheck T Ty ok;
+        % Eq is a reference to a declared variable in the context
+        std.mem Ctx (decl T _ Ty)),
+       
+        apply T Ty G GL.
+}}.
+
+Tactic Notation "eltac.apply" constr(T) := elpi apply ltac_term:(T).

--- a/apps/eltac/theories/tactics.v
+++ b/apps/eltac/theories/tactics.v
@@ -1,4 +1,5 @@
 From elpi.apps.eltac Require Export
+  apply
   intro
   constructor
   assumption


### PR DESCRIPTION
Let me know if you can suggest useful ways to eliminate duplication here between apply and rewrite, both of them are doing the same thing where they traverse nested foralls.

Is repeatedly calling `refine` and failing inefficient? I have no idea.

I would also be interested if you have suggestions for making it stronger, it would be nice to have it behave as 
"if the type of term `f` is *unifiable* with `forall (x : A), B`, then recursively apply `f _`. But I don't know how to check that checks whether a type is unifiable with a product type.