### PR TITLE
Add HOAS support for mutual fixpoints (mfix constructor)

### DIFF
--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -214,11 +214,11 @@ external symbol app     : list term -> term.                   % app [hd|args]
 external symbol match   : term -> term -> list term -> term.   % match t p [branch])
 external symbol fix     : name -> int -> term -> (term -> term) -> term. % fix name rno ty bo
 
-external symbol mfix  : name -> int -> term -> (term -> term) -> term. % mfix name rno ty rest
+external symbol mfix  : name -> term -> (term -> term) -> term. % mfix name ty rest
 
 kind mpair type.
-external symbol mpair : term -> term -> mpair.                          % mpair f body
-external symbol mbody : list mpair -> term -> term.                     % mbody defs focused
+external symbol mpair : int -> term -> mpair.                   % mpair recno body
+external symbol mbody : list mpair -> int -> term.              % mbody defs focused
 
 external symbol primitive : primitive-value -> term.
 

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -214,11 +214,10 @@ external symbol app     : list term -> term.                   % app [hd|args]
 external symbol match   : term -> term -> list term -> term.   % match t p [branch])
 external symbol fix     : name -> int -> term -> (term -> term) -> term. % fix name rno ty bo
 
-external symbol mfix  : name -> term -> (term -> term) -> term. % mfix name ty rest
-
-kind mpair type.
-external symbol mpair : int -> term -> mpair.                   % mpair recno body
-external symbol mbody : list mpair -> int -> term.              % mbody defs focused
+kind mfix-block type.
+external symbol mfix-call : int -> mfix-block -> term.          % mfix-call focus
+external symbol mfix-ty   : name -> int -> term -> (term -> mfix-block) -> mfix-block. % mfix-ty name recno ty rest
+external symbol mfix-body : list term -> mfix-block.            % mfix-body bodies
 
 external symbol primitive : primitive-value -> term.
 

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -214,9 +214,11 @@ external symbol app     : list term -> term.                   % app [hd|args]
 external symbol match   : term -> term -> list term -> term.   % match t p [branch])
 external symbol fix     : name -> int -> term -> (term -> term) -> term. % fix name rno ty bo
 
-kind mfix-def type.
-external symbol mfix-def : name -> int -> term -> mfix-def.       % mfix-def name rno ty
-external symbol mfix     : list mfix-def -> int -> term -> term.  % mfix defs focus bo
+external symbol mfix  : name -> int -> term -> (term -> term) -> term. % mfix name rno ty rest
+
+kind mpair type.
+external symbol mpair : term -> term -> mpair.                          % mpair f body
+external symbol mbody : list mpair -> term -> term.                     % mbody defs focused
 
 external symbol primitive : primitive-value -> term.
 

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -214,6 +214,10 @@ external symbol app     : list term -> term.                   % app [hd|args]
 external symbol match   : term -> term -> list term -> term.   % match t p [branch])
 external symbol fix     : name -> int -> term -> (term -> term) -> term. % fix name rno ty bo
 
+kind mfix-def type.
+external symbol mfix-def : name -> int -> term -> mfix-def.       % mfix-def name rno ty
+external symbol mfix     : list mfix-def -> int -> term -> term.  % mfix defs focus bo
+
 external symbol primitive : primitive-value -> term.
 
 % NYI

--- a/elpi/coq-HOAS.elpi
+++ b/elpi/coq-HOAS.elpi
@@ -42,11 +42,10 @@ external symbol app     : list term -> term.                   % app [hd|args]
 external symbol match   : term -> term -> list term -> term.   % match t p [branch])
 external symbol fix     : name -> int -> term -> (term -> term) -> term. % fix name rno ty bo
 
-external symbol mfix  : name -> term -> (term -> term) -> term. % mfix name ty rest
-
-kind mpair type.
-external symbol mpair : int -> term -> mpair.                   % mpair recno body
-external symbol mbody : list mpair -> int -> term.              % mbody defs focused
+kind mfix-block type.
+external symbol mfix-call : int -> mfix-block -> term.          % mfix-call focus
+external symbol mfix-ty   : name -> int -> term -> (term -> mfix-block) -> mfix-block. % mfix-ty name recno ty rest
+external symbol mfix-body : list term -> mfix-block.            % mfix-body bodies
 
 external symbol primitive : primitive-value -> term.
 

--- a/elpi/coq-HOAS.elpi
+++ b/elpi/coq-HOAS.elpi
@@ -42,9 +42,11 @@ external symbol app     : list term -> term.                   % app [hd|args]
 external symbol match   : term -> term -> list term -> term.   % match t p [branch])
 external symbol fix     : name -> int -> term -> (term -> term) -> term. % fix name rno ty bo
 
-kind mfix-def type.
-external symbol mfix-def : name -> int -> term -> mfix-def.       % mfix-def name rno ty
-external symbol mfix     : list mfix-def -> int -> term -> term.  % mfix defs focus bo
+external symbol mfix  : name -> int -> term -> (term -> term) -> term. % mfix name rno ty rest
+
+kind mpair type.
+external symbol mpair : term -> term -> mpair.                          % mpair f body
+external symbol mbody : list mpair -> term -> term.                     % mbody defs focused
 
 external symbol primitive : primitive-value -> term.
 

--- a/elpi/coq-HOAS.elpi
+++ b/elpi/coq-HOAS.elpi
@@ -42,11 +42,11 @@ external symbol app     : list term -> term.                   % app [hd|args]
 external symbol match   : term -> term -> list term -> term.   % match t p [branch])
 external symbol fix     : name -> int -> term -> (term -> term) -> term. % fix name rno ty bo
 
-external symbol mfix  : name -> int -> term -> (term -> term) -> term. % mfix name rno ty rest
+external symbol mfix  : name -> term -> (term -> term) -> term. % mfix name ty rest
 
 kind mpair type.
-external symbol mpair : term -> term -> mpair.                          % mpair f body
-external symbol mbody : list mpair -> term -> term.                     % mbody defs focused
+external symbol mpair : int -> term -> mpair.                   % mpair recno body
+external symbol mbody : list mpair -> int -> term.              % mbody defs focused
 
 external symbol primitive : primitive-value -> term.
 

--- a/elpi/coq-HOAS.elpi
+++ b/elpi/coq-HOAS.elpi
@@ -42,6 +42,10 @@ external symbol app     : list term -> term.                   % app [hd|args]
 external symbol match   : term -> term -> list term -> term.   % match t p [branch])
 external symbol fix     : name -> int -> term -> (term -> term) -> term. % fix name rno ty bo
 
+kind mfix-def type.
+external symbol mfix-def : name -> int -> term -> mfix-def.       % mfix-def name rno ty
+external symbol mfix     : list mfix-def -> int -> term -> term.  % mfix defs focus bo
+
 external symbol primitive : primitive-value -> term.
 
 % NYI

--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -115,11 +115,10 @@ copy (prod N T F) (prod N T1 F1) :- !,
 copy (app L) (app L1) :- !, map L copy L1.
 copy (fix N Rno Ty F) (fix N Rno Ty1 F1) :- !,
   copy Ty Ty1, pi x\ copy (F x) (F1 x).
-copy (mfix N Rno Ty F) (mfix N Rno Ty1 F1) :- !,
+copy (mfix N Ty F) (mfix N Ty1 F1) :- !,
   copy Ty Ty1, pi x\ copy (F x) (F1 x).
-copy (mbody Bs F) (mbody Bs1 F1) :- !,
-  copy-mpair-list Bs Bs1,
-  copy F F1.
+copy (mbody Bs N) (mbody Bs1 N) :- !,
+  copy-mpair-list Bs Bs1.
 copy (match T Rty B) (match T1 Rty1 B1) :- !,
   copy T T1, copy Rty Rty1, map B copy B1.
 copy (primitive _ as C) C :- !.
@@ -128,8 +127,8 @@ copy (uvar M L as X) W :- var X, !, map L copy L1, coq.mk-app-uvar M L1 W.
 copy (uvar X L) (uvar X L1) :- !, map L copy L1.
 
 copy-mpair-list [] [].
-copy-mpair-list [mpair A B | Xs] [mpair A1 B1 | Ys] :-
-  copy A A1, copy B B1, copy-mpair-list Xs Ys.
+copy-mpair-list [mpair R B | Xs] [mpair R B1 | Ys] :-
+  copy B B1, copy-mpair-list Xs Ys.
 
 func copy-ctx-item prop -> prop.
 copy-ctx-item (decl X N T) (decl X1 N T1) :- copy X X1, copy T T1.

--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -98,8 +98,6 @@ coq.saturate _ X X.
 % [copy A B] can be used to perform a replacement, eg
 %   (copy (const "foo") (const "bar") :- !) => copy A B
 % traverses A replacing foo with bar.
-func copy-mpair-list list mpair -> list mpair.
-
 func copy term -> term.
 :name "copy:start"
 copy X Y :- name X, !, X = Y, !. % avoid loading "copy x x" at binders
@@ -115,10 +113,8 @@ copy (prod N T F) (prod N T1 F1) :- !,
 copy (app L) (app L1) :- !, map L copy L1.
 copy (fix N Rno Ty F) (fix N Rno Ty1 F1) :- !,
   copy Ty Ty1, pi x\ copy (F x) (F1 x).
-copy (mfix N Ty F) (mfix N Ty1 F1) :- !,
-  copy Ty Ty1, pi x\ copy (F x) (F1 x).
-copy (mbody Bs N) (mbody Bs1 N) :- !,
-  copy-mpair-list Bs Bs1.
+copy (mfix-call F MF) (mfix-call F MF1) :- !,
+  copy-mfix-block MF MF1.
 copy (match T Rty B) (match T1 Rty1 B1) :- !,
   copy T T1, copy Rty Rty1, map B copy B1.
 copy (primitive _ as C) C :- !.
@@ -126,9 +122,11 @@ copy (uvar M L as X) W :- var X, !, map L copy L1, coq.mk-app-uvar M L1 W.
 % when used in CHR rules
 copy (uvar X L) (uvar X L1) :- !, map L copy L1.
 
-copy-mpair-list [] [].
-copy-mpair-list [mpair R B | Xs] [mpair R B1 | Ys] :-
-  copy B B1, copy-mpair-list Xs Ys.
+func copy-mfix-block mfix-block -> mfix-block.
+copy-mfix-block (mfix-ty N Rno Ty F) (mfix-ty N Rno Ty1 F1) :- !,
+  copy Ty Ty1, pi x\ copy-mfix-block (F x) (F1 x).
+copy-mfix-block (mfix-body Bs) (mfix-body Bs1) :- !,
+  map Bs copy Bs1.
 
 func copy-ctx-item prop -> prop.
 copy-ctx-item (decl X N T) (decl X1 N T1) :- copy X X1, copy T T1.

--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -98,6 +98,8 @@ coq.saturate _ X X.
 % [copy A B] can be used to perform a replacement, eg
 %   (copy (const "foo") (const "bar") :- !) => copy A B
 % traverses A replacing foo with bar.
+func copy-mpair-list list mpair -> list mpair.
+
 func copy term -> term.
 :name "copy:start"
 copy X Y :- name X, !, X = Y, !. % avoid loading "copy x x" at binders
@@ -113,12 +115,21 @@ copy (prod N T F) (prod N T1 F1) :- !,
 copy (app L) (app L1) :- !, map L copy L1.
 copy (fix N Rno Ty F) (fix N Rno Ty1 F1) :- !,
   copy Ty Ty1, pi x\ copy (F x) (F1 x).
+copy (mfix N Rno Ty F) (mfix N Rno Ty1 F1) :- !,
+  copy Ty Ty1, pi x\ copy (F x) (F1 x).
+copy (mbody Bs F) (mbody Bs1 F1) :- !,
+  copy-mpair-list Bs Bs1,
+  copy F F1.
 copy (match T Rty B) (match T1 Rty1 B1) :- !,
   copy T T1, copy Rty Rty1, map B copy B1.
 copy (primitive _ as C) C :- !.
 copy (uvar M L as X) W :- var X, !, map L copy L1, coq.mk-app-uvar M L1 W.
 % when used in CHR rules
 copy (uvar X L) (uvar X L1) :- !, map L copy L1.
+
+copy-mpair-list [] [].
+copy-mpair-list [mpair A B | Xs] [mpair A1 B1 | Ys] :-
+  copy A A1, copy B B1, copy-mpair-list Xs Ys.
 
 func copy-ctx-item prop -> prop.
 copy-ctx-item (decl X N T) (decl X1 N T1) :- copy X X1, copy T T1.

--- a/elpi/elpi-reduction.elpi
+++ b/elpi/elpi-reduction.elpi
@@ -45,28 +45,23 @@ whd (match A _ L) C X XC :- whd-indc A GR KA, !,
   whd {match-red GR KA L C} X XC.
 whd (fix _ N _ F as Fix) C X XC :- nth-stack N C LA A RA, whd-indc A GR KA, !,
   whd {fix-red F Fix LA GR KA RA} X XC.
-whd (mfix _ _ _ as MF) C X XC :- mk-mfixes MF 0 L, whd-mfix MF L C X XC, !.
+whd (mfix-call Fno MF) C X XC :-
+  mfix-ty-rno Fno MF N, nth-stack N C LA A RA, whd-indc A GR KA, !,
+  whd-mfix MF MF 0 Fno LA GR KA RA X XC.
 whd N C X XC :- name N, def N _ _ V, !, cache-whd N VN V, whd VN C X XC.
 whd X C X C.
 
-func whd-mfix term, list term, stack -> term, stack.
-whd-mfix (mfix _ _ F) [D|Ds] C X XC :- whd-mfix (F D) Ds C X XC.
-whd-mfix (mbody Bs N) [] C X XC :-
-  std.nth N Bs (mpair Rno B),
-  nth-stack Rno C _LA A _RA, whd-indc A _GR _KA,
-  whd B C X XC.
+func mfix-ty-rno int, mfix-block -> int.
+mfix-ty-rno 0 (mfix-ty _ Rno _ _) Rno :- !.
+mfix-ty-rno N (mfix-ty _ _ _ F) Rno :- pi x\ mfix-ty-rno {calc (N - 1)} (F x) Rno.
 
-% Build the n recursive self-references (one per mutual component)
-func mk-mfixes term, int -> list term.
-mk-mfixes (mfix N T F) Fixes R1 :-
-  (pi x\ mk-mfixes (F x) {calc (1 + Fixes)} (R x)),
-  mk-mfix N T R R1.
-mk-mfixes (mbody L _) Fixes R :-
-  std.map {std.iota Fixes} (x\r\r = mbody L x) R.
-
-func mk-mfix name, term, (term -> list term) -> list term.
-mk-mfix _ _ (_\[]) [] :- !.
-mk-mfix N T (x\[F x|FS x]) [mfix N T F|Next] :- !, mk-mfix N T (x\FS x) Next.
+func whd-mfix mfix-block, mfix-block, int, int, stack, constructor, stack, stack -> term, stack.
+whd-mfix (mfix-ty _ _ _ F) MF Cur Fixno LA K KA RA X XC :-
+  whd-mfix (F (mfix-call Cur MF)) MF {calc (Cur + 1)} Fixno LA K KA RA X XC.
+whd-mfix (mfix-body Bs) _ _ Fixno LA K KA RA X XC :-
+  append LA [{coq.mk-app (global (indc K)) KA}|RA] ArgsWRedRecNo,
+  std.nth Fixno Bs B,
+  whd B ArgsWRedRecNo X XC.
 
 % assert A reduces to a constructor
 whd-indc A GR KA :- whd A [] VA C, !, not(var VA), (VA = global (indc GR); VA = pglobal (indc GR) _), !, KA = C.

--- a/elpi/elpi-reduction.elpi
+++ b/elpi/elpi-reduction.elpi
@@ -45,8 +45,28 @@ whd (match A _ L) C X XC :- whd-indc A GR KA, !,
   whd {match-red GR KA L C} X XC.
 whd (fix _ N _ F as Fix) C X XC :- nth-stack N C LA A RA, whd-indc A GR KA, !,
   whd {fix-red F Fix LA GR KA RA} X XC.
+whd (mfix _ _ _ as MF) C X XC :- mk-mfixes MF 0 L, whd-mfix MF L C X XC, !.
 whd N C X XC :- name N, def N _ _ V, !, cache-whd N VN V, whd VN C X XC.
 whd X C X C.
+
+func whd-mfix term, list term, stack -> term, stack.
+whd-mfix (mfix _ _ F) [D|Ds] C X XC :- whd-mfix (F D) Ds C X XC.
+whd-mfix (mbody Bs N) [] C X XC :-
+  std.nth N Bs (mpair Rno B),
+  nth-stack Rno C _LA A _RA, whd-indc A _GR _KA,
+  whd B C X XC.
+
+% Build the n recursive self-references (one per mutual component)
+func mk-mfixes term, int -> list term.
+mk-mfixes (mfix N T F) Fixes R1 :-
+  (pi x\ mk-mfixes (F x) {calc (1 + Fixes)} (R x)),
+  mk-mfix N T R R1.
+mk-mfixes (mbody L _) Fixes R :-
+  std.map {std.iota Fixes} (x\r\r = mbody L x) R.
+
+func mk-mfix name, term, (term -> list term) -> list term.
+mk-mfix _ _ (_\[]) [] :- !.
+mk-mfix N T (x\[F x|FS x]) [mfix N T F|Next] :- !, mk-mfix N T (x\FS x) Next.
 
 % assert A reduces to a constructor
 whd-indc A GR KA :- whd A [] VA C, !, not(var VA), (VA = global (indc GR); VA = pglobal (indc GR) _), !, KA = C.

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -939,38 +939,29 @@ let in_elpi_fix name rno ty bo =
 let in_elpiast_fix ~loc n rno ty bo =
   A.mkAppGlobal ~loc ~hdloc:loc fixc (in_elpiast_name ~loc n) [A.mkOpaque ~loc @@ CD.int.cino rno; ty; A.mkLam ~loc (name_of_name ~loc n) bo]
 
-let mfixc     = E.Constants.declare_global_symbol "mfix"
-let mbodyc    = E.Constants.declare_global_symbol "mbody"
-let mpairc    = E.Constants.declare_global_symbol "mpair"
+let mfix_callc = E.Constants.declare_global_symbol "mfix-call"
+let mfix_tyc   = E.Constants.declare_global_symbol "mfix-ty"
+let mfix_bodyc = E.Constants.declare_global_symbol "mfix-body"
 
 let in_elpiast_mfix ~loc names_rnos_tys focus_idx bodies =
   assert (List.length names_rnos_tys = List.length bodies);
-  (* Build mbody [mpair rno0 bo0, ...] focus_idx *)
-  let pairs = List.map2 (fun (_,rno,_) bo ->
-    A.mkAppGlobal ~loc ~hdloc:loc mpairc
-      (A.mkOpaque ~loc @@ CD.int.cino rno) [bo]
-  ) names_rnos_tys bodies in
-  let inner = A.mkAppGlobal ~loc ~hdloc:loc mbodyc
-    (A.list_to_lp_list ~loc pairs)
-    [A.mkOpaque ~loc @@ CD.int.cino focus_idx] in
-  (* Wrap with mfix nodes from inside out *)
-  List.fold_right (fun (name, _, ty) acc ->
-    A.mkAppGlobal ~loc ~hdloc:loc mfixc (in_elpiast_name ~loc name)
-      [ty; A.mkLam ~loc (name_of_name ~loc name) acc]
-  ) names_rnos_tys inner
+  let inner = A.mkAppGlobal ~loc ~hdloc:loc mfix_bodyc
+    (A.list_to_lp_list ~loc bodies) [] in
+  let block = List.fold_right (fun (name, rno, ty) acc ->
+    A.mkAppGlobal ~loc ~hdloc:loc mfix_tyc (in_elpiast_name ~loc name)
+      [A.mkOpaque ~loc @@ CD.int.cino rno; ty;
+       A.mkLam ~loc (name_of_name ~loc name) acc]
+  ) names_rnos_tys inner in
+  A.mkAppGlobal ~loc ~hdloc:loc mfix_callc
+    (A.mkOpaque ~loc @@ CD.int.cino focus_idx) [block]
 
 let in_elpi_mfix names_rnos_tys focus_idx bodies =
   assert (List.length names_rnos_tys = List.length bodies);
-  (* Build mbody [mpair rno0 bo0, ...] focus_idx *)
-  let pairs = List.map2 (fun (_,rno,_) bo ->
-    E.mkApp mpairc (CD.of_int rno) [bo]
-  ) names_rnos_tys bodies in
-  let inner = E.mkApp mbodyc (U.list_to_lp_list pairs)
-    [CD.of_int focus_idx] in
-  (* Wrap with mfix nodes from inside out *)
-  List.fold_right (fun (name, _, ty) acc ->
-    E.mkApp mfixc (in_elpi_name name) [ty; E.mkLam acc]
-  ) names_rnos_tys inner
+  let inner = E.mkApp mfix_bodyc (U.list_to_lp_list bodies) [] in
+  let block = List.fold_right (fun (name, rno, ty) acc ->
+    E.mkApp mfix_tyc (in_elpi_name name) [CD.of_int rno; ty; E.mkLam acc]
+  ) names_rnos_tys inner in
+  E.mkApp mfix_callc (CD.of_int focus_idx) [block]
 
 let primitivec   = E.Constants.declare_global_symbol "primitive"
 
@@ -2316,73 +2307,60 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
       state, EC.mkFix (([|rno|],0),([|name|],[|ty|],[|bo|])), gl1 @ gl2
 
  (* mfix *)
-  | E.App(c,name_lp,[ty_lp;rest_lam]) when mfixc == c ->
+  | E.App(c,focus_lp,[block_lp]) when mfix_callc == c ->
       (* mkFix's types live in outer_ctx (no self-refs); bodies use extended ctx. *)
       let outer_ctx = coq_ctx in
-      let rec collect_mfix ~depth state coq_ctx name_lp ty_lp rest_lam
-                           defs gls_acc =
-        let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name_lp in
-        let state, ty, gl =
-          lp2constr ~calldepth syntactic_constraints outer_ctx
-            ~depth state ~on_ty:true ty_lp in
-        let coq_ctx = push_coq_ctx_local depth
-          (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in
-        let defs = (name, ty) :: defs in
-        let gls_acc = gl @ gls_acc in
-        match E.look ~depth rest_lam with
-        | E.Lam body ->
-          let depth = depth + 1 in
-          (match E.look ~depth body with
-           | E.App(c2,name2,[ty2;rest2]) when mfixc == c2 ->
-             collect_mfix ~depth state coq_ctx name2 ty2 rest2
-               defs gls_acc
-           | E.App(c2,pairs_lp,[focus_lp]) when mbodyc == c2 ->
-             finish_mfix ~depth state coq_ctx (List.rev defs)
-               pairs_lp focus_lp gls_acc
-           | _ -> err Pp.(str"mfix: expected mfix or mbody inside mfix body"))
-        | _ -> err Pp.(str"mfix: expected lambda in mfix body")
-      and finish_mfix ~depth state coq_ctx defs pairs_lp focus_lp gls_acc =
+      let int_of ~ctx lp =
+        match E.look ~depth lp with
+        | E.CData n when CD.is_int n -> CD.to_int n
+        | _ -> err Pp.(str"mfix: " ++ str ctx ++ str" not an int: " ++
+                       str (P.Debug.show_term lp)) in
+      let focus_idx = int_of ~ctx:"focus" focus_lp in
+      let rec collect_ty ~depth state coq_ctx node defs gls_acc =
+        match E.look ~depth node with
+        | E.App(c2,name_lp,[rno_lp; ty_lp; rest_lam]) when mfix_tyc == c2 ->
+          let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name_lp in
+          let rno = int_of ~ctx:"mfix-ty rno" rno_lp in
+          let state, ty, gl =
+            lp2constr ~calldepth syntactic_constraints outer_ctx
+              ~depth state ~on_ty:true ty_lp in
+          let coq_ctx = push_coq_ctx_local depth
+            (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in
+          let defs = (name, rno, ty) :: defs in
+          let gls_acc = gl @ gls_acc in
+          (match E.look ~depth rest_lam with
+           | E.Lam body ->
+             collect_ty ~depth:(depth+1) state coq_ctx body defs gls_acc
+           | _ -> err Pp.(str"mfix: expected lambda in mfix-ty body"))
+        | E.App(c2,bodies_lp,[]) when mfix_bodyc == c2 ->
+          finish_mfix ~depth state coq_ctx (List.rev defs) bodies_lp gls_acc
+        | _ -> err Pp.(str"mfix: expected mfix-ty or mfix-body, got: " ++
+                       str (P.Debug.show_term node))
+      and finish_mfix ~depth state coq_ctx defs bodies_lp gls_acc =
         let n = List.length defs in
-        let focus_idx =
-          match E.look ~depth focus_lp with
-          | E.CData k when CD.is_int k ->
-            let idx = CD.to_int k in
-            if idx >= 0 && idx < n then idx
-            else err Pp.(str"mfix: focus index out of range: " ++ int idx)
-          | _ -> err Pp.(str"mfix: focus not an int: " ++
-                         str (P.Debug.show_term focus_lp)) in
-        let pair_list = U.lp_list_to_list ~depth pairs_lp in
-        if List.length pair_list <> n then
-          err Pp.(str"mfix: expected " ++ int n ++ str" body pairs, got " ++
-                  int (List.length pair_list));
-        let rnos_bodies = List.map (fun p ->
-          match E.look ~depth p with
-          | E.App(pc, rno_lp, [bo_lp]) when pc == mpairc ->
-            let rno = match E.look ~depth rno_lp with
-              | E.CData n when CD.is_int n -> CD.to_int n
-              | _ -> err Pp.(str"mfix: mpair rno not an int: " ++
-                             str (P.Debug.show_term rno_lp)) in
-            (rno, bo_lp)
-          | _ -> err Pp.(str"mfix: bad mpair: " ++
-                         str (P.Debug.show_term p))
-        ) pair_list in
+        if focus_idx < 0 || focus_idx >= n then
+          err Pp.(str"mfix: focus index out of range: " ++ int focus_idx);
+        let body_list = U.lp_list_to_list ~depth bodies_lp in
+        if List.length body_list <> n then
+          err Pp.(str"mfix: expected " ++ int n ++ str" bodies, got " ++
+                  int (List.length body_list));
         let state, coq_bodies, gls_bos =
-          List.fold_left (fun (state, bos, gls) (_, bo_lp) ->
+          List.fold_left (fun (state, bos, gls) bo_lp ->
             let state, bo, gl =
               lp2constr ~calldepth syntactic_constraints coq_ctx
                 ~depth state bo_lp in
             (state, bo :: bos, gl @ gls)
-          ) (state, [], []) rnos_bodies
+          ) (state, [], []) body_list
         in
         let coq_bodies = List.rev coq_bodies in
-        let names = Array.of_list (List.map fst defs) in
-        let typs = Array.of_list (List.map snd defs) in
-        let rnos = Array.of_list (List.map fst rnos_bodies) in
+        let names = Array.of_list (List.map (fun (n,_,_) -> n) defs) in
+        let rnos  = Array.of_list (List.map (fun (_,r,_) -> r) defs) in
+        let typs  = Array.of_list (List.map (fun (_,_,t) -> t) defs) in
         state,
         EC.mkFix ((rnos, focus_idx),(names, typs, Array.of_list coq_bodies)),
         gls_acc @ gls_bos
       in
-      collect_mfix ~depth state coq_ctx name_lp ty_lp rest_lam [] []
+      collect_ty ~depth state coq_ctx block_lp [] []
 
   | E.App(c,v,[]) when primitivec == c ->
       let state, v, gls = primitive_value.API.Conversion.readback ~depth state v in

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -938,7 +938,31 @@ let in_elpi_fix name rno ty bo =
 
 let in_elpiast_fix ~loc n rno ty bo =
   A.mkAppGlobal ~loc ~hdloc:loc fixc (in_elpiast_name ~loc n) [A.mkOpaque ~loc @@ CD.int.cino rno; ty; A.mkLam ~loc (name_of_name ~loc n) bo]
-  
+
+let mfixdefc = E.Constants.declare_global_symbol "mfix-def"
+let mfixc    = E.Constants.declare_global_symbol "mfix"
+
+let in_elpi_mfix_def name rno ty =
+  E.mkApp mfixdefc (in_elpi_name name) [CD.of_int rno; ty]
+
+let in_elpi_mfix defs focus_idx bodies =
+  let body_list = U.list_to_lp_list bodies in
+  let wrapped = List.fold_left (fun acc _def -> E.mkLam acc) body_list defs in
+  E.mkApp mfixc (U.list_to_lp_list defs) [CD.of_int focus_idx; wrapped]
+
+let in_elpiast_mfix ~loc names_rnos_tys focus_idx bodies =
+  let defs, lam_names_rev = List.fold_left (fun (defs, lns) (n, rno, ty) ->
+    let def = A.mkAppGlobal ~loc ~hdloc:loc mfixdefc
+      (in_elpiast_name ~loc n) [A.mkOpaque ~loc @@ CD.int.cino rno; ty] in
+    let ln = name_of_name ~loc n in
+    (def :: defs, ln :: lns)) ([], []) names_rnos_tys in
+  let defs = List.rev defs in
+  let body_list = A.list_to_lp_list ~loc bodies in
+  let wrapped = List.fold_left (fun acc nm ->
+    A.mkLam ~loc nm acc) body_list lam_names_rev in
+  A.mkAppGlobal ~loc ~hdloc:loc mfixc (A.list_to_lp_list ~loc defs)
+    [A.mkOpaque ~loc @@ CD.int.cino focus_idx; wrapped]
+
 let primitivec   = E.Constants.declare_global_symbol "primitive"
 
 
@@ -1664,7 +1688,20 @@ let rec constr2lp coq_ctx ~calldepth ~depth state t =
          let state, t = aux ~depth env state t in
          let state, p = in_elpi_primitive ~depth state (Projection p) in
          state, in_elpi_app ~depth p [|t|]
-    | C.Fix _ -> nYI "HOAS for mutual fix"
+    | C.Fix((rargs, focus_idx),(names, typs, bos)) ->
+         let n = Array.length names in
+         let state, elpi_typs =
+           CArray.fold_left_map (aux ~depth env) state typs in
+         let defs = Array.to_list (Array.init n (fun i ->
+           in_elpi_mfix_def names.(i).Context.binder_name rargs.(i) elpi_typs.(i))) in
+         let envn = Array.fold_left (fun env i ->
+           EConstr.push_rel
+             Context.Rel.Declaration.(LocalAssum(names.(i), typs.(i))) env
+         ) env (Array.init n Fun.id) in
+         let state, elpi_bos =
+           CArray.fold_left_map (aux ~depth:(depth+n) envn) state bos in
+         state,
+         in_elpi_mfix defs focus_idx (Array.to_list elpi_bos)
     | C.CoFix _ -> nYI "HOAS for cofix"
     | x -> in_elpi_primitive_value ~depth state x
   in
@@ -2268,6 +2305,65 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
         | E.CData n when CD.is_int n -> CD.to_int n
         | _ -> err Pp.(str"Not an int: " ++ str (P.Debug.show_term rno)) in
       state, EC.mkFix (([|rno|],0),([|name|],[|ty|],[|bo|])), gl1 @ gl2
+
+  | E.App(c,defs_lp,[focus_lp;bodies_lam]) when mfixc == c ->
+      let focus_idx =
+        match E.look ~depth focus_lp with
+        | E.CData n when CD.is_int n -> CD.to_int n
+        | _ -> err Pp.(str"mfix: focus not an int: " ++
+                       str (P.Debug.show_term focus_lp)) in
+      let defs_list = U.lp_list_to_list ~depth defs_lp in
+      let n = List.length defs_list in
+      let parse_def d =
+        match E.look ~depth d with
+        | E.App(dc, name_lp, [rno_lp; ty_lp]) when dc == mfixdefc ->
+          (name_lp, rno_lp, ty_lp)
+        | _ -> err Pp.(str"mfix: bad def: " ++ str (P.Debug.show_term d))
+      in
+      let parsed_defs = List.map parse_def defs_list in
+      let state, names_typs_rnos, gls_defs, coq_ctx, _i =
+        List.fold_left (fun (state, acc, gls, coq_ctx, i) (name_lp, rno_lp, ty_lp) ->
+          let d = depth + i in
+          let name = in_coq_fresh_annot_name ~depth:d ~coq_ctx d name_lp in
+          let state, ty, gl = aux ~depth state ~on_ty:true ty_lp in
+          let rno =
+            match E.look ~depth rno_lp with
+            | E.CData n when CD.is_int n -> CD.to_int n
+            | _ -> err Pp.(str"mfix: rno not an int") in
+          let coq_ctx = push_coq_ctx_local d
+            (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in
+          (state, (name, ty, rno) :: acc, gl @ gls, coq_ctx, i + 1)
+        ) (state, [], [], coq_ctx, 0) parsed_defs
+      in
+      let names_typs_rnos = List.rev names_typs_rnos in
+      let rec unwrap_lams k d t =
+        if k = 0 then t
+        else match E.look ~depth:d t with
+          | E.Lam t -> unwrap_lams (k - 1) (d + 1) t
+          | _ -> err Pp.(str"mfix: expected " ++ int n ++
+                         str" lambdas, got fewer")
+      in
+      let bodies_list_term = unwrap_lams n depth bodies_lam in
+      let body_terms = U.lp_list_to_list ~depth:(depth+n) bodies_list_term in
+      if List.length body_terms <> n then
+        err Pp.(str"mfix: expected " ++ int n ++ str" bodies, got " ++
+                int (List.length body_terms));
+      let state, coq_bodies, gls_bos =
+        List.fold_left (fun (state, bos, gls) bo_lp ->
+          let state, bo, gl =
+            lp2constr ~calldepth syntactic_constraints coq_ctx
+              ~depth:(depth+n) state bo_lp in
+          (state, bo :: bos, gl @ gls)
+        ) (state, [], []) body_terms
+      in
+      let coq_bodies = List.rev coq_bodies in
+      let names_arr = Array.of_list (List.map (fun (n,_,_) -> n) names_typs_rnos) in
+      let typs_arr = Array.of_list (List.map (fun (_,t,_) -> t) names_typs_rnos) in
+      let rnos_arr = Array.of_list (List.map (fun (_,_,r) -> r) names_typs_rnos) in
+      let bos_arr = Array.of_list coq_bodies in
+      state,
+      EC.mkFix ((rnos_arr, focus_idx),(names_arr, typs_arr, bos_arr)),
+      gls_defs @ gls_bos
 
   | E.App(c,v,[]) when primitivec == c ->
       let state, v, gls = primitive_value.API.Conversion.readback ~depth state v in

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -939,29 +939,43 @@ let in_elpi_fix name rno ty bo =
 let in_elpiast_fix ~loc n rno ty bo =
   A.mkAppGlobal ~loc ~hdloc:loc fixc (in_elpiast_name ~loc n) [A.mkOpaque ~loc @@ CD.int.cino rno; ty; A.mkLam ~loc (name_of_name ~loc n) bo]
 
-let mfixdefc = E.Constants.declare_global_symbol "mfix-def"
-let mfixc    = E.Constants.declare_global_symbol "mfix"
-
-let in_elpi_mfix_def name rno ty =
-  E.mkApp mfixdefc (in_elpi_name name) [CD.of_int rno; ty]
-
-let in_elpi_mfix defs focus_idx bodies =
-  let body_list = U.list_to_lp_list bodies in
-  let wrapped = List.fold_left (fun acc _def -> E.mkLam acc) body_list defs in
-  E.mkApp mfixc (U.list_to_lp_list defs) [CD.of_int focus_idx; wrapped]
+let mfixc     = E.Constants.declare_global_symbol "mfix"
+let mbodyc    = E.Constants.declare_global_symbol "mbody"
+let mpairc    = E.Constants.declare_global_symbol "mpair"
 
 let in_elpiast_mfix ~loc names_rnos_tys focus_idx bodies =
-  let defs, lam_names_rev = List.fold_left (fun (defs, lns) (n, rno, ty) ->
-    let def = A.mkAppGlobal ~loc ~hdloc:loc mfixdefc
-      (in_elpiast_name ~loc n) [A.mkOpaque ~loc @@ CD.int.cino rno; ty] in
-    let ln = name_of_name ~loc n in
-    (def :: defs, ln :: lns)) ([], []) names_rnos_tys in
-  let defs = List.rev defs in
-  let body_list = A.list_to_lp_list ~loc bodies in
-  let wrapped = List.fold_left (fun acc nm ->
-    A.mkLam ~loc nm acc) body_list lam_names_rev in
-  A.mkAppGlobal ~loc ~hdloc:loc mfixc (A.list_to_lp_list ~loc defs)
-    [A.mkOpaque ~loc @@ CD.int.cino focus_idx; wrapped]
+  assert (List.length names_rnos_tys = List.length bodies);
+  let bvar name =
+    let n = match name with
+      | Names.Name.Name id -> API.Ast.Name.from_string (Names.Id.to_string id)
+      | Names.Name.Anonymous -> API.Ast.Name.from_string "_" in
+    A.mkBound ~loc ~language:!coq_language n in
+  (* Build mbody [mpair f0 bo0, ...] f_focus *)
+  let pairs = List.map2 (fun (name,_,_) bo ->
+    A.mkAppGlobal ~loc ~hdloc:loc mpairc (bvar name) [bo]
+  ) names_rnos_tys bodies in
+  let (fn,_,_) = List.nth names_rnos_tys focus_idx in
+  let inner = A.mkAppGlobal ~loc ~hdloc:loc mbodyc
+    (A.list_to_lp_list ~loc pairs) [bvar fn] in
+  (* Wrap with mfix nodes from inside out *)
+  List.fold_right (fun (name, rno, ty) acc ->
+    A.mkAppGlobal ~loc ~hdloc:loc mfixc (in_elpiast_name ~loc name)
+      [A.mkOpaque ~loc @@ CD.int.cino rno; ty;
+       A.mkLam ~loc (name_of_name ~loc name) acc]
+  ) names_rnos_tys inner
+
+let in_elpi_mfix ~depth names_rnos_tys focus_idx bodies =
+  assert (List.length names_rnos_tys = List.length bodies);
+  (* Build mbody [mpair f0 bo0, ...] f_focus *)
+  let pairs = List.mapi (fun i bo ->
+    E.mkApp mpairc (E.mkConst (depth + i)) [bo]
+  ) bodies in
+  let inner = E.mkApp mbodyc (U.list_to_lp_list pairs)
+    [E.mkConst (depth + focus_idx)] in
+  (* Wrap with mfix nodes from inside out *)
+  List.fold_right (fun (name, rno, ty) acc ->
+    E.mkApp mfixc (in_elpi_name name) [CD.of_int rno; ty; E.mkLam acc]
+  ) names_rnos_tys inner
 
 let primitivec   = E.Constants.declare_global_symbol "primitive"
 
@@ -1684,16 +1698,12 @@ let rec constr2lp coq_ctx ~calldepth ~depth state t =
          let env = EConstr.push_rel Context.Rel.Declaration.(LocalAssum(name,typ0)) env in
          let state, bo = aux ~depth:(depth+1) env state bo in
          state, in_elpi_fix name.Context.binder_name rarg typ bo
-    | C.Proj(p,_,t) ->
-         let state, t = aux ~depth env state t in
-         let state, p = in_elpi_primitive ~depth state (Projection p) in
-         state, in_elpi_app ~depth p [|t|]
     | C.Fix((rargs, focus_idx),(names, typs, bos)) ->
          let n = Array.length names in
          let state, elpi_typs =
            CArray.fold_left_map (aux ~depth env) state typs in
-         let defs = Array.to_list (Array.init n (fun i ->
-           in_elpi_mfix_def names.(i).Context.binder_name rargs.(i) elpi_typs.(i))) in
+         let names_rnos_tys = Array.to_list (Array.init n (fun i ->
+           (names.(i).Context.binder_name, rargs.(i), elpi_typs.(i)))) in
          let envn = Array.fold_left (fun env i ->
            EConstr.push_rel
              Context.Rel.Declaration.(LocalAssum(names.(i), typs.(i))) env
@@ -1701,7 +1711,11 @@ let rec constr2lp coq_ctx ~calldepth ~depth state t =
          let state, elpi_bos =
            CArray.fold_left_map (aux ~depth:(depth+n) envn) state bos in
          state,
-         in_elpi_mfix defs focus_idx (Array.to_list elpi_bos)
+         in_elpi_mfix ~depth names_rnos_tys focus_idx (Array.to_list elpi_bos)
+    | C.Proj(p,_,t) ->
+         let state, t = aux ~depth env state t in
+         let state, p = in_elpi_primitive ~depth state (Projection p) in
+         state, in_elpi_app ~depth p [|t|]
     | C.CoFix _ -> nYI "HOAS for cofix"
     | x -> in_elpi_primitive_value ~depth state x
   in
@@ -2306,64 +2320,72 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
         | _ -> err Pp.(str"Not an int: " ++ str (P.Debug.show_term rno)) in
       state, EC.mkFix (([|rno|],0),([|name|],[|ty|],[|bo|])), gl1 @ gl2
 
-  | E.App(c,defs_lp,[focus_lp;bodies_lam]) when mfixc == c ->
-      let focus_idx =
-        match E.look ~depth focus_lp with
-        | E.CData n when CD.is_int n -> CD.to_int n
-        | _ -> err Pp.(str"mfix: focus not an int: " ++
-                       str (P.Debug.show_term focus_lp)) in
-      let defs_list = U.lp_list_to_list ~depth defs_lp in
-      let n = List.length defs_list in
-      let parse_def d =
-        match E.look ~depth d with
-        | E.App(dc, name_lp, [rno_lp; ty_lp]) when dc == mfixdefc ->
-          (name_lp, rno_lp, ty_lp)
-        | _ -> err Pp.(str"mfix: bad def: " ++ str (P.Debug.show_term d))
+ (* mfix *)
+  | E.App(c,name_lp,[rno_lp;ty_lp;rest_lam]) when mfixc == c ->
+      let base_depth = depth in
+      let rec collect_mfix ~depth state coq_ctx name_lp rno_lp ty_lp rest_lam
+                           defs gls_acc =
+        let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name_lp in
+        (* coq_ctx evolves at each iteration *)
+        let state, ty, gl =
+          lp2constr ~calldepth syntactic_constraints coq_ctx
+            ~depth state ~on_ty:true ty_lp in
+        let rno =
+          match E.look ~depth rno_lp with
+          | E.CData n when CD.is_int n -> CD.to_int n
+          | _ -> err Pp.(str"Not an int: " ++ str (P.Debug.show_term rno_lp)) in
+        let coq_ctx = push_coq_ctx_local depth
+          (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in
+        let defs = (name, ty, rno) :: defs in
+        let gls_acc = gl @ gls_acc in
+        match E.look ~depth rest_lam with
+        | E.Lam body ->
+          let depth = depth + 1 in
+          (match E.look ~depth body with
+           | E.App(c2,name2,[rno2;ty2;rest2]) when mfixc == c2 ->
+             collect_mfix ~depth state coq_ctx name2 rno2 ty2 rest2
+               defs gls_acc
+           | E.App(c2,pairs_lp,[focus_lp]) when mbodyc == c2 ->
+             finish_mfix ~depth state coq_ctx (List.rev defs)
+               pairs_lp focus_lp gls_acc
+           | _ -> err Pp.(str"mfix: expected mfix or mbody inside mfix body"))
+        | _ -> err Pp.(str"mfix: expected lambda in mfix body")
+      and finish_mfix ~depth state coq_ctx defs pairs_lp focus_lp gls_acc =
+        let n = List.length defs in
+        let pair_list = U.lp_list_to_list ~depth pairs_lp in
+        if List.length pair_list <> n then
+          err Pp.(str"mfix: expected " ++ int n ++ str" body pairs, got " ++
+                  int (List.length pair_list));
+        let body_terms = List.map (fun p ->
+          match E.look ~depth p with
+          | E.App(pc, _fi, [bi]) when pc == mpairc -> bi
+          | _ -> err Pp.(str"mfix: bad mpair: " ++
+                         str (P.Debug.show_term p))
+        ) pair_list in
+        let state, coq_bodies, gls_bos =
+          List.fold_left (fun (state, bos, gls) bo_lp ->
+            let state, bo, gl =
+              lp2constr ~calldepth syntactic_constraints coq_ctx
+                ~depth state bo_lp in
+            (state, bo :: bos, gl @ gls)
+          ) (state, [], []) body_terms
+        in
+        let coq_bodies = List.rev coq_bodies in
+        let focus_idx =
+          match E.look ~depth focus_lp with
+          | E.Const k ->
+            let idx = k - base_depth in
+            if idx >= 0 && idx < n then idx
+            else err Pp.(str"mfix: focus variable out of range")
+          | _ -> err Pp.(str"mfix: focus not a bound variable: " ++
+                         str (P.Debug.show_term focus_lp))
+        in
+        let names, typs, rnos = CArray.split3 (Array.of_list defs) in
+        state,
+        EC.mkFix ((rnos, focus_idx),(names, typs, Array.of_list coq_bodies)),
+        gls_acc @ gls_bos
       in
-      let parsed_defs = List.map parse_def defs_list in
-      let state, names_typs_rnos, gls_defs, coq_ctx, _i =
-        List.fold_left (fun (state, acc, gls, coq_ctx, i) (name_lp, rno_lp, ty_lp) ->
-          let d = depth + i in
-          let name = in_coq_fresh_annot_name ~depth:d ~coq_ctx d name_lp in
-          let state, ty, gl = aux ~depth state ~on_ty:true ty_lp in
-          let rno =
-            match E.look ~depth rno_lp with
-            | E.CData n when CD.is_int n -> CD.to_int n
-            | _ -> err Pp.(str"mfix: rno not an int") in
-          let coq_ctx = push_coq_ctx_local d
-            (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in
-          (state, (name, ty, rno) :: acc, gl @ gls, coq_ctx, i + 1)
-        ) (state, [], [], coq_ctx, 0) parsed_defs
-      in
-      let names_typs_rnos = List.rev names_typs_rnos in
-      let rec unwrap_lams k d t =
-        if k = 0 then t
-        else match E.look ~depth:d t with
-          | E.Lam t -> unwrap_lams (k - 1) (d + 1) t
-          | _ -> err Pp.(str"mfix: expected " ++ int n ++
-                         str" lambdas, got fewer")
-      in
-      let bodies_list_term = unwrap_lams n depth bodies_lam in
-      let body_terms = U.lp_list_to_list ~depth:(depth+n) bodies_list_term in
-      if List.length body_terms <> n then
-        err Pp.(str"mfix: expected " ++ int n ++ str" bodies, got " ++
-                int (List.length body_terms));
-      let state, coq_bodies, gls_bos =
-        List.fold_left (fun (state, bos, gls) bo_lp ->
-          let state, bo, gl =
-            lp2constr ~calldepth syntactic_constraints coq_ctx
-              ~depth:(depth+n) state bo_lp in
-          (state, bo :: bos, gl @ gls)
-        ) (state, [], []) body_terms
-      in
-      let coq_bodies = List.rev coq_bodies in
-      let names_arr = Array.of_list (List.map (fun (n,_,_) -> n) names_typs_rnos) in
-      let typs_arr = Array.of_list (List.map (fun (_,t,_) -> t) names_typs_rnos) in
-      let rnos_arr = Array.of_list (List.map (fun (_,_,r) -> r) names_typs_rnos) in
-      let bos_arr = Array.of_list coq_bodies in
-      state,
-      EC.mkFix ((rnos_arr, focus_idx),(names_arr, typs_arr, bos_arr)),
-      gls_defs @ gls_bos
+      collect_mfix ~depth state coq_ctx name_lp rno_lp ty_lp rest_lam [] []
 
   | E.App(c,v,[]) when primitivec == c ->
       let state, v, gls = primitive_value.API.Conversion.readback ~depth state v in

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -945,36 +945,31 @@ let mpairc    = E.Constants.declare_global_symbol "mpair"
 
 let in_elpiast_mfix ~loc names_rnos_tys focus_idx bodies =
   assert (List.length names_rnos_tys = List.length bodies);
-  let bvar name =
-    let n = match name with
-      | Names.Name.Name id -> API.Ast.Name.from_string (Names.Id.to_string id)
-      | Names.Name.Anonymous -> API.Ast.Name.from_string "_" in
-    A.mkBound ~loc ~language:!coq_language n in
-  (* Build mbody [mpair f0 bo0, ...] f_focus *)
-  let pairs = List.map2 (fun (name,_,_) bo ->
-    A.mkAppGlobal ~loc ~hdloc:loc mpairc (bvar name) [bo]
+  (* Build mbody [mpair rno0 bo0, ...] focus_idx *)
+  let pairs = List.map2 (fun (_,rno,_) bo ->
+    A.mkAppGlobal ~loc ~hdloc:loc mpairc
+      (A.mkOpaque ~loc @@ CD.int.cino rno) [bo]
   ) names_rnos_tys bodies in
-  let (fn,_,_) = List.nth names_rnos_tys focus_idx in
   let inner = A.mkAppGlobal ~loc ~hdloc:loc mbodyc
-    (A.list_to_lp_list ~loc pairs) [bvar fn] in
+    (A.list_to_lp_list ~loc pairs)
+    [A.mkOpaque ~loc @@ CD.int.cino focus_idx] in
   (* Wrap with mfix nodes from inside out *)
-  List.fold_right (fun (name, rno, ty) acc ->
+  List.fold_right (fun (name, _, ty) acc ->
     A.mkAppGlobal ~loc ~hdloc:loc mfixc (in_elpiast_name ~loc name)
-      [A.mkOpaque ~loc @@ CD.int.cino rno; ty;
-       A.mkLam ~loc (name_of_name ~loc name) acc]
+      [ty; A.mkLam ~loc (name_of_name ~loc name) acc]
   ) names_rnos_tys inner
 
-let in_elpi_mfix ~depth names_rnos_tys focus_idx bodies =
+let in_elpi_mfix names_rnos_tys focus_idx bodies =
   assert (List.length names_rnos_tys = List.length bodies);
-  (* Build mbody [mpair f0 bo0, ...] f_focus *)
-  let pairs = List.mapi (fun i bo ->
-    E.mkApp mpairc (E.mkConst (depth + i)) [bo]
-  ) bodies in
+  (* Build mbody [mpair rno0 bo0, ...] focus_idx *)
+  let pairs = List.map2 (fun (_,rno,_) bo ->
+    E.mkApp mpairc (CD.of_int rno) [bo]
+  ) names_rnos_tys bodies in
   let inner = E.mkApp mbodyc (U.list_to_lp_list pairs)
-    [E.mkConst (depth + focus_idx)] in
+    [CD.of_int focus_idx] in
   (* Wrap with mfix nodes from inside out *)
-  List.fold_right (fun (name, rno, ty) acc ->
-    E.mkApp mfixc (in_elpi_name name) [CD.of_int rno; ty; E.mkLam acc]
+  List.fold_right (fun (name, _, ty) acc ->
+    E.mkApp mfixc (in_elpi_name name) [ty; E.mkLam acc]
   ) names_rnos_tys inner
 
 let primitivec   = E.Constants.declare_global_symbol "primitive"
@@ -1711,7 +1706,7 @@ let rec constr2lp coq_ctx ~calldepth ~depth state t =
          let state, elpi_bos =
            CArray.fold_left_map (aux ~depth:(depth+n) envn) state bos in
          state,
-         in_elpi_mfix ~depth names_rnos_tys focus_idx (Array.to_list elpi_bos)
+         in_elpi_mfix names_rnos_tys focus_idx (Array.to_list elpi_bos)
     | C.Proj(p,_,t) ->
          let state, t = aux ~depth env state t in
          let state, p = in_elpi_primitive ~depth state (Projection p) in
@@ -2321,29 +2316,23 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
       state, EC.mkFix (([|rno|],0),([|name|],[|ty|],[|bo|])), gl1 @ gl2
 
  (* mfix *)
-  | E.App(c,name_lp,[rno_lp;ty_lp;rest_lam]) when mfixc == c ->
-      let base_depth = depth in
-      let rec collect_mfix ~depth state coq_ctx name_lp rno_lp ty_lp rest_lam
+  | E.App(c,name_lp,[ty_lp;rest_lam]) when mfixc == c ->
+      let rec collect_mfix ~depth state coq_ctx name_lp ty_lp rest_lam
                            defs gls_acc =
         let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name_lp in
-        (* coq_ctx evolves at each iteration *)
         let state, ty, gl =
           lp2constr ~calldepth syntactic_constraints coq_ctx
             ~depth state ~on_ty:true ty_lp in
-        let rno =
-          match E.look ~depth rno_lp with
-          | E.CData n when CD.is_int n -> CD.to_int n
-          | _ -> err Pp.(str"Not an int: " ++ str (P.Debug.show_term rno_lp)) in
         let coq_ctx = push_coq_ctx_local depth
           (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in
-        let defs = (name, ty, rno) :: defs in
+        let defs = (name, ty) :: defs in
         let gls_acc = gl @ gls_acc in
         match E.look ~depth rest_lam with
         | E.Lam body ->
           let depth = depth + 1 in
           (match E.look ~depth body with
-           | E.App(c2,name2,[rno2;ty2;rest2]) when mfixc == c2 ->
-             collect_mfix ~depth state coq_ctx name2 rno2 ty2 rest2
+           | E.App(c2,name2,[ty2;rest2]) when mfixc == c2 ->
+             collect_mfix ~depth state coq_ctx name2 ty2 rest2
                defs gls_acc
            | E.App(c2,pairs_lp,[focus_lp]) when mbodyc == c2 ->
              finish_mfix ~depth state coq_ctx (List.rev defs)
@@ -2352,40 +2341,46 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
         | _ -> err Pp.(str"mfix: expected lambda in mfix body")
       and finish_mfix ~depth state coq_ctx defs pairs_lp focus_lp gls_acc =
         let n = List.length defs in
+        let focus_idx =
+          match E.look ~depth focus_lp with
+          | E.CData k when CD.is_int k ->
+            let idx = CD.to_int k in
+            if idx >= 0 && idx < n then idx
+            else err Pp.(str"mfix: focus index out of range: " ++ int idx)
+          | _ -> err Pp.(str"mfix: focus not an int: " ++
+                         str (P.Debug.show_term focus_lp)) in
         let pair_list = U.lp_list_to_list ~depth pairs_lp in
         if List.length pair_list <> n then
           err Pp.(str"mfix: expected " ++ int n ++ str" body pairs, got " ++
                   int (List.length pair_list));
-        let body_terms = List.map (fun p ->
+        let rnos_bodies = List.map (fun p ->
           match E.look ~depth p with
-          | E.App(pc, _fi, [bi]) when pc == mpairc -> bi
+          | E.App(pc, rno_lp, [bo_lp]) when pc == mpairc ->
+            let rno = match E.look ~depth rno_lp with
+              | E.CData n when CD.is_int n -> CD.to_int n
+              | _ -> err Pp.(str"mfix: mpair rno not an int: " ++
+                             str (P.Debug.show_term rno_lp)) in
+            (rno, bo_lp)
           | _ -> err Pp.(str"mfix: bad mpair: " ++
                          str (P.Debug.show_term p))
         ) pair_list in
         let state, coq_bodies, gls_bos =
-          List.fold_left (fun (state, bos, gls) bo_lp ->
+          List.fold_left (fun (state, bos, gls) (_, bo_lp) ->
             let state, bo, gl =
               lp2constr ~calldepth syntactic_constraints coq_ctx
                 ~depth state bo_lp in
             (state, bo :: bos, gl @ gls)
-          ) (state, [], []) body_terms
+          ) (state, [], []) rnos_bodies
         in
         let coq_bodies = List.rev coq_bodies in
-        let focus_idx =
-          match E.look ~depth focus_lp with
-          | E.Const k ->
-            let idx = k - base_depth in
-            if idx >= 0 && idx < n then idx
-            else err Pp.(str"mfix: focus variable out of range")
-          | _ -> err Pp.(str"mfix: focus not a bound variable: " ++
-                         str (P.Debug.show_term focus_lp))
-        in
-        let names, typs, rnos = CArray.split3 (Array.of_list defs) in
+        let names = Array.of_list (List.map fst defs) in
+        let typs = Array.of_list (List.map snd defs) in
+        let rnos = Array.of_list (List.map fst rnos_bodies) in
         state,
         EC.mkFix ((rnos, focus_idx),(names, typs, Array.of_list coq_bodies)),
         gls_acc @ gls_bos
       in
-      collect_mfix ~depth state coq_ctx name_lp rno_lp ty_lp rest_lam [] []
+      collect_mfix ~depth state coq_ctx name_lp ty_lp rest_lam [] []
 
   | E.App(c,v,[]) when primitivec == c ->
       let state, v, gls = primitive_value.API.Conversion.readback ~depth state v in

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -2317,11 +2317,13 @@ and lp2constr ~calldepth syntactic_constraints coq_ctx ~depth state ?(on_ty=fals
 
  (* mfix *)
   | E.App(c,name_lp,[ty_lp;rest_lam]) when mfixc == c ->
+      (* mkFix's types live in outer_ctx (no self-refs); bodies use extended ctx. *)
+      let outer_ctx = coq_ctx in
       let rec collect_mfix ~depth state coq_ctx name_lp ty_lp rest_lam
                            defs gls_acc =
         let name = in_coq_fresh_annot_name ~depth ~coq_ctx depth name_lp in
         let state, ty, gl =
-          lp2constr ~calldepth syntactic_constraints coq_ctx
+          lp2constr ~calldepth syntactic_constraints outer_ctx
             ~depth state ~on_ty:true ty_lp in
         let coq_ctx = push_coq_ctx_local depth
           (Context.Rel.Declaration.LocalAssum(name,ty)) coq_ctx in

--- a/src/rocq_elpi_HOAS.mli
+++ b/src/rocq_elpi_HOAS.mli
@@ -203,6 +203,7 @@ val in_elpiast_let : loc:Ast.Loc.t -> Names.Name.t -> ty:Ast.Term.t -> bo:Ast.Te
 val in_elpiast_appl : loc:Ast.Loc.t -> Ast.Term.t -> Ast.Term.t list -> Ast.Term.t
 val in_elpiast_match : loc:Ast.Loc.t -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t list -> Ast.Term.t
 val in_elpiast_fix : loc:Ast.Loc.t -> Names.Name.t -> int -> Ast.Term.t -> Ast.Term.t -> Ast.Term.t
+val in_elpiast_mfix : loc:Ast.Loc.t -> (Names.Name.t * int * Ast.Term.t) list -> int -> Ast.Term.t list -> Ast.Term.t
 val in_elpiast_name : loc:Ast.Loc.t -> Names.Name.t -> Ast.Term.t
 val in_elpiast_decl : loc:Ast.Loc.t -> v:Ast.Term.t -> Names.Name.t -> ty:Ast.Term.t -> Ast.Term.t
 val in_elpiast_def : loc:Ast.Loc.t -> v:Ast.Term.t -> Names.Name.t -> ty:Ast.Term.t -> bo:Ast.Term.t -> Ast.Term.t

--- a/src/rocq_elpi_glob_quotation.ml
+++ b/src/rocq_elpi_glob_quotation.ml
@@ -576,7 +576,32 @@ let gterm2lpast ~pattern ~language state glob =
       let bo = glob_intros tctx bo in
       under_binder ~loc (Name.Name name) ty None bo state ~k:(fun name t state ->
         in_elpiast_fix ~loc name rno ty (gterm2lp state bo))
-  | GRec _ -> nYI "(glob)HOAS mutual/non-struct fix"
+  | GRec(GFix(rnos,focus_idx),names,tctxs,tys,bos) ->
+      let n = Array.length names in
+      let tys = Array.map2 glob_intros_prod tctxs tys in
+      let elpi_tys = Array.map (gterm2lp state) tys in
+      let bos = Array.map2 glob_intros tctxs bos in
+      (* Introduce all fixpoint names into scope *)
+      let state, actual_names = Array.fold_left (fun (state, acc) i ->
+        let id = names.(i) in
+        let { taken } = get_glob_env state in
+        let id =
+          if Names.Id.Set.mem id taken then
+            Names.Id.of_string_soft (Format.asprintf "_elpi_renamed_%s_%d"
+              (Id.to_string id) (Names.Id.Set.cardinal taken))
+          else id in
+        let state = push_glob_ctx state id
+          (Some (mk_decl state ~loc id ~ty:elpi_tys.(i))) in
+        (state, id :: acc)
+      ) (state, []) (Array.init n Fun.id) in
+      let actual_names = List.rev actual_names in
+      let names_rnos_tys = List.mapi (fun i id ->
+        (Names.Name.Name id,
+         (match rnos.(i) with Some r -> r | None -> 0),
+         elpi_tys.(i))) actual_names in
+      let elpi_bos = Array.to_list (Array.map (gterm2lp state) bos) in
+      in_elpiast_mfix ~loc names_rnos_tys focus_idx elpi_bos
+  | GRec _ -> nYI "(glob)HOAS non-struct fix/cofix"
   | GInt i -> in_elpiast_primitive ~loc (Uint63 i)
   | GFloat f -> in_elpiast_primitive ~loc (Float64 f)
   | GString s -> in_elpiast_primitive ~loc (Pstring s)

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -694,3 +694,33 @@ Elpi Query lp:{{
   .
 
 }}.
+
+(* mfix: mutual fixpoints *)
+
+Fixpoint myeven (n : nat) : bool :=
+  match n with O => true | S n' => myodd n' end
+with myodd (n : nat) : bool :=
+  match n with O => false | S n' => myeven n' end.
+
+Fixpoint f3_0 (n : nat) : nat :=
+  match n with O => 0 | S n' => f3_1 n' end
+with f3_1 (n : nat) : nat :=
+  match n with O => 1 | S n' => f3_2 n' end
+with f3_2 (n : nat) : nat :=
+  match n with O => 2 | S n' => f3_0 n' end.
+
+Elpi Command test_mfix.
+Elpi Accumulate lp:{{
+main [trm T] :-
+  coq.term->gref T (const C),
+  coq.env.const C (some Body) _Ty,
+  std.assert! (Body = mfix _ _ _) "expected mfix",
+  coq.elaborate-skeleton Body ETy _ ok,
+  coq.say {coq.gref->string (const C)} ":" {coq.term->string ETy}.
+}}.
+
+Elpi test_mfix (myeven).
+Elpi test_mfix (myodd).
+Elpi test_mfix (f3_0).
+Elpi test_mfix (f3_1).
+Elpi test_mfix (f3_2).

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -714,7 +714,7 @@ Elpi Accumulate lp:{{
 main [trm T] :-
   coq.term->gref T (const C),
   coq.env.const C (some Body) _Ty,
-  std.assert! (Body = mfix _ _ _ _) "expected mfix",
+  std.assert! (Body = mfix _ _ _) "expected mfix",
   coq.elaborate-skeleton Body ETy _ ok,
   coq.say {coq.gref->string (const C)} ":" {coq.term->string ETy}.
 }}.

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -759,3 +759,35 @@ main _ :-
 }}.
 
 Elpi test_mfix_outer_ref.
+
+Elpi Query lp:{{
+
+  @pi-decl `x` {{nat}} x\ sigma Term Stack Reduct\
+    whd {{ myeven }} [{{ S lp:x }}] Term Stack,
+    unwind Term Stack Reduct,
+    std.assert! (Reduct =
+      {{ fix xx (n : nat) : bool :=
+            match n with O => true | S n' => yy n' end
+          with yy (n : nat) : bool :=
+            match n with O => false | S n' => xx n' end
+          for yy lp:x }}
+    ) "bad reduction",
+    coq.unify-eq Reduct {{ myodd lp:x }} ok
+
+}}.
+
+Elpi Query lp:{{
+
+  @pi-decl `x` {{nat}} x\ sigma Term Stack Reduct\
+    whd {{ myeven }} [{{ lp:x }}] Term Stack,
+    unwind Term Stack Reduct,
+    std.assert! (Reduct =
+      {{ fix xx (n : nat) : bool :=
+            match n with O => true | S n' => yy n' end
+          with yy (n : nat) : bool :=
+            match n with O => false | S n' => xx n' end
+          for xx lp:x }}
+    ) "bad reduction",
+    coq.unify-eq Reduct {{ myeven lp:x }} ok
+
+}}.

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -714,7 +714,7 @@ Elpi Accumulate lp:{{
 main [trm T] :-
   coq.term->gref T (const C),
   coq.env.const C (some Body) _Ty,
-  std.assert! (Body = mfix _ _ _) "expected mfix",
+  std.assert! (Body = mfix _ _ _ _) "expected mfix",
   coq.elaborate-skeleton Body ETy _ ok,
   coq.say {coq.gref->string (const C)} ":" {coq.term->string ETy}.
 }}.
@@ -724,3 +724,19 @@ Elpi test_mfix (myodd).
 Elpi test_mfix (f3_0).
 Elpi test_mfix (f3_1).
 Elpi test_mfix (f3_2).
+
+Elpi Command test_mfix_copy.
+Elpi Accumulate lp:{{
+main [trm T] :-
+  coq.term->gref T (const C),
+  coq.env.const C (some Body) _Ty,
+  copy Body Body1,
+  std.assert! (Body = Body1) "copy of mfix changed the term",
+  coq.say "copy ok for" {coq.gref->string (const C)}.
+}}.
+
+Elpi test_mfix_copy (myeven).
+Elpi test_mfix_copy (myodd).
+Elpi test_mfix_copy (f3_0).
+Elpi test_mfix_copy (f3_1).
+Elpi test_mfix_copy (f3_2).

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -714,7 +714,7 @@ Elpi Accumulate lp:{{
 main [trm T] :-
   coq.term->gref T (const C),
   coq.env.const C (some Body) _Ty,
-  std.assert! (Body = mfix _ _ _) "expected mfix",
+  std.assert! (Body = mfix-call _ _) "expected mfix-call",
   coq.elaborate-skeleton Body ETy _ ok,
   coq.say {coq.gref->string (const C)} ":" {coq.term->string ETy}.
 }}.
@@ -741,20 +741,20 @@ Elpi test_mfix_copy (f3_0).
 Elpi test_mfix_copy (f3_1).
 Elpi test_mfix_copy (f3_2).
 
-(* Regression: second mfix component's type references an outer binder.
-   lp2constr must read each type in the ctx *before* self-refs are pushed,
-   otherwise the outer Rel is shifted and mkFix fails with unbound Rel. *)
+(* mfix component types must be read in the outer context, 
+   before self-refs are pushed. *)
 Elpi Command test_mfix_outer_ref.
 Elpi Accumulate lp:{{
 main _ :-
   T = fun `B` (sort (typ _)) (bv\
         fun `default` bv (dv\
-          mfix `f` (prod `n` {{ nat }} (_\ bv)) (fv\
-            mfix `g` (prod `n` {{ nat }} (_\ bv)) (gv\
-              mbody [
-                mpair 0 (fun `n` {{ nat }} (_\ dv)),
-                mpair 0 (fun `n` {{ nat }} (_\ dv))
-              ] 0)))),
+          mfix-call 0
+            (mfix-ty `f` 0 (prod `n` {{ nat }} (_\ bv)) (fv\
+              mfix-ty `g` 0 (prod `n` {{ nat }} (_\ bv)) (gv\
+                mfix-body [
+                  fun `n` {{ nat }} (_\ dv),
+                  fun `n` {{ nat }} (_\ dv)
+                ]))))),
   coq.typecheck T _ ok.
 }}.
 
@@ -789,5 +789,86 @@ Elpi Query lp:{{
           for xx lp:x }}
     ) "bad reduction",
     coq.unify-eq Reduct {{ myeven lp:x }} ok
+
+}}.
+
+Elpi Query lp:{{
+
+  @pi-decl `x` {{nat}} x\ sigma Term Stack Reduct\
+    whd {{ f3_0 }} [{{ lp:x }}] Term Stack,
+    unwind Term Stack Reduct,
+    std.assert! (Reduct =
+      {{ fix xx (n : nat) : nat :=
+            match n with O => 0 | S n' => yy n' end
+          with yy (n : nat) : nat :=
+            match n with O => 1 | S n' => zz n' end
+          with zz (n : nat) : nat :=
+            match n with O => 2 | S n' => xx n' end
+          for xx lp:x }}
+    ) "bad reduction",
+    coq.unify-eq Reduct {{ f3_0 lp:x }} ok
+
+}}.
+
+Elpi Query lp:{{
+
+  @pi-decl `x` {{nat}} x\ sigma Term Stack Reduct\
+    whd {{ f3_1 }} [{{ S lp:x }}] Term Stack,
+    unwind Term Stack Reduct,
+    std.assert! (Reduct =
+      {{ fix xx (n : nat) : nat :=
+            match n with O => 0 | S n' => yy n' end
+          with yy (n : nat) : nat :=
+            match n with O => 1 | S n' => zz n' end
+          with zz (n : nat) : nat :=
+            match n with O => 2 | S n' => xx n' end
+          for zz lp:x }}
+    ) "bad reduction",
+    coq.unify-eq Reduct {{ f3_2 lp:x }} ok
+
+}}.
+
+Elpi Query lp:{{
+
+  @pi-decl `x` {{nat}} x\ sigma Term Stack Reduct\
+    whd {{ f3_2 }} [{{ S lp:x }}] Term Stack,
+    unwind Term Stack Reduct,
+    std.assert! (Reduct =
+      {{ fix xx (n : nat) : nat :=
+            match n with O => 0 | S n' => yy n' end
+          with yy (n : nat) : nat :=
+            match n with O => 1 | S n' => zz n' end
+          with zz (n : nat) : nat :=
+            match n with O => 2 | S n' => xx n' end
+          for xx lp:x }}
+    ) "bad reduction",
+    coq.unify-eq Reduct {{ f3_0 lp:x }} ok
+
+}}.
+
+Elpi Query lp:{{
+
+  sigma Term Stack Reduct\
+    whd {{ f3_0 3 }} [] Term Stack,
+    unwind Term Stack Reduct,
+    coq.unify-eq Reduct {{ 0 }} ok
+
+}}.
+
+Elpi Query lp:{{
+
+  sigma Term Stack Reduct\
+    whd {{ f3_1 3 }} [] Term Stack,
+    unwind Term Stack Reduct,
+    coq.unify-eq Reduct {{ 1 }} ok
+
+}}.
+
+Elpi Query lp:{{
+
+  sigma Term Stack Reduct\
+    whd {{ f3_2 3 }} [] Term Stack,
+    unwind Term Stack Reduct,
+    coq.unify-eq Reduct {{ 2 }} ok
 
 }}.

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -740,3 +740,22 @@ Elpi test_mfix_copy (myodd).
 Elpi test_mfix_copy (f3_0).
 Elpi test_mfix_copy (f3_1).
 Elpi test_mfix_copy (f3_2).
+
+(* Regression: second mfix component's type references an outer binder.
+   lp2constr must read each type in the ctx *before* self-refs are pushed,
+   otherwise the outer Rel is shifted and mkFix fails with unbound Rel. *)
+Elpi Command test_mfix_outer_ref.
+Elpi Accumulate lp:{{
+main _ :-
+  T = fun `B` (sort (typ _)) (bv\
+        fun `default` bv (dv\
+          mfix `f` (prod `n` {{ nat }} (_\ bv)) (fv\
+            mfix `g` (prod `n` {{ nat }} (_\ bv)) (gv\
+              mbody [
+                mpair 0 (fun `n` {{ nat }} (_\ dv)),
+                mpair 0 (fun `n` {{ nat }} (_\ dv))
+              ] 0)))),
+  coq.typecheck T _ ok.
+}}.
+
+Elpi test_mfix_outer_ref.


### PR DESCRIPTION
New ELPI types:

```ocaml
kind mfix-def type.
mfix-def : name -> int -> term -> mfix-def.       % name, rarg, type                                                 
mfix     : list mfix-def -> int -> term -> term.   % defs, focus, bodies                                             
```
                                                                                                                       
The third argument of mfix is N nested lambdas binding one ELPI variable per function, wrapping a list of N bodies:  

```                                                                                                                 
  mfix [mfix-def `f0` rno0 ty0, mfix-def `f1` rno1 ty1] 0                                                              
    (f0\ f1\ [body0, body1])                                                                                           
``` 

This mirrors the single fix constructor's (term -> term) binder pattern, extended to simultaneous binding via nested lambdas. The focus index (0-based) selects which function in the mutual block this term occurrence represents, faithful to Coq's kernel Fix((rargs, focus_idx), ...).                                                               

De Bruijn alignment: constr2lp pushes all N function names into the environment and converts all bodies at depth+N. In the ELPI term, nested lambdas bind at depths d, d+1, ..., d+N-1, so bodies at depth+N see the same constants. The `lp2constr` readback mirrors this by pushing names at incrementing depths and unwrapping N lambdas before converting bodies.   