### PR TITLE
fix typo ("begin accumulated")

### DIFF
--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -795,7 +795,7 @@ let preprocess_clause ~depth clause =
         E.mkLam (subst ~depth:(depth+1) m x)
     | E.Builtin(c,xs) ->
         E.mkBuiltin c (List.map (subst ~depth m) xs)
-    | E.UnifVar _ -> CErrors.user_err Pp.(str"The clause begin accumulated contains unification variables, this is forbidden. You must quantify them out using 'pi'.")
+    | E.UnifVar _ -> CErrors.user_err Pp.(str"The clause being accumulated contains unification variables, this is forbidden. You must quantify them out using 'pi'.")
     | E.Const _ | E.Nil | E.CData _ -> t
     in
   let clause =


### PR DESCRIPTION
fix a typo in an error message: "begin accumulated" -> "being accumulated"
