### PR TITLE
Adapt to rocq-prover/rocq#21161 (parametrize typeclass interface by i…

### DIFF
--- a/apps/tc/src/rocq_elpi_class_tactics_takeover.ml
+++ b/apps/tc/src/rocq_elpi_class_tactics_takeover.ml
@@ -102,7 +102,8 @@ module Modes = struct
 end
 
 module Solver = struct
-  let solve_TC program = let open Class_tactics in { solver = fun env sigma ~depth ~unique ~best_effort ~goals ->
+
+  let solve_TC_solver = fun program env sigma ~depth ~unique ~best_effort ~goals ->
     let atts = [] in
     let gls = goals in
     let query ~base state =
@@ -127,7 +128,16 @@ module Solver = struct
         | API.Execute.NoMoreSteps -> CErrors.user_err Pp.(str "elpi run out of steps")
         | API.Execute.Failure -> elpi_fails program
         | exception (Rocq_elpi_utils.LtacFail (level, msg)) -> raise Not_found
+
+  [%%if coq = "8.20" || coq = "9.0" || coq = "9.1"]
+  let solve_TC program = let open Class_tactics in { solver = fun env sigma ~depth ~unique ~best_effort ~goals ->
+      solve_TC_solver program env sigma ~depth ~unique ~best_effort ~goals
   }
+  [%%else]
+  let solve_TC program = let open Class_tactics in { solver = fun ?db env sigma ~depth ~unique ~best_effort ~goals ->
+      solve_TC_solver program env sigma ~depth ~unique ~best_effort ~goals
+  }
+  [%%endif]
 
   type action = 
     | Create


### PR DESCRIPTION
…ts DB of hints to allow the use of other DBs)

The typeclass API now expect the ~db optional argument. This is used to invoke typeclass inference on other dbs than typeclass_instances.