### PR TITLE
fix: isK elaborates keeping universes

### DIFF
--- a/apps/derive/elpi/isK.elpi
+++ b/apps/derive/elpi/isK.elpi
@@ -32,7 +32,7 @@ func main-K string, term, term, constructor -> prop.
 main-K Prefix Ity Arity GRK Clause :-
   coq.env.global (indc GRK) K,
   coq.bind-ind-arity Ity Arity (body K) TSek,
-  std.assert-ok! (coq.elaborate-skeleton TSek Ty T) "derive.isK generates illtyped term",
+  (@keepunivs! => std.assert-ok! (coq.elaborate-skeleton TSek Ty T) "derive.isK generates illtyped term"),
   Name is Prefix ^ {coq.gref->id (indc GRK)},
   coq.env.add-const Name T Ty _ IsK,
   Clause = (isK-db GRK (global (const IsK)) :- !).

--- a/apps/derive/tests/test_isK.v
+++ b/apps/derive/tests/test_isK.v
@@ -90,6 +90,12 @@ Elpi derive.isK I.
 Inductive Wrap := K : I -> Wrap.
 Elpi derive.isK Wrap.
 
+Inductive Prod (A B : Type) := PR : A -> B -> Prod A B.
+Elpi derive.isK Prod.
+
+Inductive Sum (A B : Type) := InL : A -> Sum A B | InR : B -> Sum A B.
+Elpi derive.isK Sum.
+
 Inductive List (A : Type) := Nil | Cons : A -> List A -> List A.
 Elpi derive.isK List.
 End UnivPoly.

--- a/apps/derive/tests/test_projK_isK.v
+++ b/apps/derive/tests/test_projK_isK.v
@@ -1,0 +1,16 @@
+From elpi.apps Require Import derive.isK derive.projK.
+
+Set Universe Polymorphism.
+
+Module ProjK_IsK.
+
+Inductive Sum (A B : Type) := InL : A -> Sum A B | InR : B -> Sum A B.
+Elpi derive Sum.
+Redirect "tmp" Check Sum_isk_InL.
+Redirect "tmp" Check Sum_isk_InR.
+Redirect "tmp" Check Sum_getk_InL1.
+Redirect "tmp" Check Sum_getk_InR1.
+
+End ProjK_IsK.
+
+Unset Universe Polymorphism.


### PR DESCRIPTION
Fixes an issue in which deriving `isK` along with `projK` was causing an anomaly 

```rocq
From elpi.apps Require Import derive.isK derive.projK.

Set Universe Polymorphism.

Module ProjK_IsK.

Inductive Sum (A B : Type) := InL : A -> Sum A B | InR : B -> Sum A B.
Elpi derive Sum.
Redirect "tmp" Check Sum_isk_InL.
Redirect "tmp" Check Sum_isk_InR.
Redirect "tmp" Check Sum_getk_InL1.
Redirect "tmp" Check Sum_getk_InR1.

End ProjK_IsK.
```