### PR TITLE
collect-goals for primitive projections

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,9 @@ Requires Elpi 3.0.0 and Coq 8.20 or Rocq 9.0 or Rocq 9.1.
 ### APPS:
 - New experimental app `rbuild`: build any record with « ... »
 
+### API
+- `coq.ltac.collect-goals` now takes the parameters of primitive projections into account
+
 # [2.6.0] 8/7/2025
 
 Requires Elpi 2.0.7 and Coq 8.20 or Rocq 9.0 or Rocq 9.1.


### PR DESCRIPTION
As things stand, collecting goals in a primitive projection does not take the parameters into account. I do not know any other way than retyping to access the parameters. There is also an infinite loop because one of said parameters may mention the projection in its context. I know there is a way to make an evar appear in its own type, so there is probably a way to make it appear in its context, which would trigger the loop without using primitive projections.