### PR TITLE
Give constant to every primitive projection

### DIFF
--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -510,7 +510,7 @@ coq.term->gref (global GR) GR :- !.
 coq.term->gref (pglobal GR _) GR :- !.
 coq.term->gref (app [Hd|_]) GR :- !, coq.term->gref Hd GR.
 coq.term->gref (let _ _ T x\x) GR :- !, coq.term->gref T GR.
-coq.term->gref (primitive (proj Proj _)) (const C) :- coq.env.primitive-projection? Proj C, !.
+coq.term->gref (primitive (proj Proj _)) (const C) :- coq.env.primitive-projection? Proj C _, !.
 :name "term->gref:fail"
 coq.term->gref Term _ :-
   fatal-error-w-data "term->gref: input has no global reference" Term.

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -2363,11 +2363,8 @@ denote the same x as before.|};
   MLCode(Pred("coq.env.primitive-projection?",
     In(projection, "Projection",
     Out(constant, "Compatibility constant",
-    Easy "relates a projection to its compatibility constant.")),
-    (fun p _ ~depth ->
-      let c = Projection.constant p in 
-      try !: (ignore (Structures.Structure.find_from_projection c); Constant c)
-      with Not_found -> raise No_clause)),
+    Easy "relates a primitive projection to its compatibility constant.")),
+    (fun p _ ~depth -> !: (Constant (Projection.constant p)))),
   DocAbove);
 
   LPDoc "-- Sorts (and their universe level, if applicable) ----------------";

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -2363,14 +2363,15 @@ denote the same x as before.|};
   MLCode(Pred("coq.env.primitive-projection?",
     InOut(B.ioarg projection, "Projection",
     InOut(B.ioarg constant, "Compatibility constant",
-    Read(global, "Relates a primitive projection to its compatibility constant."))),
-    (fun p c ~depth coq_context _ _ ->
+    Out(int, "Index",
+    Read(global, "Relates a primitive projection to its compatibility constant and its index in the record.")))),
+    (fun p c _ ~depth coq_context _ _ ->
       match p, c with
       | _, Data (Variable c) -> raise No_clause
       | Data p, Data (Constant c) ->
-          if Constant.equal (Projection.constant p) c then ?: None +? None else raise No_clause
+          if Constant.equal (Projection.constant p) c then ?: None +? None +! Names.Projection.(arg p + npars p) else raise No_clause
       | NoData, NoData -> U.type_error "coq.env.primitive-projection?: got no input data"
-      | Data p, NoData -> ?: None +! (Constant (Projection.constant p))
+      | Data p, NoData -> ?: None +! (Constant (Projection.constant p)) +! Names.Projection.(arg p + npars p)
       | NoData, Data (Constant c) ->
           (match Environ.constant_opt_value_in coq_context.env (UVars.in_punivs c) with
           | None -> raise No_clause
@@ -2381,7 +2382,9 @@ denote the same x as before.|};
               | App (hd, _) -> get_proj hd
               | Proj (p, _, _) -> p
               | _ -> raise No_clause
-            in !: (get_proj p) +? None))),
+            in
+            let p = get_proj p in
+            !: p +? None +! Names.Projection.(arg p + npars p)))),
   DocAbove);
 
   LPDoc "-- Sorts (and their universe level, if applicable) ----------------";

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -2361,10 +2361,27 @@ denote the same x as before.|};
   DocAbove);
 
   MLCode(Pred("coq.env.primitive-projection?",
-    In(projection, "Projection",
-    Out(constant, "Compatibility constant",
-    Easy "relates a primitive projection to its compatibility constant.")),
-    (fun p _ ~depth -> !: (Constant (Projection.constant p)))),
+    InOut(B.ioarg projection, "Projection",
+    InOut(B.ioarg constant, "Compatibility constant",
+    Read(global, "Relates a primitive projection to its compatibility constant."))),
+    (fun p c ~depth coq_context _ _ ->
+      match p, c with
+      | _, Data (Variable c) -> raise No_clause
+      | Data p, Data (Constant c) ->
+          if Constant.equal (Projection.constant p) c then ?: None +? None else raise No_clause
+      | NoData, NoData -> U.type_error "coq.env.primitive-projection?: got no input data"
+      | Data p, NoData -> ?: None +! (Constant (Projection.constant p))
+      | NoData, Data (Constant c) ->
+          (match Environ.constant_opt_value_in coq_context.env (UVars.in_punivs c) with
+          | None -> raise No_clause
+          | Some p ->
+            let rec get_proj c =
+              match Constr.kind c with
+              | Lambda (_, _, t) -> get_proj t
+              | App (hd, _) -> get_proj hd
+              | Proj (p, _, _) -> p
+              | _ -> raise No_clause
+            in !: (get_proj p) +? None))),
   DocAbove);
 
   LPDoc "-- Sorts (and their universe level, if applicable) ----------------";
@@ -2758,6 +2775,17 @@ Supported attributes:
            let _, { CanonicalSolution.constant } = CanonicalSolution.find env sigma (p,v) in
            !: [{ CSTable.projection = p; value = v; solution = fst @@ EConstr.destRef sigma constant }]
          with Not_found -> !: [])),
+  DocAbove);
+
+  MLCode(Pred("coq.CS.canonical-projection?",
+    In(constant, "Projection",
+    Easy "Tells if the projection can be used for CS inference."),
+    (fun c ~depth ->
+      match c with
+      | Variable _ -> raise No_clause
+      | Constant c ->
+        try ignore (Structures.Structure.find_from_projection c)
+        with Not_found -> raise No_clause)),
   DocAbove);
 
   MLCode(Pred("coq.TC.declare-class",

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -2364,7 +2364,7 @@ denote the same x as before.|};
     InOut(B.ioarg projection, "Projection",
     InOut(B.ioarg constant, "Compatibility constant",
     Out(int, "Index",
-    Read(global, "Relates a primitive projection to its compatibility constant and its index in the record.")))),
+    Read(global, "Relates a primitive projection to its compatibility constant. Index is set to the constructor argument extracted by the projection (starting from 0).")))),
     (fun p c _ ~depth coq_context _ _ ->
       match p, c with
       | _, Data (Variable c) -> raise No_clause

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -221,7 +221,7 @@ Module P''.
 
   Elpi Query  lp:{{
     app[primitive (proj P _) | _] = {{X.(proj1 _)}},
-    coq.env.primitive-projection? P C,
+    coq.env.primitive-projection? P C _,
     global (const C) = {{proj1}}.
   }}.
 


### PR DESCRIPTION
Followup to https://github.com/LPCIC/coq-elpi/pull/790, because I do need the compatibility constant for every primitive projection, not only for canonical ones.
@gares Should I add another predicate?