### PR TITLE
Fold with binders in collect-goals

### DIFF
--- a/elpi/elpi-ltac.elpi
+++ b/elpi/elpi-ltac.elpi
@@ -87,10 +87,10 @@ open T (nabla G) O :- (pi x\ open T (G x) (NG x)), private.distribute-nabla NG O
 open _ (seal (goal _ _ _ Solution _)) [] :- not (var Solution), !. % solved by side effect
 open T (seal (goal Ctx _ _ _ _ as G)) O :-
   std.filter Ctx private.not-already-assumed Ctx1,
-  (Ctx1 => T G O),
-  if (var O)
-     (G = goal _ _ _ P _, coq.ltac.collect-goals P O1 O2, std.append O1 O2 O)
-     true.
+  Ctx1 => (T G O,
+    if (var O)
+       (G = goal _ _ _ P _, coq.ltac.collect-goals P O1 O2, std.append O1 O2 O)
+       true).
 
 % helper code ---------------------------------------------------------------
 

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -3898,7 +3898,6 @@ fold_left over the terms, letin body comes before the type).
       let sigma = get_sigma state in
       let evars_of_term c =
         let rec evrec env (acc_set,acc_rev_l as acc) c =
-          let c = EConstr.whd_evar sigma c in
           match EConstr.kind sigma c with
           | Constr.Evar (n, l) ->
             if Evar.Set.mem n acc_set then


### PR DESCRIPTION
There is a bug in `coq.collect-goals` because we do not update the environment when traversing a term, so typechecking a term referencing a local variable fails.
There is also an issue in `coq.ltac.open`, which does not declare the local variables before calling `coq.collect-goals`.