### PR TITLE
`derive.param{1,2}` : give fresh names to constructors

### DIFF
--- a/apps/derive/elpi/param1.elpi
+++ b/apps/derive/elpi/param1.elpi
@@ -152,8 +152,10 @@ dispatch (const GR) Prefix Clauses :- !, do! [
 ].
 
 func prefix-indc string, constructor -> pair constructor id.
-prefix-indc Prefix K (pr K NewName) :-
-  coq.gref->id (indc K) Name, NewName is Prefix ^ Name.
+prefix-indc Prefix K (pr K FNewName) :-
+  coq.gref->id (indc K) Name,
+  NewName is Prefix ^ Name,
+  coq.ensure-fresh-global-id NewName FNewName.
 
 dispatch (indt GR) Prefix Clauses :- !, do! [
   Ind = global (indt GR),

--- a/apps/derive/elpi/param2.elpi
+++ b/apps/derive/elpi/param2.elpi
@@ -124,9 +124,10 @@ param-indt GR IsInd Lno Luno Ty Knames Ktypes
 ].
 
 func rename-indc string, constructor -> pair constructor id.
-rename-indc Suffix GR (pr GR NameR) :-
+rename-indc Suffix GR (pr GR FNameR) :-
   coq.gref->id (indc GR) Name,
-  NameR is Name ^ Suffix.
+  NameR is Name ^ Suffix,
+  coq.ensure-fresh-global-id NameR FNameR.
 
 func param-indc term, term -> term.
 param-indc K T TRK :- !,


### PR DESCRIPTION
When `param{1,2}.elpi` registers a relation as a new inductive type,
the name of the type itself is processed by `coq.ensure-fresh-global-id`, but not those of its constructors (KnamesR):
https://github.com/LPCIC/coq-elpi/blob/87d8ba7cdc3321e7479de1380dade8eb9ad4189a/apps/derive/elpi/param2.elpi#L202

This caused conflicts while I was experimenting `derive` in `coq-monae`.

This PR is intended to solve this issue by inserting `coq.ensure-fresh-global-id` in `rename-indc` and `prefix-indc`.

CC: @affeldt-aist