### PR TITLE
Fix phase separation for `lib:qid` syntax

### DIFF
--- a/src/rocq_elpi_vernacular.ml
+++ b/src/rocq_elpi_vernacular.ml
@@ -844,3 +844,30 @@ let export_command ~atts:proof ?as_ p =
   let nature = Rocq_elpi_programs.Synterp.get_nature p in
   Lib.add_leaf (in_exported_program (proof,nature,p,q))
 
+let libref_tag = GenConstr.create "elpi-libref"
+
+let lib_ref ?loc ~expl qid = CAst.make ?loc @@ Constrexpr.CGenarg (Raw (libref_tag, (expl,qid)))
+
+let intern_libref ?loc ist (expl,qid) =
+  let id = String.concat "." (snd qid) in
+  let gr = try Rocqlib.lib_ref id
+    with Rocqlib.NotFoundRef _ ->
+      CErrors.user_err ?loc
+        Pp.(str "Global reference not found: lib:" ++ str id
+            ++ str " (you may need to require some .v file with \
+                    `Register ... as " ++ str id ++ str ".`).")
+  in
+  let path = Nametab.path_of_global gr in
+  let qid = Libnames.qualid_of_path ~loc:(fst qid) path in
+  let c =
+    if expl then
+      CAst.make ?loc @@ Constrexpr.CAppExpl ((qid,None),[])
+    else CAst.make ?loc @@ Constrexpr.CRef (qid, None)
+  in
+  Constrintern.intern_core WithoutTypeConstraint ist c
+
+let () =
+  Genintern.register_intern_constr_gen libref_tag intern_libref
+
+let () =
+  Genintern.register_intern_pat_gen libref_tag intern_libref

--- a/src/rocq_elpi_vernacular.mli
+++ b/src/rocq_elpi_vernacular.mli
@@ -70,3 +70,6 @@ val run_in_tactic : loc:Loc.t -> ?program:qualified_name -> Elpi.API.Ast.Loc.t *
 
 (* move to synterp *)
 val export_command : atts:proof option -> ?as_:qualified_name -> qualified_name -> unit
+
+(** [loc] is loc of the whole [lib:qid], then we also get the loc of just the [qid] part. *)
+val lib_ref : ?loc:Loc.t -> expl:bool -> (Loc.t * qualified_name) -> Constrexpr.constr_expr

--- a/src/rocq_elpi_vernacular_syntax.mlg
+++ b/src/rocq_elpi_vernacular_syntax.mlg
@@ -143,14 +143,9 @@ GRAMMAR EXTEND Gram
 
   term: LEVEL "0"
     [ [ lookahead_lib_colon;IDENT "lib"; ":"; id = qualified_name -> {
-          let ref = lib_ref id in
-          let path = Nametab.path_of_global ref in
-          CAst.make ~loc Constrexpr.(CRef (Libnames.qualid_of_path ~loc:(fst id) path,None)) }
+          Rocq_elpi_vernacular.lib_ref ~loc ~expl:false id }
       | lookahead_lib_colon;IDENT "lib"; ":"; "@"; id = qualified_name -> {
-          let ref = lib_ref id in
-          let path = Nametab.path_of_global ref in
-          let f = Libnames.qualid_of_path ~loc:(fst id) path in
-          CAst.make ~loc Constrexpr.(CAppExpl((f,None),[])) } ] ]
+          Rocq_elpi_vernacular.lib_ref ~loc ~expl:true id } ] ]
   ;
 END
 


### PR DESCRIPTION
Using https://github.com/rocq-prover/rocq/pull/22106

