### PR TITLE
Increase a test timeout

### DIFF
--- a/tests-stdlib/test_API_env.v
+++ b/tests-stdlib/test_API_env.v
@@ -340,7 +340,7 @@ Elpi Query lp:{{
   coq.locate "Ranalysis5.derivable_pt_lim_CVU" GR,
   std.time (coq.env.transitive-dependencies GR _ S) T,
   std.assert! ({coq.gref.set.cardinal S} > 3000) "too few",
-  std.assert! (T < 10.0) "too slow" % 0.5 here
+  std.assert! (T < 20.0) "too slow" % 0.5 here
 
 }}.
 


### PR DESCRIPTION
@gares A test timeout introduced from commit 83acc878421351cf91f34aaa401bf538c76ed3b7 might be too short on riscv64:
https://buildd.debian.org/status/fetch.php?pkg=coq-elpi&arch=riscv64&ver=2.5.0-1%2Bb1&stamp=1749981311&raw=0
```
File "./tests-stdlib/test_API_env.v", line 338, characters 0-235:
Error:
too slow: 10.899094 < 10.000000
```