### PR TITLE
names carry the relevance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,11 @@
 
 ### HOAS:
 - New `minductive` and `mblock` for mutual inductive types
+- New the `name` data type carries a relevance (as in Rocq). Quotations
+  default to "relevant" as before, while omitted biner names are mapped to
+  Rocq relevance variables, that can be set by the typechecker.
+  Similarly `coq.id->name` leaves the relevance unset, and `coq.name-suffix`
+  preserves the orignal relevance.
 
 ### API:
 - fix `coq.CS.canonical-projection?`, used to disregard `#[canonical=no]`
@@ -10,6 +15,7 @@
 - New `coq.elpi.add-predicate?` to check if a predicate is declared in elpi
 - New `coq.env.indt-block` to list the inductive types in the same
   mutual block
+- New `coq.name.relevant?` to test the relevance set by the typechecker
 
 ### LIB:
 - Change `coq.build-indt-decl`, now taking a `coq.indt-spec` tuple

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -1814,12 +1814,17 @@ kind name type.
 % an int or another name
 external func coq.name-suffix name, any -> name.
 
-% [coq.string->name Hint Name] creates a name hint
+% [coq.string->name Hint Name] creates a name hint using a relevance
+% variable
 external func coq.string->name string -> name.
+
+% [coq.string->name-relevant Hint Name] creates a name hint with the
+% relevant mark (see SProp)
+external func coq.string->name-relevant string -> name.
 
 
 func coq.id->name id -> name.
-coq.id->name S N :- coq.string->name S N.
+coq.id->name S N :- coq.string->name-relevant S N.
   
 
 % [coq.name->id Name Id] tuns a pretty printing hint into a string. This API

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -1826,6 +1826,10 @@ coq.id->name S N :- coq.string->name S N.
 % is for internal use, no guarantee on its behavior.
 external func coq.name->id name -> id.
 
+% [coq.name.relevant? Name Relevance] Reads the relevance mark. none means
+% unset, some tt means relevant.
+external func coq.name.relevant? name -> option bool.
+
 % [coq.gref->id GR Id] extracts the label (last component of a full kernel
 % name)
 external func coq.gref->id gref -> id.

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -2309,7 +2309,8 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
               | Projection p ->
                   let state, i, gl1 = aux ~depth state i in
                   let state, xs, gl2 = API.Utils.map_acc (aux ~depth ~on_ty:false) state xs in
-                  let state, rv = fresh_relevance_variable state in
+                  (* let state, rv = fresh_relevance_variable state in *)
+                  let rv = EC.ERelevance.relevant in
                   state, EC.mkApp (EC.mkProj (p,rv,i),Array.of_list xs), gls @ gl1 @ gl2
               | _ ->  err Pp.(str"not a primitive projection:" ++ str (E.Constants.show c))
               end

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -24,13 +24,18 @@ open Rocq_elpi_utils
 
 (* {{{ CData ************************************************************** *)
 
+type annot_name = (Name.t,EConstr.ERelevance.t) Context.pbinder_annot
+
 (* names *)
-let namein, naminc, isname, nameout, name =
+let namein, naminc, isname, nameout, (name : annot_name API.Conversion.t) =
   let { CD.cin; cino; isc; cout }, name  = CD.declare {
     CD.name = "name";
     doc = "Name.Name.t: Name hints (in binders), can be input writing a name between backticks, e.g. `x` or `_` for anonymous. Important: these are just printing hints with no meaning, hence in elpi two name are always related: `x` = `y`";
-    pp = (fun fmt x ->
-      Format.fprintf fmt "`%a`" Pp.pp_with (Name.print x));
+    pp = (fun fmt (x : annot_name) ->
+      Format.fprintf fmt "`%a:%a`"
+        Pp.pp_with (Name.print @@ Context.binder_name x)
+        Pp.pp_with ((function Sorts.Relevant -> Pp.str"r" | Sorts.Irrelevant -> Pp.str"i" | Sorts.RelevanceVar q -> Pp.str @@ Sorts.QVar.to_string q) @@ Evd.MiniEConstr.ERelevance.unsafe_to_relevance @@ Context.binder_relevance x)
+        );
     compare = (fun _ _ -> 0);
     hash = (fun _ -> 0);
     hconsed = false;
@@ -43,23 +48,13 @@ let in_elpiast_name ~loc x = A.mkOpaque ~loc @@ naminc x
 let coq_language = ref API.Quotation.elpi_language
 let set_coq coq = coq_language := coq
 let name_of_name ~loc = function
-  | Names.Name.Anonymous -> None
-  | Names.Name.Name id -> Some (API.Ast.Name.from_string @@ Names.Id.to_string id, loc, !coq_language)
+  | { Context.binder_name = Names.Name.Anonymous } -> None
+  | { Context.binder_name = Names.Name.Name id } -> Some (API.Ast.Name.from_string @@ Names.Id.to_string id, loc, !coq_language)
 
 let is_coq_name ~depth t =
   match E.look ~depth t with
   | E.CData n -> isname n || (CD.is_string n && Id.is_valid (CD.to_string n))
   | _ -> false
-
-let in_coq_name ~depth t =
-  match E.look ~depth t with
-  | E.CData n when isname n -> nameout n
-  | E.CData n when CD.is_string n ->
-     let s = CD.to_string n in
-     if s = "_" then Name.Anonymous
-     else Name.Name (Id.of_string s)
-  | E.UnifVar _ -> Name.Anonymous
-  | _ -> err Pp.(str"Not a name: " ++ str (API.RawPp.Debug.show_term t))
 
 (* engine prologue, to break ciclicity *)
 
@@ -558,31 +553,6 @@ let ast_sort ~loc = function
   | Sorts.Type u -> A.mkAppGlobal ~loc ~hdloc:loc typc (A.mkOpaque ~loc @@ univino u) []
   | _ -> assert false
 
-
-let in_coq_fresh ~id_only =
-  let mk_fresh dbl =
-    Id.of_string_soft
-      (Printf.sprintf "elpi_ctx_entry_%d_" dbl) in
-fun ~depth dbl name ~names ->
-  match in_coq_name ~depth name with
-  | Name.Anonymous when id_only -> Name.Name (mk_fresh dbl)
-  | Name.Anonymous as x -> x
-  | Name.Name id when Id.Set.mem id names -> Name.Name (mk_fresh dbl)
-  | Name.Name id as x -> x
-
-let relevant = EConstr.ERelevance.relevant
-let anonR = Context.make_annot Names.Name.Anonymous EConstr.ERelevance.irrelevant 
-let nameR x = Context.make_annot (Names.Name.Name x) EConstr.ERelevance.irrelevant 
-let annotR x = Context.make_annot x EConstr.ERelevance.irrelevant 
-    
-let in_coq_annot ~depth t = Context.make_annot (in_coq_name ~depth t) relevant
-
-let in_coq_fresh_annot_name ~depth ~coq_ctx dbl t =
-  Context.make_annot (in_coq_fresh ~id_only:false ~depth ~names:coq_ctx.names dbl t) relevant
-
-let in_coq_fresh_annot_id ~depth ~names dbl t =
-  let get_name = function Name.Name x -> x | Name.Anonymous -> assert false in
-  Context.make_annot (in_coq_fresh ~id_only:true ~depth ~names dbl t |> get_name) relevant
 
 let unspec2opt = function Elpi.Builtin.Given x -> Some x | Elpi.Builtin.Unspec -> None
 let opt2unspec = function Some x -> Elpi.Builtin.Given x | None -> Elpi.Builtin.Unspec
@@ -1223,6 +1193,60 @@ module UVMap = struct
 
 end
 
+let fresh_relevance_variable state =
+  S.update_return engine state (fun e -> 
+    let sigma, qv = Evd.new_quality_variable e.sigma in
+    let rv = Sorts.RelevanceVar qv in
+    let rv = EConstr.ERelevance.make rv in
+    { e with sigma }, rv)
+
+let mk_coq_annot state id =
+  let state, rv = fresh_relevance_variable state in
+  state, Context.make_annot (Name.Name id) rv
+
+let in_coq_name ~depth state t =
+  match E.look ~depth t with
+  | E.CData n when isname n ->
+      let name = nameout n in
+      let { sigma } = S.get engine state in
+       let name = Context.map_annot_relevance (fun x -> EConstr.ERelevance.(make (kind sigma x))) name in
+      state, name,[]
+  | E.CData n when CD.is_string n ->
+     let state, rv = fresh_relevance_variable state in
+     let s = CD.to_string n in
+     if s = "_" then
+      state, Context.make_annot Name.Anonymous rv,[]
+     else
+      state, Context.make_annot (Name.Name (Id.of_string s)) rv,[]
+  | E.UnifVar _ ->
+     let state, rv = fresh_relevance_variable state in
+     let annot = Context.make_annot Name.Anonymous rv in
+     state, annot,[API.Conversion.Unify(t,in_elpi_name annot)]
+  | _ -> err Pp.(str"Not a name: " ++ str (API.RawPp.Debug.show_term t))
+
+let in_coq_fresh ~id_only =
+  let mk_fresh dbl =
+    Id.of_string_soft
+      (Printf.sprintf "elpi_ctx_entry_%d_" dbl) in
+fun ~depth dbl name ~names state ->
+  let state, binder, gls = in_coq_name ~depth state name in
+  let binder = match binder.Context.binder_name with
+        | Name.Anonymous when id_only -> { binder with Context.binder_name = Name.Name (mk_fresh dbl) }
+        | Name.Anonymous -> binder
+        | Name.Name id when Id.Set.mem id names -> { binder with Context.binder_name = Name.Name (mk_fresh dbl) }
+        | Name.Name _ -> binder in
+  state, binder, gls
+
+let in_coq_annot ~depth state t = in_coq_name ~depth state t
+
+let in_coq_fresh_annot_name ~depth ~coq_ctx dbl state t =
+  in_coq_fresh ~id_only:false ~depth ~names:coq_ctx.names dbl state t
+
+let in_coq_fresh_annot_id ~depth ~names dbl state t =
+  let get_name (st,n,gl) = st, Context.map_annot (function Name.Name x -> x | Name.Anonymous -> assert false) n, gl in
+  in_coq_fresh ~id_only:true ~depth ~names dbl t state |> get_name
+
+
 let section_ids env =
     let named_ctx = Environ.named_context env in
     Context.Named.fold_inside
@@ -1671,25 +1695,25 @@ let rec constr2lp coq_ctx ~calldepth ~depth state t =
     | C.Cast (t,_,ty0) ->
          let state, t = aux ~depth env state t in
          let state, ty = aux ~depth env state ty0 in
-         let env = EConstr.push_rel Context.Rel.Declaration.(LocalAssum(Context.make_annot Anonymous relevant,ty0)) env in
+         let env = EConstr.push_rel Context.Rel.Declaration.(LocalAssum(EConstr.anonR,ty0)) env in
          let state, self = aux ~depth:(depth+1) env state (EC.mkRel 1) in
-         state, in_elpi_let Names.Name.Anonymous t ty self
+         state, in_elpi_let EConstr.anonR t ty self
     | C.Prod(n,s0,t) ->
          let state, s = aux ~depth env state s0 in
          let env = EConstr.push_rel Context.Rel.Declaration.(LocalAssum(n,s0)) env in
          let state, t = aux ~depth:(depth+1) env state t in
-         state, in_elpi_prod n.Context.binder_name s t
+         state, in_elpi_prod n s t
     | C.Lambda(n,s0,t) ->
          let state, s = aux ~depth env state s0 in
          let env = EConstr.push_rel Context.Rel.Declaration.(LocalAssum(n,s0)) env in
          let state, t = aux ~depth:(depth+1) env state t in
-         state, in_elpi_lam n.Context.binder_name s t
+         state, in_elpi_lam n s t
     | C.LetIn(n,b0,s0,t) ->
          let state, b = aux ~depth env state b0 in
          let state, s = aux ~depth env state s0 in
          let env = EConstr.push_rel Context.Rel.Declaration.(LocalDef(n,b0,s0)) env in
          let state, t = aux ~depth:(depth+1) env state t in
-         state, in_elpi_let n.Context.binder_name b s t
+         state, in_elpi_let n b s t
     | C.App(hd,args) ->
          let state, hd = aux ~depth env state hd in
          let state, args = CArray.fold_left_map (aux ~depth env) state args in
@@ -1719,7 +1743,7 @@ let rec constr2lp coq_ctx ~calldepth ~depth state t =
          let state, typ = aux ~depth env state typ0 in
          let env = EConstr.push_rel Context.Rel.Declaration.(LocalAssum(name,typ0)) env in
          let state, bo = aux ~depth:(depth+1) env state bo in
-         state, in_elpi_fix name.Context.binder_name rarg typ bo
+         state, in_elpi_fix name rarg typ bo
     | C.Fix((rargs, focus_idx),(names, tys, bos)) ->
          let names = Array.to_list names in
          let tys = Array.to_list tys in
@@ -1729,7 +1753,7 @@ let rec constr2lp coq_ctx ~calldepth ~depth state t =
              let state,typ = aux ~depth env state typ0 in
              let typ = U.move ~from:depth ~to_:(depth+n) typ in
              let env = EConstr.push_rel Context.Rel.Declaration.(LocalAssum(name,typ0)) env in
-             (n+1,state,env), (name.Context.binder_name, rno, typ))
+             (n+1,state,env), (name, rno, typ))
            (0,state,env) (List.combine (List.combine names rargs) tys) in
          let state, bos = CArray.fold_left_map (aux ~depth:(depth+n) env) state bos in
          state, in_elpi_mfix names_rnos_tys focus_idx (Array.to_list bos)
@@ -1753,16 +1777,16 @@ and under_coq2elpi_ctx ~calldepth state ctx ?(mk_ctx_item=fun decl -> mk_pi_arro
   let gls = ref [] in
   let rec aux i ~depth coq_ctx state = function
     | [] -> state, coq_ctx
-    | LocalAssum (Context.{binder_name=coq_name}, ty) as e :: rest ->
-        let name = Name coq_name in
+    | LocalAssum (name, ty) as e :: rest ->
+        let name = Context.map_annot (fun x -> Name x) name in
         let state, ty, gls_ty = constr2lp coq_ctx ~calldepth ~depth:(depth+1) state ty in
         gls := gls_ty @ !gls;
         let hsrc = mk_decl ~depth name ~ty in
         let hyp = { E.hsrc ; hdepth = depth + 1 } in
         let coq_ctx = push_coq_ctx_proof depth (e,hyp) coq_ctx in
         aux (succ i) ~depth:(depth+1) coq_ctx state rest
-      | LocalDef (Context.{binder_name=coq_name},bo,ty) as e :: rest ->
-        let name = Name coq_name in
+      | LocalDef (name,bo,ty) as e :: rest ->
+        let name = Context.map_annot (fun x -> Name x) name in
         let state, ty, gls_ty = constr2lp coq_ctx ~calldepth ~depth:(depth+1) state ty in
         let state, bo, gls_bo = constr2lp coq_ctx ~calldepth ~depth:(depth+1) state bo in
         gls := gls_ty @ gls_bo @ !gls;
@@ -2162,10 +2186,10 @@ let rec of_elpi_ctx ~calldepth syntactic_constraints depth dbl2ctx state initial
         let state, bo, gl2 = aux coq_ctx depth state bo in
         state, Context.Named.Declaration.LocalDef(id,bo,ty), gl1 @ gl2
   in
-  let of_elpi_ctx_entry_name dbl names ~depth e =
+  let of_elpi_ctx_entry_name dbl names ~depth state e =
     match e with
-    | `Decl(name_hint,_) -> in_coq_fresh_annot_id ~depth ~names dbl name_hint
-    | `Def(name_hint,_,_) -> in_coq_fresh_annot_id ~depth ~names dbl name_hint
+    | `Decl(name_hint,_) -> in_coq_fresh_annot_id ~depth ~names dbl state name_hint
+    | `Def(name_hint,_,_) -> in_coq_fresh_annot_id ~depth ~names dbl state name_hint
   in
   let rec build_ctx_entry coq_ctx state gls = function
     | [] -> state, coq_ctx, List.(concat (rev gls))
@@ -2178,19 +2202,20 @@ let rec of_elpi_ctx ~calldepth syntactic_constraints depth dbl2ctx state initial
   in
   (* we go from the bottom (most recent addition) to the top in order to
      give precedence to the name recently introduced *)
-  let rec ctx_entries_names names i =
-    if i < 0 then []
+  let rec ctx_entries_names names i state =
+    if i < 0 then state, [], []
     else (* context entry for the i-th variable *)
       if not (Int.Map.mem i dbl2ctx)
-      then ctx_entries_names names (i - 1)
+      then ctx_entries_names names (i - 1) state
       else
         let d, t, e = Int.Map.find i dbl2ctx in
-        let id = of_elpi_ctx_entry_name i names ~depth:d e in
+        let state, id, gl = of_elpi_ctx_entry_name i names ~depth:d state e in
         let names = Id.Set.add (Context.binder_name id) names in
-        (i,id,d,t,e) :: ctx_entries_names names (i - 1)
+        let state, res, gls = ctx_entries_names names (i - 1) state in
+        state, (i,id,d,t,e) :: res, gl :: gls
   in
-    ctx_entries_names initial_coq_ctx.names (depth-1) |>
-    List.rev |> (* we need to readback the context from top to bottom *)
+    let state, names, gls = ctx_entries_names initial_coq_ctx.names(depth-1) state in
+    List.rev names |> (* we need to readback the context from top to bottom *)
     build_ctx_entry initial_coq_ctx state []
 
 (* ***************************************************************** *)
@@ -2234,22 +2259,22 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
     end
  (* binders *)
   | E.App(c,name,[s;t]) when lamc == c || prodc == c ->
-      let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name in
+      let state, name, gl0 = in_coq_fresh_annot_name ~depth ~coq_ctx depth name state in
       let state, s, gl1 = aux ~depth state ~on_ty:true s in
       let coq_ctx = push_coq_ctx_local depth (Context.Rel.Declaration.LocalAssum(name,s)) coq_ctx in
       let state, t, gl2 = aux_lam coq_ctx ~depth state t in
-      if lamc == c then state, EC.mkLambda (name,s,t), gl1 @ gl2
-      else state, EC.mkProd (name,s,t), gl1 @ gl2
+      if lamc == c then state, EC.mkLambda (name,s,t), gl0 @ gl1 @ gl2
+      else state, EC.mkProd (name,s,t), gl0 @ gl1 @ gl2
   | E.App(c,name,[s;b;t]) when letc == c ->
-      let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name in
+      let state, name, gl0 = in_coq_fresh_annot_name ~depth ~coq_ctx depth name state in
       let state, s, gl1 = aux ~depth state ~on_ty:true s in
       let state, b, gl2 = aux ~depth state b in
       let coq_ctx = push_coq_ctx_local depth (Context.Rel.Declaration.LocalDef(name,b,s)) coq_ctx in
       let state, t, gl3 = aux_lam coq_ctx ~depth state t in
       if EC.eq_constr (get_sigma state) t (EC.mkRel 1) then
-        state, EC.mkCast (b,Constr.DEFAULTcast,s), gl1 @ gl2 @ gl3
+        state, EC.mkCast (b,Constr.DEFAULTcast,s), gl0 @ gl1 @ gl2 @ gl3
       else
-        state, EC.mkLetIn (name,b,s,t), gl1 @ gl2 @ gl3
+        state, EC.mkLetIn (name,b,s,t), gl0 @ gl1 @ gl2 @ gl3
       
   | E.Const n ->
                   
@@ -2280,8 +2305,8 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
               | Projection p ->
                   let state, i, gl1 = aux ~depth state i in
                   let state, xs, gl2 = API.Utils.map_acc (aux ~depth ~on_ty:false) state xs in
-                  (* TODO handle relevance *)
-                  state, EC.mkApp (EC.mkProj (p,relevant,i),Array.of_list xs), gls @ gl1 @ gl2
+                  let state, rv = fresh_relevance_variable state in
+                  state, EC.mkApp (EC.mkProj (p,rv,i),Array.of_list xs), gls @ gl1 @ gl2
               | _ ->  err Pp.(str"not a primitive projection:" ++ str (E.Constants.show c))
               end
           | x, _ ->
@@ -2327,7 +2352,8 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
       begin match ind with
       | `SomeInd ind ->
           let ci = Inductiveops.make_case_info (get_global_env state) ind C.MatchStyle in
-          state, EC.mkCase (EConstr.contract_case (get_global_env state) sigma (ci,(rt,relevant),C.NoInvert,t,Array.of_list bt)), gl1 @ gl2 @ gl3
+          let state, rv = fresh_relevance_variable state in
+          state, EC.mkCase (EConstr.contract_case (get_global_env state) sigma (ci,(rt,rv),C.NoInvert,t,Array.of_list bt)), gl1 @ gl2 @ gl3
       | `None -> CErrors.anomaly Pp.(str "non dependent match on unknown, non singleton, inductive")
       | `SomeTerm (n,rt) ->
           let ci = default_case_info () in
@@ -2335,17 +2361,18 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
             match bt with
             | [t] -> [||], t
             | _ -> assert false in
-          state, EConstr.mkCase (ci,EConstr.EInstance.empty,[||],(([|n|],rt),relevant),Constr.NoInvert,t,[|b|]), gl1 @ gl2 @ gl3
+          let state, rv = fresh_relevance_variable state in
+          state, EConstr.mkCase (ci,EConstr.EInstance.empty,[||],(([|n|],rt),rv),Constr.NoInvert,t,[|b|]), gl1 @ gl2 @ gl3
       end
 
  (* fix *)
   | E.App(c,name,[rno;ty;bo]) when fixc == c ->
-      let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name in
+      let state, name, gl0 = in_coq_fresh_annot_name ~depth ~coq_ctx depth name state in
       let state, ty, gl1 = aux ~depth state ~on_ty:true ty in
       let coq_ctx = push_coq_ctx_local depth (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in
       let state, bo, gl2 = aux_lam coq_ctx ~depth state bo in
       let rno = lp2int ~depth ~ctx:"fix" rno in
-      state, EC.mkFix (([|rno|],0),([|name|],[|ty|],[|bo|])), gl1 @ gl2
+      state, EC.mkFix (([|rno|],0),([|name|],[|ty|],[|bo|])), gl0 @ gl1 @ gl2
 
  (* mfix *)
   | E.App(c,focus_lp,[rno;block_lp]) when mfixc == c ->
@@ -2356,7 +2383,7 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
       let rec collect_ty ~depth state coq_ctx node defs gls_acc =
         match E.look ~depth node with
         | E.App(c2,name_lp,[rno_lp; ty_lp; rest_lam]) when mfix_tyc == c2 ->
-          let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name_lp in
+          let state, name, gl0 = in_coq_fresh_annot_name ~depth ~coq_ctx depth name_lp state in
           let rno = lp2int ~depth ~ctx:"mfix-ty rno" rno_lp in
           let state, ty, gl =
             lp2constr ~calldepth syntactic_constraints outer_ctx
@@ -2364,7 +2391,7 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
           let coq_ctx = push_coq_ctx_local depth
             (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in
           let defs = (name, rno, ty) :: defs in
-          let gls_acc = gl @ gls_acc in
+          let gls_acc = gl0 @ gl @ gls_acc in
           (match E.look ~depth rest_lam with
            | E.Lam body ->
              collect_ty ~depth:(depth+1) state coq_ctx body defs gls_acc
@@ -3173,9 +3200,9 @@ let in_coq_bool ~depth state ~default b =
   | Elpi.Builtin.Unspec -> default
 
 let in_elpi_arity_parameter id ~imp ty rest =
-  E.mkApp arity_parameterc (in_elpi_id id) [imp;ty;E.mkLam rest]
+  E.mkApp arity_parameterc (in_elpi_id @@ Context.binder_name id) [imp;ty;E.mkLam rest]
 let in_elpi_inductive_parameter id ~imp ty rest =
-  E.mkApp inductive_parameterc (in_elpi_id id) [imp;ty;E.mkLam rest]
+  E.mkApp inductive_parameterc (in_elpi_id @@ Context.binder_name id) [imp;ty;E.mkLam rest]
   
 let in_elpi_arity t =
   E.mkApp arityc t []
@@ -3232,11 +3259,11 @@ let readback_arity ~depth coq_ctx constraints state t =
   let rec aux_arity coq_ctx ~depth params impls state extra t =
     match E.look ~depth t with
     | E.App(c,name,[imp;ty;decl]) when is_coq_name ~depth name && c == arity_parameterc ->
-        let name = in_coq_annot ~depth name in
+        let state, name, gl0 = in_coq_annot ~depth state name in
         let state, imp = in_coq_imp ~depth state imp in
         let state, ty, gls = lp2constr coq_ctx ~depth state ty in
         let e = Context.Rel.Declaration.LocalAssum(name,ty) in
-        aux_lam e coq_ctx ~depth (e :: params) (manual_implicit_of_binding_kind (Context.binder_name name) imp :: impls) state (gls :: extra) decl
+        aux_lam e coq_ctx ~depth (e :: params) (manual_implicit_of_binding_kind (Context.binder_name name) imp :: impls) state (gl0 :: gls :: extra) decl
     | E.App(c,ty,[]) when c == arityc ->
         let state, ty, gls = lp2constr coq_ctx ~depth state ty in
         state, params, impls, ty,  List.flatten @@ gls :: extra
@@ -3437,9 +3464,10 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
       let private_ind = false in
       let state, poly, cumulative, udecl, variances =
         poly_cumul_udecl_variance_of_options state coq_ctx.options in
+      let state, name = mk_coq_annot state itname in
       let the_type =
         let open Context.Rel.Declaration in
-        LocalAssum(nameR itname, EConstr.it_mkProd_or_LetIn arity (nuparams @ params)) in
+        LocalAssum(name, EConstr.it_mkProd_or_LetIn arity (nuparams @ params)) in
       let env_ar_params = (Global.env ()) |> EC.push_rel the_type |> EC.push_rel_context (nuparams @ params) in
 
     (* restruction to used universes *)
@@ -3494,16 +3522,15 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
     | E.App(c,atts,[n; ty; fields]) when c == fieldc ->
       begin match E.look ~depth fields with
       | E.Lam fields ->
-        let state, fs, tf = aux_fields (depth+1) state ind fields in
-        let name = in_coq_name ~depth n in
-        let state, atts, gls = record_field_attributes.API.Conversion.readback ~depth state atts in
-        assert(gls = []);
-        state, { name; is_coercion = is_coercion_att atts; is_canonical = is_canonical_att atts } :: fs,
-          in_elpi_prod name ty tf
+        let state, fs, tf, gl = aux_fields (depth+1) state ind fields in
+        let state, name, gl0 = in_coq_name ~depth state n in
+        let state, atts, gl1 = record_field_attributes.API.Conversion.readback ~depth state atts in
+        state, { name = name.Context.binder_name; is_coercion = is_coercion_att atts; is_canonical = is_canonical_att atts } :: fs,
+          in_elpi_prod name ty tf, gl0 :: gl1 :: gl
       | _ -> err Pp.(str"field/end-record expected: "++
                    str (pp2string P.(term depth) fields))
       end
-    | E.Const c when c == end_recordc -> state, [], ind
+    | E.Const c when c == end_recordc -> state, [], ind, []
     | _ ->  err Pp.(str"field/end-record expected: "++ 
                  str (pp2string P.(term depth) fields))
   in
@@ -3572,7 +3599,7 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
       let ind_types =
         List.mapi (fun i (name, arity) ->
           let ty = EConstr.it_mkProd_or_LetIn arity params in
-          Context.Rel.Declaration.LocalAssum(nameR name, EConstr.Vars.lift i ty))
+          Context.Rel.Declaration.LocalAssum(EConstr.nameR name, EConstr.Vars.lift i ty))
           (List.combine indnames arities) in
       let env_ar_params =
         let env_ar = List.fold_left (fun env ind_type -> EC.push_rel ind_type env) (Global.env ()) ind_types in
@@ -3618,7 +3645,7 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
 
     match E.look ~depth t with
     | E.App(c,name,[imp;ty;decl]) when is_coq_name ~depth name && c == inductive_parameterc ->
-        let name = in_coq_annot ~depth name in
+        let state, name, gl0 = in_coq_annot ~depth state name in
         let state, imp = in_coq_imp ~depth state imp in
         let state, ty, gls = lp2constr coq_ctx ~depth state ty in
         let e = Context.Rel.Declaration.LocalAssum(name,ty) in
@@ -3639,7 +3666,7 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
 
         let state, arity, gl1 = lp2constr coq_ctx ~depth state arity in
 
-        let name = in_coq_annot ~depth id in
+        let state, name, gl2 = in_coq_annot ~depth state id in
         if Name.is_anonymous (Context.binder_name name) then
           err Pp.(str"id expected, got: "++ str (pp2string P.(term depth) id));
         let e = Context.Rel.Declaration.LocalAssum(name,arity) in
@@ -3648,9 +3675,9 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
         let fields = U.move ~from:depth ~to_:(depth+1) fields in
         (* We simulate the missing binders for the inductive *)
         let ind = E.mkConst depth in
-        let state, fields_names_coercions, kty = aux_fields (depth+1) state ind fields in
+        let state, fields_names_coercions, kty, gl3 = aux_fields (depth+1) state ind fields in
         let k = [E.mkApp constructorc kn [in_elpi_arity kty]] in
-        let state, melims, idecl, uctx, ubinders, i_impls, ks_impls, gl2 =
+        let state, melims, idecl, uctx, ubinders, i_impls, ks_impls, gl4 =
           aux_construtors (push_coq_ctx_local depth e coq_ctx) ~depth:(depth+1) (params,List.rev impls) ([],[]) arity iname Declarations.BiFinite
             state k in
         let primitive = coq_ctx.options.primitive = Some true in
@@ -3666,7 +3693,7 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
     | _ -> err Pp.(str"lambda expected: "  ++
                  str (pp2string P.(term depth) t))
   and aux_inductive ~depth id fin arity coq_ctx state =
-    let name = in_coq_annot ~depth id in
+    let state, name, gl0 = in_coq_annot ~depth state id in
     if Name.is_anonymous (Context.binder_name name) then
       err Pp.(str"id expected, got: "++ str (pp2string P.(term depth) id));
     let fin = if in_coq_bool ~depth state ~default:true fin then Declarations.Finite else Declarations.CoFinite in
@@ -3674,7 +3701,7 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
     let e = Context.Rel.Declaration.LocalAssum(name,arity) in
     let iname =
       match Context.binder_name name with Name x -> x | _ -> assert false in
-    state, e, fin, iname, nuparams, nuimpls, arity, gl1
+    state, e, fin, iname, nuparams, nuimpls, arity, gl0 @ gl1
 
   and aux_mind_decl coq_ctx ~depth params impls inds state extra t =
     match E.look ~depth t with
@@ -3758,7 +3785,7 @@ let mk_arity_parameter2 ~depth name impl ty rest state =
   
 let mk_ctx_item_record_field ~depth name atts ty rest state =
   let state, atts, gls = record_field_attributes.API.Conversion.embed ~depth state (Elpi.Builtin.Given atts) in
-  state, in_elpi_field atts name ty rest
+  state, in_elpi_field atts (Context.binder_name name) ty rest
 
 let under_coq2elpi_relctx ~calldepth state (ctx : 'a ctx_entry list) ~coq_ctx ~mk_ctx_item kont =
   let gls = ref [] in
@@ -3768,12 +3795,12 @@ let under_coq2elpi_relctx ~calldepth state (ctx : 'a ctx_entry list) ~coq_ctx ~m
         gls := gls_t @ !gls;
         state, t
     | { id; typ; extra } :: rest ->
-        let name = Names.Name id in
+        let state, name = mk_coq_annot state id in
         let state, ty, gls_ty = constr2lp coq_ctx ~calldepth ~depth state typ in
         gls := gls_ty @ !gls;
         let hyp = mk_decl ~depth name ~ty in
         let hyps = { E.hsrc = hyp ; hdepth = depth } :: hyps in
-        let e = Context.Rel.Declaration.LocalAssum (annotR name, typ) in
+        let e = Context.Rel.Declaration.LocalAssum (name, typ) in
         let coq_ctx = push_coq_ctx_local depth e coq_ctx in
         let state, rest = aux ~depth:(depth+1) coq_ctx hyps state rest in
         mk_ctx_item ~depth name extra ty rest state
@@ -3852,7 +3879,7 @@ let hoas_ind2lp ~depth coq_ctx state { params; decl } =
         else
           let indno = i - arityno - paramsno in
           let ind = EC.mkRel (arityno + indno) in
-          iter paramsno ind (fun x -> EConstr.mkLambda (anonR,EConstr.mkProp,EConstr.Vars.lift 1 x))) in
+          iter paramsno ind (fun x -> EConstr.mkLambda (EConstr.anonR,EConstr.mkProp,EConstr.Vars.lift 1 x))) in
       let reloc ctx_len t =
         let t = EC.Vars.substl (subst ctx_len) t in
         Reductionops.nf_beta (Global.env()) sigma t in
@@ -3860,7 +3887,7 @@ let hoas_ind2lp ~depth coq_ctx state { params; decl } =
         | [] -> state, [], coq_ctx, depth, []
         | { id; nuparams; typ; _ } :: rest ->
             let state, arity, gls = embed_arity ~depth coq_ctx state (nuparams,typ) in
-            let coq_ctx = push_coq_ctx_local depth (Context.Rel.Declaration.LocalAssum(anonR,EConstr.mkProp)) coq_ctx in
+            let coq_ctx = push_coq_ctx_local depth (Context.Rel.Declaration.LocalAssum(EConstr.anonR,EConstr.mkProp)) coq_ctx in
             let state, arities, coq_ctx, depth, gls_rest = embed_arities coq_ctx (depth+1) state rest in
             state, arity :: arities, coq_ctx, depth, gls @ gls_rest in
       let state, arities, coq_ctx, depth, gls1 = embed_arities coq_ctx depth state inds in

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -1200,9 +1200,13 @@ let fresh_relevance_variable state =
     let rv = EConstr.ERelevance.make rv in
     { e with sigma }, rv)
 
-let mk_coq_annot state id =
+let mk_coq_name state id =
   let state, rv = fresh_relevance_variable state in
   state, Context.make_annot (Name.Name id) rv
+
+let mk_coq_annot state id =
+  let state, rv = fresh_relevance_variable state in
+  state, Context.make_annot id rv
 
 let in_coq_name ~depth state t =
   match E.look ~depth t with
@@ -3464,7 +3468,7 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
       let private_ind = false in
       let state, poly, cumulative, udecl, variances =
         poly_cumul_udecl_variance_of_options state coq_ctx.options in
-      let state, name = mk_coq_annot state itname in
+      let state, name = mk_coq_name state itname in
       let the_type =
         let open Context.Rel.Declaration in
         LocalAssum(name, EConstr.it_mkProd_or_LetIn arity (nuparams @ params)) in
@@ -3795,7 +3799,7 @@ let under_coq2elpi_relctx ~calldepth state (ctx : 'a ctx_entry list) ~coq_ctx ~m
         gls := gls_t @ !gls;
         state, t
     | { id; typ; extra } :: rest ->
-        let state, name = mk_coq_annot state id in
+        let state, name = mk_coq_name state id in
         let state, ty, gls_ty = constr2lp coq_ctx ~calldepth ~depth state typ in
         gls := gls_ty @ !gls;
         let hyp = mk_decl ~depth name ~ty in

--- a/src/rocq_elpi_HOAS.mli
+++ b/src/rocq_elpi_HOAS.mli
@@ -151,11 +151,12 @@ val inductive_entry2lp :
 val record_entry2lp :
   depth:int -> empty conv_context -> constraints -> State.t -> loose_udecl:bool ->Record.Record_decl.t ->
     State.t * term * Conversion.extra_goals
+type annot_name = (Name.t,EConstr.ERelevance.t) Context.pbinder_annot
   
 val in_elpi_id : Names.Name.t -> term
 val in_elpi_bool : State.t -> bool -> term
-val in_elpi_arity_parameter : Names.Name.t -> imp:term -> term -> term -> term
-val in_elpi_inductive_parameter : Names.Name.t -> imp:term -> term -> term -> term
+val in_elpi_arity_parameter : annot_name -> imp:term -> term -> term -> term
+val in_elpi_inductive_parameter : annot_name -> imp:term -> term -> term -> term
 val in_elpi_arity : term -> term
 val in_elpi_indtdecl_record : Names.Name.t -> term -> Names.Name.t -> term -> term
 val in_elpi_indtdecl_endrecord : unit -> term
@@ -181,14 +182,14 @@ val in_elpi_poly_gr : depth:int -> State.t -> Names.GlobRef.t -> term -> term
 val in_elpi_poly_gr_instance : depth:int -> State.t -> Names.GlobRef.t -> UVars.Instance.t -> term
 val in_elpi_flex_sort : term -> term
 val in_elpi_sort : depth:int -> 'a conv_context -> constraints -> state -> Sorts.t -> state * term * Conversion.extra_goals
-val in_elpi_prod : Name.t -> term -> term -> term
-val in_elpi_lam : Name.t -> term -> term -> term
-val in_elpi_let : Name.t -> term -> term -> term -> term
+val in_elpi_prod : annot_name -> term -> term -> term
+val in_elpi_lam : annot_name -> term -> term -> term
+val in_elpi_let : annot_name -> term -> term -> term -> term
 val in_elpi_appl : depth:int -> term -> term list -> term
 val in_elpi_match : term -> term -> term list -> term
-val in_elpi_fix : Name.t -> int -> term -> term -> term
-val in_elpi_mfix : (Names.Name.t * int * term) list -> int -> term list -> term
-val in_elpi_name : Name.t -> term
+val in_elpi_fix : annot_name -> int -> term -> term -> term
+val in_elpi_mfix : (annot_name * int * term) list -> int -> term list -> term
+val in_elpi_name : annot_name -> term
 
 val set_coq : Elpi.API.Ast.Scope.language -> unit
 
@@ -200,18 +201,20 @@ val in_elpiast_poly_gr : loc:Ast.Loc.t -> Names.GlobRef.t -> Ast.Term.t -> Ast.T
 val in_elpiast_poly_gr_instance : loc:Ast.Loc.t -> Names.GlobRef.t -> UVars.Instance.t -> Ast.Term.t
 val in_elpiast_flex_sort : loc:Ast.Loc.t -> Ast.Term.t -> Ast.Term.t
 val in_elpiast_sort : loc:Ast.Loc.t -> state -> Sorts.t -> Ast.Term.t
-val in_elpiast_prod : loc:Ast.Loc.t -> Names.Name.t -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t
-val in_elpiast_lam : loc:Ast.Loc.t -> Names.Name.t -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t
-val in_elpiast_let : loc:Ast.Loc.t -> Names.Name.t -> ty:Ast.Term.t -> bo:Ast.Term.t -> Ast.Term.t -> Ast.Term.t
+val in_elpiast_prod : loc:Ast.Loc.t -> annot_name -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t
+val in_elpiast_lam : loc:Ast.Loc.t -> annot_name -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t
+val in_elpiast_let : loc:Ast.Loc.t -> annot_name -> ty:Ast.Term.t -> bo:Ast.Term.t -> Ast.Term.t -> Ast.Term.t
 val in_elpiast_appl : loc:Ast.Loc.t -> Ast.Term.t -> Ast.Term.t list -> Ast.Term.t
 val in_elpiast_match : loc:Ast.Loc.t -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t list -> Ast.Term.t
-val in_elpiast_fix : loc:Ast.Loc.t -> Names.Name.t -> int -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t
-val in_elpiast_mfix : loc:Ast.Loc.t -> (Names.Name.t * int * Ast.Term.t) list -> int -> Ast.Term.t list -> Ast.Term.t
-val in_elpiast_name : loc:Ast.Loc.t -> Names.Name.t -> Ast.Term.t
-val in_elpiast_decl : loc:Ast.Loc.t -> v:Ast.Term.t -> Names.Name.t -> ty:Ast.Term.t -> Ast.Term.t
-val in_elpiast_def : loc:Ast.Loc.t -> v:Ast.Term.t -> Names.Name.t -> ty:Ast.Term.t -> bo:Ast.Term.t -> Ast.Term.t
+val in_elpiast_fix : loc:Ast.Loc.t -> annot_name -> int -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t
+val in_elpiast_mfix : loc:Ast.Loc.t -> (annot_name * int * Ast.Term.t) list -> int -> Ast.Term.t list -> Ast.Term.t
+val in_elpiast_name : loc:Ast.Loc.t -> annot_name -> Ast.Term.t
+val in_elpiast_decl : loc:Ast.Loc.t -> v:Ast.Term.t -> annot_name -> ty:Ast.Term.t -> Ast.Term.t
+val in_elpiast_def : loc:Ast.Loc.t -> v:Ast.Term.t -> annot_name -> ty:Ast.Term.t -> bo:Ast.Term.t -> Ast.Term.t
 
-val in_coq_name : depth:int -> term -> Name.t
+val mk_coq_annot : State.t -> Names.Id.t -> State.t * annot_name
+
+val in_coq_name : depth:int -> State.t -> term -> State.t * annot_name * Conversion.extra_goals
 val is_coq_name : depth:int -> term -> bool
 
 val in_coq_imp : depth:int -> State.t -> term -> State.t * Glob_term.binding_kind
@@ -284,8 +287,8 @@ val is_let : depth:int -> term -> (term * term * term) option (* ty, d, bo @ dep
 val is_lam : depth:int -> term -> (term * term) option (* ty, bo @ depth+1 *)
 
 val isname : RawOpaqueData.t -> bool
-val nameout : RawOpaqueData.t -> Name.t
-val name : Name.t Conversion.t
+val nameout : RawOpaqueData.t -> annot_name
+val name : annot_name Conversion.t
 
 type global_or_pglobal =
   | Global of term option
@@ -337,11 +340,11 @@ val grab_global_env_drop_sigma : State.t -> State.t
 
 val grab_global_env : uctx:Univ.ContextSet.t -> State.t -> State.t
 val grab_global_env_drop_sigma_keep_univs : uctx:Univ.ContextSet.t -> State.t -> State.t
-val mk_decl : depth:int -> Name.t -> ty:term -> term
+val mk_decl : depth:int -> annot_name -> ty:term -> term
 (* Adds an Arg for the normal form with ctx_len context entry vars in scope *)
 
 val mk_def :
-  depth:int -> Name.t -> bo:term -> ty:term -> term
+  depth:int -> annot_name -> bo:term -> ty:term -> term
 
 val get_global_env : State.t -> Environ.env
 val get_sigma : State.t -> Evd.evar_map

--- a/src/rocq_elpi_HOAS.mli
+++ b/src/rocq_elpi_HOAS.mli
@@ -212,7 +212,8 @@ val in_elpiast_name : loc:Ast.Loc.t -> annot_name -> Ast.Term.t
 val in_elpiast_decl : loc:Ast.Loc.t -> v:Ast.Term.t -> annot_name -> ty:Ast.Term.t -> Ast.Term.t
 val in_elpiast_def : loc:Ast.Loc.t -> v:Ast.Term.t -> annot_name -> ty:Ast.Term.t -> bo:Ast.Term.t -> Ast.Term.t
 
-val mk_coq_annot : State.t -> Names.Id.t -> State.t * annot_name
+val mk_coq_name : State.t -> Names.Id.t -> State.t * annot_name
+val mk_coq_annot : State.t -> Names.Name.t -> State.t * annot_name
 
 val in_coq_name : depth:int -> State.t -> term -> State.t * annot_name * Conversion.extra_goals
 val is_coq_name : depth:int -> term -> bool

--- a/src/rocq_elpi_arg_HOAS.ml
+++ b/src/rocq_elpi_arg_HOAS.ml
@@ -736,21 +736,23 @@ let mk_indt_decl state univpoly r =
 let rec garityparams2lp_synterp ~depth params k state =
   match params with
   | [] -> k state
-  | (name,_rel,imp,ob,src) :: params ->
+  | (name,_,imp,ob,src) :: params ->
       if ob <> None then Rocq_elpi_utils.nYI "defined parameters in a record/inductive declaration";
       let src = E.mkDiscard in
       let state, tgt = garityparams2lp_synterp ~depth params k state in
       let state, imp = in_elpi_imp ~depth state imp in
-      state, in_elpi_arity_parameter (EConstr.annotR name) ~imp src tgt
+      let name = EConstr.annotR name in (* no sigma at synterp *)
+      state, in_elpi_arity_parameter name ~imp src tgt
 let rec gindparams2lp_synterp ~depth params k state =
   match params with
   | [] -> k state
-  | (name,_rel,imp,ob,src) :: params ->
+  | (name,_,imp,ob,src) :: params ->
       if ob <> None then Rocq_elpi_utils.nYI "defined parameters in a record/inductive declaration";
       let src = E.mkDiscard in
       let state, tgt = gindparams2lp_synterp ~depth params k state in
       let state, imp = in_elpi_imp ~depth state imp in
-      state, in_elpi_inductive_parameter (EConstr.annotR name) ~imp src tgt
+      let name = EConstr.annotR name in (* no sigma at synterp *)
+      state, in_elpi_inductive_parameter name ~imp src tgt
             
       
 let rec gfields2lp_synterp ~depth fields state =
@@ -963,13 +965,14 @@ let best_effort_recover_arity ~depth state glob_sign typ bl =
   let _, grouped_bl = intern_global_context glob_sign ~intern_env:Constrintern.empty_internalization_env bl in
   let rec aux ~depth state typ gbl =
     match gbl with
-    | (name,_rel,ik,_,_) :: gbl ->
+    | (name,_,ik,_,_) :: gbl ->
       begin match Rocq_elpi_HOAS.is_prod ~depth typ with
       | None -> state, in_elpi_arity typ
       | Some(ty,bo) ->
           let state, imp = in_elpi_imp ~depth state ik in
           let state, bo = aux ~depth:(depth+1) state bo gbl in
-          state, in_elpi_arity_parameter (EConstr.annotR name) ~imp ty bo
+          let state, name = mk_coq_annot state name in
+          state, in_elpi_arity_parameter name ~imp ty bo
       end
     | _ -> state, in_elpi_arity typ
     in

--- a/src/rocq_elpi_arg_HOAS.ml
+++ b/src/rocq_elpi_arg_HOAS.ml
@@ -736,21 +736,21 @@ let mk_indt_decl state univpoly r =
 let rec garityparams2lp_synterp ~depth params k state =
   match params with
   | [] -> k state
-  | (name,imp,ob,src) :: params ->
+  | (name,_rel,imp,ob,src) :: params ->
       if ob <> None then Rocq_elpi_utils.nYI "defined parameters in a record/inductive declaration";
       let src = E.mkDiscard in
       let state, tgt = garityparams2lp_synterp ~depth params k state in
       let state, imp = in_elpi_imp ~depth state imp in
-      state, in_elpi_arity_parameter name ~imp src tgt
+      state, in_elpi_arity_parameter (EConstr.annotR name) ~imp src tgt
 let rec gindparams2lp_synterp ~depth params k state =
   match params with
   | [] -> k state
-  | (name,imp,ob,src) :: params ->
+  | (name,_rel,imp,ob,src) :: params ->
       if ob <> None then Rocq_elpi_utils.nYI "defined parameters in a record/inductive declaration";
       let src = E.mkDiscard in
       let state, tgt = gindparams2lp_synterp ~depth params k state in
       let state, imp = in_elpi_imp ~depth state imp in
-      state, in_elpi_inductive_parameter name ~imp src tgt
+      state, in_elpi_inductive_parameter (EConstr.annotR name) ~imp src tgt
             
       
 let rec gfields2lp_synterp ~depth fields state =
@@ -772,7 +772,6 @@ let grecord2lp_synterp ~depth ~name ~constructorname arity fields state =
   state, in_elpi_indtdecl_record (Name.Name qrecord_name) arity constructor fields
 
 let grecord2lp_synterp ~depth state { Cmd.name; arity; params; constructorname; fields; univpoly } =
-  let params = List.map drop_relevance params in
   let state, r = gindparams2lp_synterp ~depth params (grecord2lp_synterp ~depth ~name ~constructorname arity fields) state in
   mk_indt_decl state univpoly r
       
@@ -823,8 +822,6 @@ let drop_unit f ~depth state =
   
 let ginductive2lp_synterp ~depth state { Cmd.finiteness; name; arity; params; nuparams; nuparams_given; constructors; univpoly } =
   let space, indt_name = name in
-  let nuparams = List.map drop_relevance nuparams in
-  let params = List.map drop_relevance params in
   let do_constructor ~depth state (name, ty) =
     let state, ty = garityparams2lp_synterp nuparams (fun state -> state, in_elpi_arity E.mkDiscard) ~depth state in
     state, in_elpi_indtdecl_constructor (Name.Name name) ty
@@ -849,7 +846,7 @@ let ginductive2lp ~loc ~depth ~base state { Cmd.finiteness; name; arity; params;
     state, in_elpi_indtdecl_constructor (Name.Name name) ty
   in
   let do_inductive ~depth state =
-    let short_name = Name.Name indt_name in
+    let short_name = EConstr.annotR @@ Name.Name indt_name in
     let qindt_name = Id.of_string_soft @@ String.concat "." (space @ [Id.to_string indt_name]) in
     let state, term_arity = gterm2lp ~loc ~depth ~base (Rocq_elpi_utils.mk_gforall arity nuparams) state in
     let state, arity = garityparams2lp ~loc ~base nuparams ~k:(garity2lp ~loc ~base arity) ~depth state in
@@ -873,7 +870,6 @@ let cdeclc = E.Constants.declare_global_symbol "const-decl"
 let ucdeclc = E.Constants.declare_global_symbol "upoly-const-decl"
 
 let gdecl2lp_synterp ~depth state { Cmd.name; params; typ : _; body; udecl } =
-  let params = List.map drop_relevance params in
   let state, typ = garityparams2lp_synterp ~depth params (fun state -> state, in_elpi_arity E.mkDiscard) state in
   let body = Option.map (fun _ -> E.mkDiscard) body in
   let name = decl_name2lp name in
@@ -919,7 +915,7 @@ let rec do_context_glob ~loc fields ~depth ~base state =
       let open Rocq_elpi_glob_quotation in
       let state, ty = gterm2lp ~loc ~depth ~base ty state in
       let state, bo = option_map_acc (fun state bo -> gterm2lp ~loc ~depth ~base bo state) state bo in
-      let state, fields, () = Rocq_elpi_glob_quotation.under_ctx name ty bo ~k:(nogls (do_context_glob ~loc ~base fields)) ~depth state in
+      let state, fields, () = Rocq_elpi_glob_quotation.under_ctx (EConstr.annotR name) ty bo ~k:(nogls (do_context_glob ~loc ~base fields)) ~depth state in
       let state, bo, _ = in_option ~depth state bo in
       let state, imp = in_elpi_imp ~depth state bk in
       state, E.mkApp ctxitemc (in_elpi_id name) [imp;ty;bo;E.mkLam fields]
@@ -934,7 +930,7 @@ let rec do_context_constr coq_ctx csts fields ~depth state =
         | None -> state, None, []
         | Some bo -> let state, bo, gl = map state bo in state, Some bo, gl in
         (* TODO GLS *)
-      let state, fields, gl2 = Rocq_elpi_glob_quotation.under_ctx name ty bo ~k:(do_context_constr coq_ctx csts fields) ~depth state in
+      let state, fields, gl2 = Rocq_elpi_glob_quotation.under_ctx (EConstr.annotR name) ty bo ~k:(do_context_constr coq_ctx csts fields) ~depth state in
       let state, bo, gl3 = in_option ~depth state bo in
       let state, imp = in_elpi_imp ~depth state bk in
       state, E.mkApp ctxitemc (in_elpi_id name) [imp;ty;bo;E.mkLam fields], gl0 @ gl1 @ gl2 @ gl3
@@ -967,17 +963,17 @@ let best_effort_recover_arity ~depth state glob_sign typ bl =
   let _, grouped_bl = intern_global_context glob_sign ~intern_env:Constrintern.empty_internalization_env bl in
   let rec aux ~depth state typ gbl =
     match gbl with
-    | (name,ik,_,_) :: gbl ->
+    | (name,_rel,ik,_,_) :: gbl ->
       begin match Rocq_elpi_HOAS.is_prod ~depth typ with
       | None -> state, in_elpi_arity typ
       | Some(ty,bo) ->
           let state, imp = in_elpi_imp ~depth state ik in
           let state, bo = aux ~depth:(depth+1) state bo gbl in
-          state, in_elpi_arity_parameter name ~imp ty bo
+          state, in_elpi_arity_parameter (EConstr.annotR name) ~imp ty bo
       end
     | _ -> state, in_elpi_arity typ
     in
-      aux ~depth state typ (List.map drop_relevance (List.rev grouped_bl))
+      aux ~depth state typ (List.rev grouped_bl)
 
 let in_elpi_string_arg ~depth state x = 
   state, E.mkApp strc (CD.of_string x) [], []

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -4593,15 +4593,24 @@ and for all in a .v file which your clients will load. Eg.
   MLCode(Pred("coq.string->name",
     In(B.string, "Hint",
     Out(name,  "Name",
-    Full(global, "creates a name hint"))),
+    Full(global, "creates a name hint using a relevance variable"))),
   (fun s _ ~depth _ _ state -> 
     let state, s = mk_coq_name state (Id.of_string s) in
     state, !: s, [])),
   DocAbove);
 
+  MLCode(Pred("coq.string->name-relevant",
+    In(B.string, "Hint",
+    Out(name,  "Name",
+    Easy("creates a name hint with the relevant mark (see SProp)"))),
+  (fun s _ ~depth -> 
+    let s = EConstr.nameR (Id.of_string s) in
+    !: s)),
+  DocAbove);
+
   LPCode {|
 func coq.id->name id -> name.
-coq.id->name S N :- coq.string->name S N.
+coq.id->name S N :- coq.string->name-relevant S N.
   |};
 
   MLCode(Pred("coq.name->id",

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -4580,21 +4580,23 @@ and for all in a .v file which your clients will load. Eg.
   (fun n suffix _ ~depth ->
      match E.look ~depth suffix with
      | E.CData i when API.RawOpaqueData.(is_string i || is_int i || isname i) ->
-         let s = Pp.string_of_ppcmds (Name.print n) in
+         let s = Pp.string_of_ppcmds (Name.print @@ Context.binder_name n) in
          let suffix =
            if API.RawOpaqueData.is_string i then API.RawOpaqueData.to_string i
            else if API.RawOpaqueData.is_int i then string_of_int (API.RawOpaqueData.to_int i)
-           else Pp.string_of_ppcmds (Name.print (nameout i)) in
+           else Pp.string_of_ppcmds (Name.print (Context.binder_name @@ nameout i)) in
          let s = s ^ suffix in
-         !: (Name.mk_name (Id.of_string s))
+         !: (Context.map_annot (fun _ -> Name.mk_name (Id.of_string s)) n)
      | _ -> err Pp.(str "coq.name-suffix: suffix is not int, nor string nor name"))),
   DocAbove);
 
   MLCode(Pred("coq.string->name",
     In(B.string, "Hint",
     Out(name,  "Name",
-    Easy "creates a name hint")),
-  (fun s _ ~depth -> !: (Name.mk_name (Id.of_string s)))),
+    Full(global, "creates a name hint"))),
+  (fun s _ ~depth _ _ state -> 
+    let state, s = mk_coq_annot state (Id.of_string s) in
+    state, !: s, [])),
   DocAbove);
 
   LPCode {|
@@ -4607,10 +4609,23 @@ coq.id->name S N :- coq.string->name S N.
     Out(id,  "Id",
     Easy "tuns a pretty printing hint into a string. This API is for internal use, no guarantee on its behavior.")),
   (fun n _ ~depth ->
-     match n with
+     match Context.binder_name n with
      | Name.Anonymous -> !: "_"
      | Name.Name s -> !: (Id.to_string s))),
   DocAbove);
+
+  MLCode(Pred("coq.name.relevant?",
+    In(name, "Name",
+    Out(option bool,  "Relevance",
+    Read(global, "Reads the relevance mark. none means unset, some tt means relevant."))),
+  (fun n _ ~depth _ _ state ->
+     let sigma = get_sigma state in
+     match EConstr.ERelevance.kind sigma @@ Context.binder_relevance n with
+     | Sorts.Irrelevant -> !: (Some false)
+     | Sorts.Relevant -> !: (Some true)
+     | Sorts.RelevanceVar _ -> !: None)),
+  DocAbove);
+
 
   MLCode(Pred("coq.gref->id",
     In(gref, "GR",

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -4595,7 +4595,7 @@ and for all in a .v file which your clients will load. Eg.
     Out(name,  "Name",
     Full(global, "creates a name hint"))),
   (fun s _ ~depth _ _ state -> 
-    let state, s = mk_coq_annot state (Id.of_string s) in
+    let state, s = mk_coq_name state (Id.of_string s) in
     state, !: s, [])),
   DocAbove);
 

--- a/src/rocq_elpi_glob_quotation.ml
+++ b/src/rocq_elpi_glob_quotation.ml
@@ -103,6 +103,7 @@ let update_subst_id l na =
     (na,id')::l, id'
   else l,na
     
+let drop_relevance (a,_,c,d,e) = (a,c,d,e)
 
 let rename_var l id =
   try
@@ -156,7 +157,7 @@ let rec rename_glob_vars l c = DAst.map_with_loc (fun ?loc -> function
   ) c
 
 let under_glob_ctx1 name ~tyast ~k t state =
-  match name with
+  match Context.binder_name name with
   | Names.Name.Anonymous -> k name t state
   | Names.Name.Name id ->
     (* let () = Printf.eprintf " intro %s\n" (Id.to_string id) in *)
@@ -167,14 +168,16 @@ let under_glob_ctx1 name ~tyast ~k t state =
           (* let () = Printf.eprintf "%s -> %s\n" (Id.to_string id) (Id.to_string new_id) in *)
           rename_glob_vars [id,new_id] t, new_id
         else t, id in
-      let state = push_glob_ctx state id (Some (tyast id)) in
-      k (Names.Name.Name id) t state
+      let name = Context.map_annot (fun _ -> Names.Name.Name id) name in
+      let aid = Context.map_annot (fun _ -> id) name in
+      let state = push_glob_ctx state id (Some (tyast aid)) in
+      k name t state
   
 let rec under_glob_ctxn names ~tyasts ~k ts state acc =
   match names, tyasts with
   | [], [] -> k (List.rev acc) ts state
   | name :: names, tyast :: tyasts ->
-    begin match name with
+    begin match Context.binder_name name with
     | Names.Name.Anonymous -> under_glob_ctxn names ~tyasts ~k ts state acc
     | Names.Name.Name id ->
       (* let () = Printf.eprintf " intro %s\n" (Id.to_string id) in *)
@@ -185,8 +188,10 @@ let rec under_glob_ctxn names ~tyasts ~k ts state acc =
             (* let () = Printf.eprintf "%s -> %s\n" (Id.to_string id) (Id.to_string new_id) in *)
             List.map (rename_glob_vars [id,new_id]) ts, new_id
           else ts, id in
-        let state = push_glob_ctx state id (Some (tyast id)) in
-        under_glob_ctxn names ~tyasts ~k ts state (Names.Name.Name id::acc)
+        let name = Context.map_annot (fun _ -> Names.Name.Name id) name in
+        let aid = Context.map_annot (fun _ -> id) name in
+        let state = push_glob_ctx state id (Some (tyast aid)) in
+        under_glob_ctxn names ~tyasts ~k ts state (name::acc)
     end
   | _ -> assert false
 
@@ -209,7 +214,7 @@ let under_ctx name ty bo ~k ~depth state =
   let orig_glob_ctx = S.get glob_ctx state in
   let state =
     let id =
-      match name with
+      match Context.binder_name name with
       | Name id -> id
       | Anonymous ->
           Id.of_string_soft
@@ -363,12 +368,12 @@ let gterm2lpast ~pattern ~language state glob =
     | Some bo -> mk_def state ~loc id ~ty ~bo
 
   and mk_decl state ~loc name ~ty =
-    let v = A.Term.mkBound ~loc ~language @@ name_of_id name in
-    in_elpiast_decl ~loc ~v (Name.Name name) ~ty
+    let v = A.Term.mkBound ~loc ~language @@ name_of_id @@ Context.binder_name name in
+    in_elpiast_decl ~loc ~v (Context.map_annot (fun x -> Name.Name x) name) ~ty
 
   and mk_def state ~loc name ~ty ~bo =
-    let v = A.Term.mkBound ~loc ~language @@ name_of_id name in
-    in_elpiast_def ~loc ~v (Name.Name name) ~ty ~bo
+    let v = A.Term.mkBound ~loc ~language @@ name_of_id @@ Context.binder_name name in
+    in_elpiast_def ~loc ~v (Context.map_annot (fun x -> Name.Name x) name) ~ty ~bo
 
   and gterm2lp state ({ CAst.loc; v } as x) : A.Term.t =
   debug Pp.(fun () ->
@@ -403,12 +408,12 @@ let gterm2lpast ~pattern ~language state glob =
   | GProd _ as t ->
       let (name,s,t) = dest_GProd t in
       let s = gterm2lp state s in
-      under_binder ~loc name s None t state ~k:(fun name t state ->
+      under_binder ~loc (EConstr.annotR name) s None t state ~k:(fun name t state ->
         in_elpiast_prod ~loc name s (gterm2lp state t))
   | GLambda _ as t ->
       let (name,s,t) = dest_GLambda t in
       let s = gterm2lp state s in
-      under_binder ~loc name s None t state ~k:(fun name t state ->
+      under_binder ~loc (EConstr.annotR name) s None t state ~k:(fun name t state ->
         in_elpiast_lam ~loc name s (gterm2lp state t))
   | GLetIn _ as t ->
       let (name,bo , oty, t) = dest_GLetIn t in
@@ -420,7 +425,7 @@ let gterm2lpast ~pattern ~language state glob =
             A.Term.mkVar ~loc ~hdloc:loc (fresh_uv ())
               (List.map (fun x -> A.Term.mkBound ~loc ~language (name_of_id x)) args)
         | Some ty -> gterm2lp state ty in
-      under_binder ~loc name ty (Some bo) t state ~k:(fun name t state ->
+      under_binder ~loc (EConstr.annotR name) ty (Some bo) t state ~k:(fun name t state ->
         in_elpiast_let ~loc name ~ty ~bo (gterm2lp state t))
   
   | GGenarg arg when is_elpi_code arg ->
@@ -465,7 +470,7 @@ let gterm2lpast ~pattern ~language state glob =
       let id = Id.of_string "self" in
       let name = Names.Name.Name id in
       let self = A.Term.mkBound ~loc ~language (name_of_id id) in
-      in_elpiast_let ~loc name ~bo:t ~ty:c_ty self
+      in_elpiast_let ~loc (EConstr.annotR name) ~bo:t ~ty:c_ty self
 
   | GEvar(_k,_subst) -> nYI "(glob)HOAS for GEvar"
   | GPatVar _ -> nYI "(glob)HOAS for GPatVar"
@@ -596,11 +601,11 @@ let gterm2lpast ~pattern ~language state glob =
       let ty = glob_intros_prod tctx ty in
       let ty = gterm2lp state ty in
       let bo = glob_intros tctx bo in
-      under_binder ~loc (Name.Name name) ty None bo state ~k:(fun name t state ->
+      under_binder ~loc (EConstr.nameR name) ty None bo state ~k:(fun name t state ->
         in_elpiast_fix ~loc name rno ty (gterm2lp state bo))
   | GRec(GFix(rnos,focus_idx),names,tctxs,tys,bos) ->
       let n_fix = Array.length names in
-      let names = Array.map (fun x -> Name.Name x) names |> Array.to_list in
+      let names = Array.map EConstr.nameR names |> Array.to_list in
       let tys = Array.map2 glob_intros_prod tctxs tys in
       let tys = Array.map (gterm2lp state) tys |> Array.to_list in
       let bos = Array.map2 glob_intros tctxs bos |> Array.to_list in
@@ -669,20 +674,19 @@ let runtime_gterm2lp ~loc ~base glob ~depth state =
 let rec gparams2lp ~loc ~base inp params (kont : depth:int -> S.t -> S.t * _) ~depth state =
   match params with
   | [] -> kont ~depth state
-  | (name,imp,ob,src) :: params ->
+  | (name,_rel,imp,ob,src) :: params ->
       if ob <> None then Rocq_elpi_utils.nYI "defined parameters in a record/inductive declaration";
       let state, src = gterm2lp ~loc ~depth ~base src state in
       let k = nogls (gparams2lp ~loc ~base inp params kont) in
+      let name = EConstr.annotR name in
       let state, tgt, () = under_ctx name src None ~k ~depth state in
       let state, imp = in_elpi_imp ~depth state imp in
       state, inp name ~imp src tgt
-
-let drop_relevance (a,_,c,d,e) = (a,c,d,e)
     
 let gindparams2lp ~loc ~base params ~k ~depth s =
-  gparams2lp ~loc ~base in_elpi_inductive_parameter (List.map drop_relevance params) k ~depth s
+  gparams2lp ~loc ~base in_elpi_inductive_parameter params k ~depth s
 let garityparams2lp ~loc ~base params ~k ~depth s =
-  gparams2lp ~loc ~base in_elpi_arity_parameter(List.map drop_relevance params) k ~depth s
+  gparams2lp ~loc ~base in_elpi_arity_parameter params k ~depth s
   
 let garity2lp ~loc ~base t ~depth state =
   let state, t = gterm2lp ~loc t ~depth ~base state in
@@ -693,7 +697,7 @@ let rec gfields2lp ~loc ~base fields ~depth state =
   | [] -> state, in_elpi_indtdecl_endrecord ()
   | (f,({ name; is_coercion; is_canonical } as att)) :: fields ->
       let state, f = gterm2lp ~loc ~base f ~depth state in
-      let state, fields, () = under_ctx name f None ~k:(nogls (gfields2lp ~loc ~base fields)) ~depth state in
+      let state, fields, () = under_ctx (EConstr.annotR name) f None ~k:(nogls (gfields2lp ~loc ~base fields)) ~depth state in
       in_elpi_indtdecl_field ~depth state att f fields
 
 let grecord2lp ~loc ~base ~name ~constructorname arity fields ~depth state =

--- a/src/rocq_elpi_glob_quotation.mli
+++ b/src/rocq_elpi_glob_quotation.mli
@@ -12,7 +12,7 @@ val coq : Ast.Scope.language
 val set_coq_ctx_hyps : State.t -> [> `Options ] Rocq_elpi_HOAS.conv_context * hyps -> State.t
 
 val under_ctx :
-  Names.Name.t -> term -> term option ->
+  Rocq_elpi_HOAS.annot_name -> term -> term option ->
   k:(depth:int -> State.t -> State.t * 'b * 'c) ->
   depth:int -> State.t -> State.t * 'b * 'c
 
@@ -21,7 +21,7 @@ val gterm2lp :
   base:Compile.program -> 
   Glob_term.glob_constr ->
   depth:int -> State.t -> State.t * term
-  val gindparams2lp :
+val gindparams2lp :
   loc:Loc.t ->
   base:Compile.program -> 
   Glob_term.glob_decl list ->

--- a/src/rocq_elpi_name_quotation.ml
+++ b/src/rocq_elpi_name_quotation.ml
@@ -8,8 +8,8 @@ open Rocq_elpi_HOAS
 open Names
 
 let to_name ~loc src =
-    if src = "_" then in_elpiast_name ~loc Name.Anonymous
-    else in_elpiast_name ~loc (Name.Name (Id.of_string src))
+    if src = "_" then in_elpiast_name ~loc (EConstr.anonR)
+    else in_elpiast_name ~loc (EConstr.nameR (Id.of_string src))
 
 (* Install the quotation *)
 let () =

--- a/tests/test_binder_relevance.v
+++ b/tests/test_binder_relevance.v
@@ -1,0 +1,42 @@
+From elpi Require Import elpi.
+Set Allow StrictProp.
+Inductive foo : SProp := K : nat -> foo.
+Set Printing Relevance Marks.
+Definition f (x : foo) := x.
+
+Elpi Command test.
+Elpi Query lp:{{
+  const F = {{:gref f}},
+  coq.env.const F (some (fun N _ _)) Ty,
+  std.assert!(coq.name.relevant? N (some ff))"bad relevance"
+
+}}.
+
+Elpi Query lp:{{
+  B = fun N {{ nat }} (x\x),
+  coq.say {coq.term->string B},
+  std.assert!(coq.name.relevant? N none)"bad relevance",
+  coq.env.add-const "xxx" B _ tt _
+
+
+}}.
+Print xxx.
+
+Elpi Query lp:{{
+  B = fun N {{ nat }} (x\{{ K lp:x }}),
+  coq.typecheck B _ ok,
+  std.assert!(coq.name.relevant? N (some tt))"bad relevance",
+  coq.say {coq.term->string B}
+
+}}.
+
+Elpi Query lp:{{
+  B = fun N {{ foo }} (x\x),
+  coq.typecheck B _ ok,
+  std.assert!(coq.name.relevant? N (some ff))"bad relevance",
+  coq.say {coq.term->string B}
+
+}}.
+
+(* Check fun x : nat => K x.
+Check fun x : foo => x. *)


### PR DESCRIPTION
After today's call I realized that the Rocq's `Context.binder_annot` are converted into Elpi's `name` dropping relevance, and the other way back setting it to `Relevant`. This PR keeps the relevance if given, or uses a relevance/quality variable if not.

API:
- `coq.id->name` generates a relevance variable on the Rocq side
- `fun _ Ty F` as well
- `{{ fun x => ..}}` does default to relevant as it is now, making it generate a variable is not trivial because some Elpi internal
- `coq.name.relevant?` can inspect a `name` and tells if it is set to relevant/irrelevant or unset
- there is no API to set these variable, other than calling the type checker
- passing to the kernel a term with these variables is OK, they are set correctly

TODO:
- [x] propagate the change to all files
- [x] test what happens now if the user calls the kernel without typing

CC @mattam82 @CohenCyril @tabareau 