### PR TITLE
Adapt to rocq-prover/rocq#21630 (interp_sign moved to tacinterp)

### DIFF
--- a/src/rocq_elpi_arg_HOAS.ml
+++ b/src/rocq_elpi_arg_HOAS.ml
@@ -9,6 +9,7 @@ module CD = API.RawOpaqueData
 open Rocq_elpi_utils
 open Rocq_elpi_HOAS
 open Names
+open Ltac_plugin.Tacinterp
 
 type phase = Interp | Synterp | Both
 type proof =
@@ -68,11 +69,11 @@ type top_term =
 
 type raw_record_decl = Vernacentries.Preprocessed_Mind_decl.record
 type glob_record_decl = Genintern.glob_sign * raw_record_decl
-type top_record_decl = Geninterp.interp_sign * glob_record_decl
+type top_record_decl = interp_sign * glob_record_decl
 
 type raw_indt_decl = Vernacentries.Preprocessed_Mind_decl.inductive
 type glob_indt_decl = Genintern.glob_sign * raw_indt_decl
-type top_indt_decl = Geninterp.interp_sign * glob_indt_decl
+type top_indt_decl = interp_sign * glob_indt_decl
 
 type univpoly = Mono | Poly | CumulPoly
 
@@ -165,7 +166,7 @@ type glob_constant_decl_elpi = {
   body : Glob_term.glob_constr option;
 }
 type glob_constant_decl = Genintern.glob_sign * raw_constant_decl
-type top_constant_decl = Geninterp.interp_sign * glob_constant_decl
+type top_constant_decl = interp_sign * glob_constant_decl
 
 let pr_raw_constant_decl _ _ _ = Pp.str "TODO: pr_raw_constant_decl"
 let pr_glob_constant_decl _ _ _ = Pp.str "TODO: pr_glob_constant_decl"
@@ -174,7 +175,7 @@ let pr_top_constant_decl _ _ _ = Pp.str "TODO: pr_top_constant_decl"
 
 type raw_context_decl = Constrexpr.local_binder_expr list
 type glob_context_decl = Genintern.glob_sign * raw_context_decl
-type top_context_decl = Geninterp.interp_sign * glob_context_decl
+type top_context_decl = interp_sign * glob_context_decl
 
 let pr_raw_context_decl _ _ _ = Pp.str "TODO: pr_raw_context_decl"
 let pr_glob_context_decl _ _ _ = Pp.str "TODO: pr_glob_context_decl"
@@ -580,11 +581,11 @@ module Tac = struct
 
 type raw_term = Constrexpr.constr_expr
 type glob_term = Genintern.glob_constr_and_expr
-type top_term = Geninterp.interp_sign * Genintern.glob_constr_and_expr
+type top_term = interp_sign * Genintern.glob_constr_and_expr
 
 type raw_ltac_term = Constrexpr.constr_expr
 type glob_ltac_term = Glob_term.glob_constr
-type top_ltac_term = Geninterp.interp_sign * Names.Id.t
+type top_ltac_term = interp_sign * Names.Id.t
 
 type raw_ltac_tactic = Ltac_plugin.Tacexpr.raw_tactic_expr
 type glob_ltac_tactic = Ltac_plugin.Tacexpr.glob_tactic_expr
@@ -1093,7 +1094,7 @@ let in_elpi_tac ~loc ~base ~depth ?calldepth coq_ctx hyps sigma state x =
   match x with
   | LTacTactic t -> in_elpi_ltac_tactic ~depth ?calldepth coq_ctx hyps sigma state t
   | LTac(ty,(ist,id)) ->
-      let v = try Id.Map.find id ist.Geninterp.lfun with Not_found -> assert false in
+      let v = try Id.Map.find id ist.lfun with Not_found -> assert false in
       begin try
         in_elpi_ltac_arg ~loc ~depth ~base ?calldepth coq_ctx hyps sigma state ty ist v
       with Ltac_plugin.Taccoerce.CannotCoerceTo s ->

--- a/src/rocq_elpi_arg_HOAS.mli
+++ b/src/rocq_elpi_arg_HOAS.mli
@@ -4,6 +4,7 @@
 
 open Elpi.API.RawData
 open Rocq_elpi_utils
+open Ltac_plugin.Tacinterp
 
 type phase = Interp | Synterp | Both
 type proof =
@@ -18,11 +19,11 @@ type top_term = Ltac_plugin.Tacinterp.interp_sign * Genintern.glob_constr_and_ex
 
 type raw_record_decl = Vernacentries.Preprocessed_Mind_decl.record
 type glob_record_decl = Genintern.glob_sign * raw_record_decl
-type top_record_decl = Geninterp.interp_sign * glob_record_decl
+type top_record_decl = interp_sign * glob_record_decl
 
 type raw_indt_decl = Vernacentries.Preprocessed_Mind_decl.inductive
 type glob_indt_decl = Genintern.glob_sign * raw_indt_decl
-type top_indt_decl = Geninterp.interp_sign * glob_indt_decl
+type top_indt_decl = interp_sign * glob_indt_decl
 
 [%%if coq = "9.0" || coq = "9.1"]
 type raw_red_expr = Genredexpr.raw_red_expr
@@ -41,11 +42,11 @@ type raw_constant_decl = {
 
 val pr_raw_constant_decl : Environ.env -> Evd.evar_map -> raw_constant_decl -> Pp.t
 type glob_constant_decl = Genintern.glob_sign * raw_constant_decl
-type top_constant_decl = Geninterp.interp_sign * glob_constant_decl
+type top_constant_decl = interp_sign * glob_constant_decl
 
 type raw_context_decl = Constrexpr.local_binder_expr list
 type glob_context_decl = Genintern.glob_sign * raw_context_decl
-type top_context_decl = Geninterp.interp_sign * glob_context_decl
+type top_context_decl = interp_sign * glob_context_decl
 
 type ('a,'b,'c,'d,'e) t =
   | Int : int            -> ('a,'b,'c,'d,'e) t
@@ -65,7 +66,7 @@ val pp_glob : Environ.env -> Evd.evar_map -> glob -> Pp.t
 val pp_top : Environ.env -> Evd.evar_map -> top -> Pp.t
 
 val glob : Genintern.glob_sign -> raw -> glob
-val interp : Geninterp.interp_sign -> Environ.env -> Evd.evar_map -> glob -> top
+val interp : interp_sign -> Environ.env -> Evd.evar_map -> glob -> top
 val subst : Mod_subst.substitution -> glob -> glob
  
 end
@@ -74,11 +75,11 @@ module Tac : sig
 
 type raw_term = Constrexpr.constr_expr
 type glob_term = Genintern.glob_constr_and_expr
-type top_term = Geninterp.interp_sign * Genintern.glob_constr_and_expr
+type top_term = interp_sign * Genintern.glob_constr_and_expr
 
 type raw_ltac_term = Constrexpr.constr_expr
 type glob_ltac_term = Glob_term.glob_constr
-type top_ltac_term = Geninterp.interp_sign * Names.Id.t
+type top_ltac_term = interp_sign * Names.Id.t
 
 type raw_ltac_tactic = Ltac_plugin.Tacexpr.raw_tactic_expr
 type glob_ltac_tactic = Ltac_plugin.Tacexpr.glob_tactic_expr

--- a/src/rocq_elpi_vernacular.mli
+++ b/src/rocq_elpi_vernacular.mli
@@ -5,6 +5,7 @@
 open Rocq_elpi_utils
 open Rocq_elpi_programs
 open Rocq_elpi_arg_HOAS
+open Ltac_plugin
 
 val atts2impl :
   depth:int -> Elpi.API.Ast.Loc.t -> Summary.Stage.t -> Elpi.API.State.t -> Attributes.vernac_flags ->
@@ -64,8 +65,8 @@ val document_builtins : unit -> unit
 
 
 
-val run_tactic : loc:Loc.t -> qualified_name -> atts:Attributes.vernac_flags -> Geninterp.interp_sign -> Tac.top list -> unit Proofview.tactic
-val run_in_tactic : loc:Loc.t -> ?program:qualified_name -> Elpi.API.Ast.Loc.t * string -> Geninterp.interp_sign -> unit Proofview.tactic
+val run_tactic : loc:Loc.t -> qualified_name -> atts:Attributes.vernac_flags -> Tacinterp.interp_sign -> Tac.top list -> unit Proofview.tactic
+val run_in_tactic : loc:Loc.t -> ?program:qualified_name -> Elpi.API.Ast.Loc.t * string -> Tacinterp.interp_sign -> unit Proofview.tactic
 
 (* move to synterp *)
 val export_command : atts:proof option -> ?as_:qualified_name -> qualified_name -> unit


### PR DESCRIPTION
It was already reexported in tacinterp so this should be backwards compatible