### PR TITLE
Make pos_eq_dec transparent

### DIFF
--- a/apps/derive/theories/derive/eqb_core_defs.v
+++ b/apps/derive/theories/derive/eqb_core_defs.v
@@ -30,7 +30,7 @@ Definition eqax_on (eqb : A -> A -> bool) (a1:A) :=
 End Section.
 
 Lemma pos_eq_dec : forall x y:positive, {x = y} + {x <> y}.
-Proof. decide equality. Qed.
+Proof. decide equality. Defined.
 
 Theorem UIP_dec (A : Type) (eq_dec : forall x y : A, {x = y} + {x <> y}) :
   forall (x y : A) (p1 p2 : x = y), p1 = p2.


### PR DESCRIPTION
PR https://github.com/LPCIC/coq-elpi/pull/767 replaced `Pos.eq_dec` coming from stdlib with `pos_eq_dec` defined locally. But the former is transparent, while the latter is opaque. This makes `eqb_body` not compute, which is painful.