### PR TITLE
fix(ci.yml): Use `coqorg/coq:8.20` as a future-proof image name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
-          - 'coqorg/coq:8.20.0'
+          - 'coqorg/coq:8.20'
       fail-fast: false  # don't stop jobs if one fails
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Given 8.20.0 has been replaced with 8.20.1
while both images share the 8.20 tag shorthand.

Cc @proux01