### PR TITLE
Adapt to rocq#21180

### DIFF
--- a/tests-stdlib/test_quotation.v
+++ b/tests-stdlib/test_quotation.v
@@ -78,7 +78,9 @@ Elpi Query lp:{{ std.do! [
 
   std.assert-ok! (coq.elaborate-skeleton T _ T1) "does not typecheck",
   T1 = {{ fun u => SubType _ _ _ _ lp:(X u) _ }},
-  (@pi-decl _ {{ nat }} u\ coq.unify-eq (X u) {{ lp:K lp:u }} ok),
+  (pi u\ X u = app[global GR, u]) % Rocq <= 9.1
+  ;
+  (pi u\ X u = fun _ _ v\ fun _ _ w\ app[global GR, u, v, w]), % Rocq > 9.1
   std.assert! (K = global GR, coq.locate "Ord" GR) "not the right constructor"
 ]
 }}.


### PR DESCRIPTION
In one of the tests, https://github.com/rocq-prover/rocq/pull/21180 encounters a non-pattern fragment unification problem and produces an eta-expansion that breaks Rocq-Elpi's unifier. 