### PR TITLE
derive: remove leftover debug bits

### DIFF
--- a/apps/derive/elpi/eqbcorrect.elpi
+++ b/apps/derive/elpi/eqbcorrect.elpi
@@ -417,7 +417,7 @@ search What Rec (app [GR|L] as GRL) R :- !, std.do! [
 ].
 % no params, no aux lemma (no reali argument)
 search What _Rec (global GR as GRL) {{ fun (x : lp:GRL) (_ : lp:IsGR x) => lp:R x }} :-
-  std.spy(What (global GR) R),
+  What (global GR) R,
   mk-reali (global GR) IsGR, !.
 search What _ X _ :- coq.safe-dest-app X HD _, std.assert! (What HD _) "run eqbcorrect before".
 

--- a/apps/derive/elpi/param1_inhab.elpi
+++ b/apps/derive/elpi/param1_inhab.elpi
@@ -2,7 +2,7 @@
 /* license: GNU Lesser General Public License Version 2.1 or later           */
 /* ------------------------------------------------------------------------- */
 
-shorten std.{zip, assert!, spy-do!, do!, map, map2, rev}.
+shorten std.{zip, assert!, do!, map, map2, rev}.
 
 namespace derive.param1.inhab {
 

--- a/apps/derive/elpi/param1_trivial.elpi
+++ b/apps/derive/elpi/param1_trivial.elpi
@@ -2,7 +2,7 @@
 /* license: GNU Lesser General Public License Version 2.1 or later           */
 /* ------------------------------------------------------------------------- */
 
-shorten std.{assert!, spy-do!, do!, drop-last}.
+shorten std.{assert!, do!, drop-last}.
 
 namespace derive.param1.trivial {
 


### PR DESCRIPTION
#848 introduced some `spy` that I guess should not have landed in master.