### PR TITLE
Add coq.env.scheme predicate for looking up registered schemes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@ Requires Elpi 3.7.1 and Rocq 9.0, 9.1 or 9.2.
   started in Elpi with a regular `Qed` anymore.
 - New argument `const-decl` can now be introduces by the `Lemma` keyword,
   and not just by `Definition`.
+- New `coq.scheme` to query registered schemes
 
 
 # [3.3.1] 12/03/2026

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -1914,11 +1914,9 @@ external symbol coq.register.scheme : gref -> coq.register.scheme-kind ->
 % Scheme)
 external func coq.register gref, coq.register.
 
-% [coq.env.scheme Kind GR Scheme] looks up the scheme of the given kind for
-% GR. Returns none if GR is not an inductive or no such scheme is
-% registered.
-external func coq.env.scheme coq.register.scheme-kind, 
-                            gref -> option gref.
+% [coq.scheme Kind GR Scheme] looks up the scheme of the given kind for GR.
+% Returns none if GR is not an inductive or no such scheme is registered.
+external func coq.scheme coq.register.scheme-kind, gref -> option gref.
 
 % -- Extra Dependencies -----------------------------------------------
 

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -1914,6 +1914,12 @@ external symbol coq.register.scheme : gref -> coq.register.scheme-kind ->
 % Scheme)
 external func coq.register gref, coq.register.
 
+% [coq.env.scheme Kind GR Scheme] looks up the scheme of the given kind for
+% GR. Returns none if GR is not an inductive or no such scheme is
+% registered.
+external func coq.env.scheme coq.register.scheme-kind, 
+                            gref -> option gref.
+
 % -- Extra Dependencies -----------------------------------------------
 
 % [coq.extra-dep Identifier FileName] Resolve the file name of an extra

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -546,8 +546,13 @@ let abbreviation_declare = Abbreviation.declare
 let for_scheme = function
 | GlobRef.ConstRef c -> c
 | _ -> U.type_error "Register Scheme: expecing a constant."
+let lookup_scheme_opt k ind =
+  try Some (GlobRef.ConstRef (DeclareScheme.lookup_scheme k ind))
+  with Not_found -> None
 [%%else]
 let for_scheme gr = gr
+let lookup_scheme_opt k ind =
+  DeclareScheme.lookup_scheme_opt k ind
 [%%endif]
 
 let cs_pattern =
@@ -4657,6 +4662,19 @@ Supported attributes:
         declare_scheme_aux local ref k gr;
         state, (), []
       )),
+  DocAbove);
+
+  MLCode(Pred("coq.env.scheme",
+    In(scheme_kind, "Kind",
+    In(gref, "GR",
+    Out(option gref, "Scheme",
+    Easy "looks up the scheme of the given kind for GR. Returns none if GR is not an inductive or no such scheme is registered."))),
+  (fun k gr _ ~depth ->
+    let k = string_of_scheme_kind k in
+    match gr with
+    | GlobRef.IndRef ind ->
+      !: (lookup_scheme_opt k ind)
+    | _ -> !: None)),
   DocAbove);
 
   LPDoc "-- Extra Dependencies -----------------------------------------------";

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -546,13 +546,33 @@ let abbreviation_declare = Abbreviation.declare
 let for_scheme = function
 | GlobRef.ConstRef c -> c
 | _ -> U.type_error "Register Scheme: expecing a constant."
-let lookup_scheme_opt k ind =
-  try Some (GlobRef.ConstRef (DeclareScheme.lookup_scheme k ind))
-  with Not_found -> None
+let lookup_scheme_opt k gr =
+  match gr with
+  | GlobRef.IndRef ind ->
+    (try Some (GlobRef.ConstRef (DeclareScheme.lookup_scheme k ind))
+     with Not_found -> None)
+  | _ -> None
+[%%elif coq = "9.2"]
+let for_scheme gr = gr
+let lookup_scheme_opt k gr =
+  match gr with
+  | GlobRef.IndRef ind -> DeclareScheme.lookup_scheme_opt k ind
+  | _ -> None
 [%%else]
 let for_scheme gr = gr
-let lookup_scheme_opt k ind =
-  DeclareScheme.lookup_scheme_opt k ind
+let lookup_scheme_opt k gr =
+  DeclareScheme.lookup_scheme_opt k gr
+[%%endif]
+
+[%%if coq = "9.0" || coq = "9.1" || coq = "9.2"]
+let declare_scheme_for local k x gr =
+  let ind = match x with
+    | GlobRef.IndRef i -> i
+    | _ -> U.type_error "Register_scheme: expecting an inductive" in
+  DeclareScheme.declare_scheme local k (ind, for_scheme gr)
+[%%else]
+let declare_scheme_for local k x gr =
+  DeclareScheme.declare_scheme local k (x, for_scheme gr)
 [%%endif]
 
 let cs_pattern =
@@ -1953,19 +1973,6 @@ let next_name_away_with_default_using_types = Namegen.next_name_away_with_defaul
 let univ_binder_compat_820 a b = a
 [%%else]
 let univ_binder_compat_820 a b = b
-[%%endif]
-
-[%%if coq = "9.0" || coq = "9.1" || coq = "9.2"]
-let declare_scheme_aux local ref k gr =
-  let ind =
-    match ref with
-    | GlobRef.IndRef i -> i
-    | _ -> U.type_error "Register_scheme: expecting an inductive"
-  in
-  declare_scheme local k (ind,for_scheme gr)
-[%%else]
-let declare_scheme_aux local ref k gr =
-  declare_scheme local k (ref,for_scheme gr)
 [%%endif]
 
 [%%if coq = "9.0" || coq = "9.1"]
@@ -4659,22 +4666,18 @@ Supported attributes:
         state, (), []
       | Scheme(ref,k) ->
         let k = string_of_scheme_kind k in
-        declare_scheme_aux local ref k gr;
+        declare_scheme_for local k ref gr;
         state, (), []
       )),
   DocAbove);
 
-  MLCode(Pred("coq.env.scheme",
+    MLCode(Pred("coq.scheme",
     In(scheme_kind, "Kind",
     In(gref, "GR",
     Out(option gref, "Scheme",
     Easy "looks up the scheme of the given kind for GR. Returns none if GR is not an inductive or no such scheme is registered."))),
   (fun k gr _ ~depth ->
-    let k = string_of_scheme_kind k in
-    match gr with
-    | GlobRef.IndRef ind ->
-      !: (lookup_scheme_opt k ind)
-    | _ -> !: None)),
+    !: (lookup_scheme_opt (string_of_scheme_kind k) gr))),
   DocAbove);
 
   LPDoc "-- Extra Dependencies -----------------------------------------------";

--- a/tests-stdlib/test_API_register.v
+++ b/tests-stdlib/test_API_register.v
@@ -26,3 +26,23 @@ intros p q H.
 injection H.
 apply id.
 Qed.
+
+Elpi Query lp:{{
+  coq.env.scheme coq.register.scheme.eq_dec {{:gref T}} (some GR),
+  coq.say "eq_dec scheme for T:" GR.
+}}.
+
+Elpi Query lp:{{
+  coq.env.scheme coq.register.scheme.ind_dep {{:gref nat}} (some GR),
+  coq.say "ind_dep scheme for nat:" GR.
+}}.
+
+Elpi Query lp:{{
+  coq.env.scheme coq.register.scheme.rect_dep {{:gref nat}} (some GR),
+  coq.say "rect_dep scheme for nat:" GR.
+}}.
+
+(* non-inductive gref returns none *)
+Elpi Query lp:{{
+  coq.env.scheme coq.register.scheme.ind_dep {{:gref T_dec}} none.
+}}.

--- a/tests-stdlib/test_API_register.v
+++ b/tests-stdlib/test_API_register.v
@@ -28,21 +28,21 @@ apply id.
 Qed.
 
 Elpi Query lp:{{
-  coq.env.scheme coq.register.scheme.eq_dec {{:gref T}} (some GR),
+  coq.scheme coq.register.scheme.eq_dec {{:gref T}} (some GR),
   coq.say "eq_dec scheme for T:" GR.
 }}.
 
 Elpi Query lp:{{
-  coq.env.scheme coq.register.scheme.ind_dep {{:gref nat}} (some GR),
+  coq.scheme coq.register.scheme.ind_dep {{:gref nat}} (some GR),
   coq.say "ind_dep scheme for nat:" GR.
 }}.
 
 Elpi Query lp:{{
-  coq.env.scheme coq.register.scheme.rect_dep {{:gref nat}} (some GR),
+  coq.scheme coq.register.scheme.rect_dep {{:gref nat}} (some GR),
   coq.say "rect_dep scheme for nat:" GR.
 }}.
 
 (* non-inductive gref returns none *)
 Elpi Query lp:{{
-  coq.env.scheme coq.register.scheme.ind_dep {{:gref T_dec}} none.
+  coq.scheme coq.register.scheme.ind_dep {{:gref T_dec}} none.
 }}.


### PR DESCRIPTION
Analogous to rocq-prover/rocq#21658 (Ltac2 Scheme.lookup), this adds an ELPI predicate to look up the scheme registered for a given global reference and scheme kind.  The input is gref (not just inductive) for future-proofing; non-inductive grefs simply return none.