### PR TITLE
Discard clauses that depend on section variables at section closure time

### DIFF
--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -2783,6 +2783,10 @@ denote the same x as before.|};
   MLCode(Pred("coq.env.end-section",
     Full(unit_ctx, "end the current section *E*"),
   (fun ~depth _ _ -> grab_global_env_drop_sigma "coq.env.end-section" (fun state ->
+    let { section } = empty_conv_context ~options:(default_options ()) state in
+    let state = State.update clauses_for_later_interp state (List.filter (fun (_, _, vars, _) ->
+      not (List.exists (fun v -> List.mem v section) vars)
+    )) in
      let state, _ = Rocq_elpi_builtins_synterp.SynterpAction.pop_EndSection () state in
      state, (), []))),
   DocAbove);

--- a/tests/test_section.v
+++ b/tests/test_section.v
@@ -1,0 +1,33 @@
+From elpi Require Import elpi.
+
+Elpi Command cmd.
+Elpi Db db lp:{{
+pred db? o:term.
+}}.
+
+Elpi Accumulate Db db.
+
+#[synterp]
+Elpi Accumulate cmd lp:{{
+main _ :-
+  coq.env.begin-section "Dummy",
+  coq.env.end-section.
+}}.
+Elpi Accumulate cmd lp:{{
+main _ :-
+  coq.env.begin-section "Dummy",
+  coq.env.add-section-variable "T" _ {{ Type }} T,
+  coq.elpi.accumulate _ "db" (clause _ _ (db? (global (const T)))),
+  coq.env.end-section.
+}}.
+
+Elpi cmd.
+
+Section Dummy.
+Variable (T : Type).
+
+Fail Elpi Query cmd lp:{{
+db? {{ T }}.
+}}.
+
+End Dummy.


### PR DESCRIPTION
Closes #830 
It is not very efficient, I can try something with a better complexity (e.g. sorting the list of variables) if needed.