### PR TITLE
Declare compatibility constant as canonical gref for primitive projections

### DIFF
--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -510,6 +510,7 @@ coq.term->gref (global GR) GR :- !.
 coq.term->gref (pglobal GR _) GR :- !.
 coq.term->gref (app [Hd|_]) GR :- !, coq.term->gref Hd GR.
 coq.term->gref (let _ _ T x\x) GR :- !, coq.term->gref T GR.
+coq.term->gref (primitive (proj Proj _)) GR :- !, primitive-projection? Proj GR.
 :name "term->gref:fail"
 coq.term->gref Term _ :-
   fatal-error-w-data "term->gref: input has no global reference" Term.

--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -510,7 +510,7 @@ coq.term->gref (global GR) GR :- !.
 coq.term->gref (pglobal GR _) GR :- !.
 coq.term->gref (app [Hd|_]) GR :- !, coq.term->gref Hd GR.
 coq.term->gref (let _ _ T x\x) GR :- !, coq.term->gref T GR.
-coq.term->gref (primitive (proj Proj _)) GR :- !, primitive-projection? Proj GR.
+coq.term->gref (primitive (proj Proj _)) (const C) :- coq.env.primitive-projection? Proj C, !.
 :name "term->gref:fail"
 coq.term->gref Term _ :-
   fatal-error-w-data "term->gref: input has no global reference" Term.


### PR DESCRIPTION
As of now, we can not obtain a gref out of a primitive projection, although the compatibility constant is a canonical gref associated to it. This is useful when we want to turn a term into a cs-pattern (although I guess I could also add a clause to the latter predicate).