### PR TITLE
Add HOAS support for mutual inductive types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@
 - New `coq.env.indt-block` to list the inductive types in the same
   mutual block
 
+### LIB:
+- Change `coq.build-indt-decl`, not taking a `coq.indt-spec` tuple
+- New `coq.build-mindt-decl` taking a list of `coq.indt-spec`
+
 
 # [3.4.0] 19/05/2026
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,7 @@
   mutual block
 
 ### LIB:
-- Change `coq.build-indt-decl`, not taking a `coq.indt-spec` tuple
+- Change `coq.build-indt-decl`, now taking a `coq.indt-spec` tuple
 - New `coq.build-mindt-decl` taking a list of `coq.indt-spec`
 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,15 @@
 
 # [UNRELEASED]
 
+### HOAS:
+- New `minductive` and `mblock` for mutual inductive types
+
 ### API:
 - fix `coq.CS.canonical-projection?`, used to disregard `#[canonical=no]`
 - fix `ltac_tactic:(t)`, use to ignore ltac variables in `t`
 - New `coq.elpi.add-predicate?` to check if a predicate is declared in elpi
+- New `coq.env.indt-block` to list the inductive types in the same
+  mutual block
 
 
 # [3.4.0] 19/05/2026
@@ -40,8 +45,6 @@ Requires Elpi 3.7.1 and Rocq 9.0, 9.1 or 9.2.
 - New argument `const-decl` can now be introduces by the `Lemma` keyword,
   and not just by `Definition`.
 - New `coq.scheme` to query registered schemes
-- New `coq.env.mutual-inductives` to list the inductive types in the same
-  mutual block without reifying the full inductive declaration
 
 
 # [3.3.1] 12/03/2026

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,8 @@ Requires Elpi 3.7.1 and Rocq 9.0, 9.1 or 9.2.
 - New argument `const-decl` can now be introduces by the `Lemma` keyword,
   and not just by `Definition`.
 - New `coq.scheme` to query registered schemes
+- New `coq.env.mutual-inductives` to list the inductive types in the same
+  mutual block without reifying the full inductive declaration
 
 
 # [3.3.1] 12/03/2026

--- a/apps/derive/elpi/param1.elpi
+++ b/apps/derive/elpi/param1.elpi
@@ -174,8 +174,7 @@ dispatch (indt GR) Prefix Clauses :- !, do! [
     NewName is Prefix ^ {coq.gref->id (indt GR)},
 
     coq.ensure-fresh-global-id NewName FNewName,
-    coq.build-indt-decl
-      (pr new_name FNewName) tt LnoR LnoR {coq.subst-fun [Ind] TyR} KnamesR KtypesR DeclR
+    coq.build-indt-decl (coq.indt-spec new_name FNewName tt {coq.subst-fun [Ind] TyR} KnamesR KtypesR) LnoR LnoR  DeclR
   ),
 
   std.assert-ok! (coq.typecheck-indt-decl DeclR) "derive.param1 generates illtyped inductive",

--- a/apps/derive/elpi/param2.elpi
+++ b/apps/derive/elpi/param2.elpi
@@ -389,8 +389,7 @@ dispatch (indt I as GR) Suffix Clauses :- do! [
   pi new_name\ sigma KtypesR TyR\ (
       (param-indt I IsInd Lno Luno Ty Ks Ktypes
  	    	 new_name IsIndR LnoR LunoR TyR KtypesR),
-    coq.build-indt-decl
-      (pr new_name FNameR) IsIndR LnoR LunoR {coq.subst-fun [Ind, Ind] TyR} KnamesR KtypesR DeclR
+    coq.build-indt-decl (coq.indt-spec new_name FNameR IsIndR {coq.subst-fun [Ind, Ind] TyR} KnamesR KtypesR) LnoR LunoR  DeclR
   ),
 
   std.assert-ok! (coq.typecheck-indt-decl DeclR) "derive.param2 generates illtyped term",

--- a/builtin-doc/coq-builtin-synterp.elpi
+++ b/builtin-doc/coq-builtin-synterp.elpi
@@ -155,6 +155,8 @@ external symbol arity       : term -> arity.
 
 external symbol parameter   : id -> implicit_kind -> term -> (term -> indt-decl) -> indt-decl = "2".
 external symbol inductive   : id -> bool -> arity -> (term -> list indc-decl) -> indt-decl. % tt means inductive, ff coinductive
+external symbol minductive  : id -> bool -> arity -> (term -> indt-decl) -> indt-decl. % one type of a mutual block
+external symbol mblock      : list (list indc-decl) -> indt-decl. % constructor blocks for minductive declarations
 external symbol record      : id -> term -> id -> record-decl -> indt-decl.
 
 external symbol constructor : id -> arity -> indc-decl.

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -687,6 +687,17 @@ external func coq.env.indt % reads the inductive type declaration for the enviro
    % list of constructor names
   list term.       % list of the types of the constructors (type of KNames) including parameters
   
+external func coq.env.indt-block % reads the inductive type declaration for the environment.
+  inductive               % Ind
+  -> bool,                % tt if the type is inductive (ff for co-inductive)
+  int,                    % number of parameters
+  int,                    % number of parameters that are uniform (<= parameters)
+  list inductive,         % all inductives in the block
+  list term,              % types of the inductive types constructors including parameters
+  list (list constructor), 
+   % lists of constructor names
+  list (list term).       % lists of the types of the constructors (type of KNames) including parameters
+  
 external func coq.env.indt-decl % reads the inductive type declaration for the environment.
 % Supported attributes:
 % - @uinstance! I (default: fresh instance I)
@@ -694,10 +705,6 @@ external func coq.env.indt-decl % reads the inductive type declaration for the e
   -> indt-decl.
    % HOAS description of the inductive type
   
-% [coq.env.indt-block Ind AllInd] AllInd are all the inductive types in the
-% mutual block of Ind, in declaration order
-external func coq.env.indt-block inductive -> list inductive.
-
 % [coq.env.indc->indt K I N] finds the inductive I to which constructor K
 % belongs and its position N among the other constructors
 external func coq.env.indc->indt constructor -> inductive, int.

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -694,9 +694,9 @@ external func coq.env.indt-decl % reads the inductive type declaration for the e
   -> indt-decl.
    % HOAS description of the inductive type
   
-% [coq.env.mutual-inductives reference to an inductive type Inductives]
-% lists all inductive types in the same mutual block, in declaration order
-external func coq.env.mutual-inductives inductive -> list inductive.
+% [coq.env.indt-block Ind AllInd] AllInd are all the inductive types in the
+% mutual block of Ind, in declaration order
+external func coq.env.indt-block inductive -> list inductive.
 
 % [coq.env.indc->indt K I N] finds the inductive I to which constructor K
 % belongs and its position N among the other constructors

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -128,6 +128,8 @@ external symbol arity       : term -> arity.
 
 external symbol parameter   : id -> implicit_kind -> term -> (term -> indt-decl) -> indt-decl = "2".
 external symbol inductive   : id -> bool -> arity -> (term -> list indc-decl) -> indt-decl. % tt means inductive, ff coinductive
+external symbol minductive  : id -> bool -> arity -> (term -> indt-decl) -> indt-decl. % one type of a mutual block
+external symbol mblock      : list (list indc-decl) -> indt-decl. % constructor blocks for minductive declarations
 external symbol record      : id -> term -> id -> record-decl -> indt-decl.
 
 external symbol constructor : id -> arity -> indc-decl.
@@ -692,6 +694,10 @@ external func coq.env.indt-decl % reads the inductive type declaration for the e
   -> indt-decl.
    % HOAS description of the inductive type
   
+% [coq.env.mutual-inductives reference to an inductive type Inductives]
+% lists all inductive types in the same mutual block, in declaration order
+external func coq.env.mutual-inductives inductive -> list inductive.
+
 % [coq.env.indc->indt K I N] finds the inductive I to which constructor K
 % belongs and its position N among the other constructors
 external func coq.env.indc->indt constructor -> inductive, int.

--- a/elpi/coq-arg-HOAS.elpi
+++ b/elpi/coq-arg-HOAS.elpi
@@ -113,6 +113,8 @@ external symbol arity       : term -> arity.
 
 external symbol parameter   : id -> implicit_kind -> term -> (term -> indt-decl) -> indt-decl = "2".
 external symbol inductive   : id -> bool -> arity -> (term -> list indc-decl) -> indt-decl. % tt means inductive, ff coinductive
+external symbol minductive  : id -> bool -> arity -> (term -> indt-decl) -> indt-decl. % one type of a mutual block
+external symbol mblock      : list (list indc-decl) -> indt-decl. % constructor blocks for minductive declarations
 external symbol record      : id -> term -> id -> record-decl -> indt-decl.
 
 external symbol constructor : id -> arity -> indc-decl.

--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -133,9 +133,16 @@ copy-indt-decl (parameter ID I Ty D) (parameter ID I Ty1 D1) :-
 copy-indt-decl (inductive ID CO A D) (inductive ID CO A1 D1) :-
   copy-arity A A1,
   @pi-inductive ID A1 i\ std.map (D i) copy-constructor (D1 i).
+copy-indt-decl (minductive ID CO A D) (minductive ID CO A1 D1) :-
+  copy-arity A A1,
+  @pi-inductive ID A1 i\ copy-indt-decl (D i) (D1 i).
+copy-indt-decl (mblock Bs) (mblock Bs1) :- map Bs copy-constructor-block Bs1.
 copy-indt-decl (record ID T IDK F) (record ID T1 IDK F1) :-
   copy T T1,
   copy-fields F F1.
+
+func copy-constructor-block list indc-decl -> list indc-decl.
+copy-constructor-block Ks Ks1 :- map Ks copy-constructor Ks1.
 
 func copy-fields record-decl -> record-decl.
 copy-fields end-record end-record.
@@ -214,12 +221,19 @@ coq.upoly-decl-cumul.complete-constraints.aux (covariant V) CS :- coq.univ.varia
 coq.upoly-decl-cumul.complete-constraints.aux (invariant V) CS :- coq.univ.variable.constraints V CS.
 coq.upoly-decl-cumul.complete-constraints.aux (irrelevant V) CS :- coq.univ.variable.constraints V CS.
 
+kind coq.mindt-spec type.
+type coq.mindt-spec inductive -> id -> bool -> term -> list (pair constructor id) -> list term -> coq.mindt-spec.
+
 :index (1)
 func coq.build-indt-decl
   (pair inductive id), bool, int, int, term, list (pair constructor id), list term -> indt-decl.
 
 coq.build-indt-decl GR IsInd Pno UPno Arity Kns Ktys Decl :-
   coq.build-indt-decl-aux GR IsInd Pno UPno Arity Kns Ktys [] Decl.
+
+func coq.build-mindt-decl list coq.mindt-spec, int, int -> indt-decl.
+coq.build-mindt-decl Specs Pno UPno Decl :-
+  coq.build-mindt-decl-aux Specs Pno UPno [] Decl.
 
 func coq.build-indt-decl-aux
   pair inductive id, bool, int, int, term, list (pair constructor id), list term, list term -> indt-decl.
@@ -301,6 +315,55 @@ coq.indt-unif->indt-nonunif (inductive _ _ _ _ as I) I.
 coq.indt-unif->indt-nonunif (record _ _ _ _) _ :-
   coq.error "coq.indt-unif->indt-nonunif does not support record types".
 
+func coq.build-mindt-decl-aux list coq.mindt-spec, int, int, list term -> indt-decl.
+coq.build-mindt-decl-aux Specs 0 0 Params Decl :- !,
+  rev Params ParamsR,
+  coq.build-mindt-decl-binders Specs Specs ParamsR [] Decl.
+coq.build-mindt-decl-aux ([coq.mindt-spec _ _ _ (prod N S _) _ _|_] as Specs) Pno UPno Params (parameter NS explicit S Res) :- Pno > 0, UPno > 0, !,
+  coq.name->id N NS,
+  Pno1 is Pno - 1,
+  UPno1 is UPno - 1,
+  pi p\
+    std.map Specs (coq.build-mindt-decl-subst-param p) Specs1,
+    coq.build-mindt-decl-aux Specs1 Pno1 UPno1 [p|Params] (Res p).
+:name "coq.build-mindt-decl-aux:fail"
+coq.build-mindt-decl-aux _ _ _ _ _ :- !,
+  fatal-error "coq.build-mindt-decl-aux: invalid mutual declaration".
+
+func coq.build-mindt-decl-subst-param term, coq.mindt-spec -> coq.mindt-spec.
+coq.build-mindt-decl-subst-param P (coq.mindt-spec GR ID IsInd (prod _ _ T) Kns Ktys) (coq.mindt-spec GR ID IsInd (T P) Kns Ktys1) :- !,
+  std.map Ktys (coq.subst-prod [P]) Ktys1.
+coq.build-mindt-decl-subst-param _ _ _ :- !,
+  fatal-error "coq.build-mindt-decl-subst-param: parameter mismatch".
+
+func coq.build-mindt-decl-binders list coq.mindt-spec, list coq.mindt-spec, list term, list (pair inductive term) -> indt-decl.
+coq.build-mindt-decl-binders All [] ParamsR Acc (mblock Blocks) :- !,
+  rev Acc Pairs,
+  std.map All (coq.build-mindt-decl-block Pairs ParamsR) Blocks.
+coq.build-mindt-decl-binders All [coq.mindt-spec GR ID IsInd Ty _ _|Rest] ParamsR Acc (minductive ID IsInd Arity More) :- !,
+  coq.term->arity Ty 0 Arity,
+  @pi-inductive ID Arity i\
+    coq.build-mindt-decl-binders All Rest ParamsR [pr GR i|Acc] (More i).
+
+func coq.build-mindt-decl-block list (pair inductive term), list term, coq.mindt-spec -> list indc-decl.
+coq.build-mindt-decl-block Pairs ParamsR (coq.mindt-spec _ _ _ _ Kns Ktys) Block :-
+  coq.build-mindt-decl-copy-clauses Pairs ParamsR Sub,
+  std.map2 Kns Ktys (gr_name\ ty\ res\ sigma tmp name ar\
+    (Sub ==> copy ty tmp),
+    coq.term->arity tmp 0 ar,
+    gr_name = pr _ name,
+    res = constructor name ar) Block.
+
+func coq.build-mindt-decl-copy-clauses list (pair inductive term), list term -> list prop.
+coq.build-mindt-decl-copy-clauses [] _ [].
+coq.build-mindt-decl-copy-clauses [pr GR I|Rest] ParamsR [
+    (pi l rest r\ copy (app[global (indt GR)|l]) r :- !, std.append ParamsR rest l, coq.mk-app I rest r, !),
+    (pi l rest r ui\ copy (app[pglobal (indt GR) ui|l]) r :- !, std.append ParamsR rest l, coq.mk-app I rest r, !),
+    (copy (global (indt GR)) I :- !),
+    (pi ui\ copy (pglobal (indt GR) ui) I :- !)
+  | More] :-
+  coq.build-mindt-decl-copy-clauses Rest ParamsR More.
+
 :index (_ 1)
 func coq.rename-arity
   (func id -> id),
@@ -331,9 +394,25 @@ coq.rename-indt-decl RP RI RK (inductive ID Ind A In) (inductive ID1 Ind A1 Out)
   coq.arity->term A TY,
   @pi-decl Name TY i\
     std.map (In i) (coq.rename-indt-decl.aux RP RI RK) (Out i).
+coq.rename-indt-decl RP RI RK (minductive ID Ind A In) (minductive ID1 Ind A1 Out) :-
+  RI ID ID1,
+  coq.rename-arity RP A A1,
+  coq.id->name ID Name,
+  coq.arity->term A TY,
+  @pi-decl Name TY i\
+    coq.rename-indt-decl RP RI RK (In i) (Out i).
+coq.rename-indt-decl RP RI RK (mblock Blocks) (mblock Blocks1) :-
+  map Blocks (coq.rename-indt-decl.block RP RI RK) Blocks1.
 coq.rename-indt-decl _ RI RK (record ID A KID F) (record ID1 A KID1 F) :-
   RI ID ID1,
   RK KID KID1.
+
+func coq.rename-indt-decl.block
+  (func id -> id),
+  (func id -> id),
+  (func id -> id),
+  list indc-decl -> list indc-decl.
+coq.rename-indt-decl.block RP RI RK Ks Ks1 :- map Ks (coq.rename-indt-decl.aux RP RI RK) Ks1.
 
 func coq.rename-indt-decl.aux
   (func id -> id),
@@ -378,6 +457,10 @@ coq.typecheck-indt-decl (inductive ID _ Arity KDecl) Diag :- do-ok! Diag [
   coq.typecheck-indt-arity Arity A NUPNO,
   d\ @pi-parameter ID A i\ forall-ok (KDecl i) (coq.typecheck-indt-decl-c i A NUPNO) d
 ].
+coq.typecheck-indt-decl (minductive ID _ Arity Rest) Diag :- do-ok! Diag [
+  coq.typecheck-indt-arity Arity A NUPNO,
+  d\ @pi-parameter ID A i\ coq.typecheck-indt-decl-mutual [pr i (pr A NUPNO)] (Rest i) d
+].
 coq.typecheck-indt-decl (record ID A _IDK FDecl) Diag :- do-ok! Diag [
   coq.typecheck-ty A _,
   d\ @pi-parameter ID A i\ do-ok! d [
@@ -385,6 +468,24 @@ coq.typecheck-indt-decl (record ID A _IDK FDecl) Diag :- do-ok! Diag [
     coq.typecheck-indt-decl-c i A 0 (constructor "fields" (arity (K i)))
   ]
 ].
+
+func coq.typecheck-indt-decl-mutual list (pair term (pair term int)), indt-decl -> diagnostic.
+coq.typecheck-indt-decl-mutual Acc (minductive ID _ Arity Rest) Diag :- !, do-ok! Diag [
+  coq.typecheck-indt-arity Arity A NUPNO,
+  d\ @pi-parameter ID A i\ coq.typecheck-indt-decl-mutual [pr i (pr A NUPNO)|Acc] (Rest i) d
+].
+coq.typecheck-indt-decl-mutual Acc (mblock Blocks) Diag :- !,
+  rev Acc Infos,
+  coq.typecheck-indt-decl-blocks Infos Blocks Diag.
+coq.typecheck-indt-decl-mutual _ _ (error "minductive/mblock expected") :- !.
+
+func coq.typecheck-indt-decl-blocks list (pair term (pair term int)), list (list indc-decl) -> diagnostic.
+coq.typecheck-indt-decl-blocks [] [] ok :- !.
+coq.typecheck-indt-decl-blocks [pr I (pr A NUPNO)|Infos] [Ks|Blocks] Diag :- !, do-ok! Diag [
+  forall-ok Ks (coq.typecheck-indt-decl-c I A NUPNO),
+  d\ coq.typecheck-indt-decl-blocks Infos Blocks d
+].
+coq.typecheck-indt-decl-blocks _ _ (error "mblock constructor block count mismatch") :- !.
 
 func coq.typecheck-indc-arity arity, int -> term, sort, diagnostic.
 coq.typecheck-indc-arity A 0 T S Diag :- !,
@@ -439,11 +540,42 @@ coq.elaborate-indt-decl-skeleton (inductive ID I Arity KDecl) (inductive ID I Ar
        d\ @pi-parameter ID A1 i\ map-ok (KDecl i) (coq.elaborate-indt-decl-skeleton-c i Arity1 NUPNO) (KDecl1 i) d
   ]
 ].
+coq.elaborate-indt-decl-skeleton (minductive ID I Arity Rest) (minductive ID I Arity1 Rest1) Diag :- do-ok! Diag [
+  coq.elaborate-arity-skeleton Arity _ Arity1,
+  lift-ok (coq.arity->nparams Arity1 NUPNO) "",
+  d\ coq.arity->term Arity1 A1, do-ok! d [
+       coq.typecheck-indt-decl.heuristic-var-type A1,
+       d\ @pi-parameter ID A1 i\ coq.elaborate-indt-decl-skeleton-mutual [pr i (pr Arity1 NUPNO)] (Rest i) (Rest1 i) d
+  ]
+].
 coq.elaborate-indt-decl-skeleton (record ID A IDK FDecl) (record ID A1 IDK FDecl1) Diag :- do-ok! Diag [
   coq.elaborate-ty-skeleton A _ A1,
   lift-ok (A1 = sort U) "record type is not a sort",
   d\ @pi-parameter ID A1 i\ coq.elaborate-indt-decl-skeleton-fields U FDecl FDecl1 d
 ].
+
+:index (_ 1)
+func coq.elaborate-indt-decl-skeleton-mutual list (pair term (pair arity int)), indt-decl -> indt-decl, diagnostic.
+coq.elaborate-indt-decl-skeleton-mutual Acc (minductive ID I Arity Rest) (minductive ID I Arity1 Rest1) Diag :- !, do-ok! Diag [
+  coq.elaborate-arity-skeleton Arity _ Arity1,
+  lift-ok (coq.arity->nparams Arity1 NUPNO) "",
+  d\ coq.arity->term Arity1 A1, do-ok! d [
+       coq.typecheck-indt-decl.heuristic-var-type A1,
+       d\ @pi-parameter ID A1 i\ coq.elaborate-indt-decl-skeleton-mutual [pr i (pr Arity1 NUPNO)|Acc] (Rest i) (Rest1 i) d
+  ]
+].
+coq.elaborate-indt-decl-skeleton-mutual Acc (mblock Blocks) (mblock Blocks1) Diag :- !,
+  rev Acc Infos,
+  coq.elaborate-indt-decl-skeleton-blocks Infos Blocks Blocks1 Diag.
+coq.elaborate-indt-decl-skeleton-mutual _ _ _ (error "minductive/mblock expected") :- !.
+
+func coq.elaborate-indt-decl-skeleton-blocks list (pair term (pair arity int)), list (list indc-decl) -> list (list indc-decl), diagnostic.
+coq.elaborate-indt-decl-skeleton-blocks [] [] [] ok :- !.
+coq.elaborate-indt-decl-skeleton-blocks [pr I (pr Arity NUPNO)|Infos] [Ks|Blocks] [Ks1|Blocks1] Diag :- !, do-ok! Diag [
+  map-ok Ks (coq.elaborate-indt-decl-skeleton-c I Arity NUPNO) Ks1,
+  d\ coq.elaborate-indt-decl-skeleton-blocks Infos Blocks Blocks1 d
+].
+coq.elaborate-indt-decl-skeleton-blocks _ _ _ (error "mblock constructor block count mismatch") :- !.
 
 :index (_ 1)
 func coq.elaborate-indt-decl-skeleton-fields sort, record-decl -> record-decl, diagnostic.
@@ -542,16 +674,31 @@ coq.arity->implicits (parameter Id I Ty F) [I|Is] :-
   @pi-parameter Id Ty x\ coq.arity->implicits (F x) Is.
 coq.arity->implicits (arity _) [].
 
-% Get impargs setting from an indt-decl
-func coq.indt-decl->implicits indt-decl -> list implicit_kind, list (list implicit_kind).
-coq.indt-decl->implicits (parameter Id I Ty F) [I|Is] R :-
-  @pi-parameter Id Ty x\ coq.indt-decl->implicits (F x) Is R1,
-  std.map R1 (l\r\r = [I|l]) R.
-coq.indt-decl->implicits (record _ _ _ _) [] [[]].
-coq.indt-decl->implicits (inductive Id _ A Ks) Is R :-
+func coq.constructor-block->implicits list indc-decl -> list (list implicit_kind).
+coq.constructor-block->implicits Ks R :-
+  std.map Ks (c\i\sigma a\ c = constructor _ a, coq.arity->implicits a i) R.
+
+% Get impargs settings from all inductives in an indt-decl, and from their
+% constructor blocks, in declaration order.
+func coq.indt-decl->implicits-all indt-decl -> list (list implicit_kind), list (list (list implicit_kind)).
+coq.indt-decl->implicits-all (parameter Id I Ty F) Inds1 Ks1 :-
+  @pi-parameter Id Ty x\ coq.indt-decl->implicits-all (F x) Inds Ks,
+  std.map Inds (l\r\ r = [I|l]) Inds1,
+  std.map Ks (b\r\ std.map b (l\r\ r = [I|l]) r) Ks1.
+coq.indt-decl->implicits-all (record _ _ _ _) [[]] [[[]]].
+coq.indt-decl->implicits-all (inductive Id _ A Ks) [Is] [R] :-
   coq.arity->implicits A Is,
-  @pi-inductive Id A x\
-    std.map (Ks x) (c\i\sigma a\c = constructor _ a,coq.arity->implicits a i) R.
+  @pi-inductive Id A x\ coq.constructor-block->implicits (Ks x) R.
+coq.indt-decl->implicits-all (minductive Id _ A Rest) [Is|Inds] Ks :-
+  coq.arity->implicits A Is,
+  @pi-inductive Id A x\ coq.indt-decl->implicits-all (Rest x) Inds Ks.
+coq.indt-decl->implicits-all (mblock Ks) [] R :-
+  std.map Ks coq.constructor-block->implicits R.
+
+% Get impargs setting from the first inductive in an indt-decl.
+func coq.indt-decl->implicits indt-decl -> list implicit_kind, list (list implicit_kind).
+coq.indt-decl->implicits D Is Ks :-
+  coq.indt-decl->implicits-all D [Is|_] [Ks|_].
 
 % Check if some implicits are set
 func coq.any-implicit? list implicit_kind ->.

--- a/elpi/coq-lib.elpi
+++ b/elpi/coq-lib.elpi
@@ -221,19 +221,14 @@ coq.upoly-decl-cumul.complete-constraints.aux (covariant V) CS :- coq.univ.varia
 coq.upoly-decl-cumul.complete-constraints.aux (invariant V) CS :- coq.univ.variable.constraints V CS.
 coq.upoly-decl-cumul.complete-constraints.aux (irrelevant V) CS :- coq.univ.variable.constraints V CS.
 
-kind coq.mindt-spec type.
-type coq.mindt-spec inductive -> id -> bool -> term -> list (pair constructor id) -> list term -> coq.mindt-spec.
 
-:index (1)
-func coq.build-indt-decl
-  (pair inductive id), bool, int, int, term, list (pair constructor id), list term -> indt-decl.
+kind coq.indt-spec type.
+type coq.indt-spec inductive -> id -> bool -> term -> list (pair constructor id) -> list term -> coq.indt-spec.
 
-coq.build-indt-decl GR IsInd Pno UPno Arity Kns Ktys Decl :-
-  coq.build-indt-decl-aux GR IsInd Pno UPno Arity Kns Ktys [] Decl.
+func coq.build-indt-decl coq.indt-spec, int, int -> indt-decl.
 
-func coq.build-mindt-decl list coq.mindt-spec, int, int -> indt-decl.
-coq.build-mindt-decl Specs Pno UPno Decl :-
-  coq.build-mindt-decl-aux Specs Pno UPno [] Decl.
+coq.build-indt-decl (coq.indt-spec I ID IsInd Arity Kns Ktys) Pno UPno  Decl :-
+  coq.build-indt-decl-aux (pr I ID) IsInd Pno UPno Arity Kns Ktys [] Decl.
 
 func coq.build-indt-decl-aux
   pair inductive id, bool, int, int, term, list (pair constructor id), list term, list term -> indt-decl.
@@ -266,6 +261,59 @@ coq.build-indt-decl-aux GR IsInd Pno UPno (prod N S T) Kns Ktys Params (paramete
 :name "coq.build-indt-decl-aux:fail"
 coq.build-indt-decl-aux _ _ _ _ _ _ _ _ _ :- !,
   fatal-error "coq.build-indt-decl-aux: invalid declaration".
+
+func coq.build-mindt-decl list coq.indt-spec, int, int -> indt-decl.
+coq.build-mindt-decl Specs Pno UPno Decl :-
+  coq.build-mindt-decl-aux Specs Pno UPno [] Decl.
+
+func coq.build-mindt-decl-aux list coq.indt-spec, int, int, list term -> indt-decl.
+coq.build-mindt-decl-aux Specs 0 0 Params Decl :- !,
+  rev Params ParamsR,
+  coq.build-mindt-decl-binders Specs Specs ParamsR [] Decl.
+coq.build-mindt-decl-aux ([coq.indt-spec _ _ _ (prod N S _) _ _|_] as Specs) Pno UPno Params (parameter NS explicit S Res) :- Pno > 0, UPno > 0, !,
+  coq.name->id N NS,
+  Pno1 is Pno - 1,
+  UPno1 is UPno - 1,
+  pi p\
+    std.map Specs (coq.build-mindt-decl-subst-param p) Specs1,
+    coq.build-mindt-decl-aux Specs1 Pno1 UPno1 [p|Params] (Res p).
+:name "coq.build-mindt-decl-aux:fail"
+coq.build-mindt-decl-aux _ _ _ _ _ :- !,
+  fatal-error "coq.build-mindt-decl-aux: invalid mutual declaration".
+
+func coq.build-mindt-decl-subst-param term, coq.indt-spec -> coq.indt-spec.
+coq.build-mindt-decl-subst-param P (coq.indt-spec GR ID IsInd (prod _ _ T) Kns Ktys) (coq.indt-spec GR ID IsInd (T P) Kns Ktys1) :- !,
+  std.map Ktys (coq.subst-prod [P]) Ktys1.
+coq.build-mindt-decl-subst-param _ _ _ :- !,
+  fatal-error "coq.build-mindt-decl-subst-param: parameter mismatch".
+
+func coq.build-mindt-decl-binders list coq.indt-spec, list coq.indt-spec, list term, list (pair inductive term) -> indt-decl.
+coq.build-mindt-decl-binders All [] ParamsR Acc (mblock Blocks) :- !,
+  rev Acc Pairs,
+  std.map All (coq.build-mindt-decl-block Pairs ParamsR) Blocks.
+coq.build-mindt-decl-binders All [coq.indt-spec GR ID IsInd Ty _ _|Rest] ParamsR Acc (minductive ID IsInd Arity More) :- !,
+  coq.term->arity Ty 0 Arity,
+  @pi-inductive ID Arity i\
+    coq.build-mindt-decl-binders All Rest ParamsR [pr GR i|Acc] (More i).
+
+func coq.build-mindt-decl-block list (pair inductive term), list term, coq.indt-spec -> list indc-decl.
+coq.build-mindt-decl-block Pairs ParamsR (coq.indt-spec _ _ _ _ Kns Ktys) Block :-
+  coq.build-mindt-decl-copy-clauses Pairs ParamsR Sub,
+  std.map2 Kns Ktys (gr_name\ ty\ res\ sigma tmp name ar\
+    (Sub ==> copy ty tmp),
+    coq.term->arity tmp 0 ar,
+    gr_name = pr _ name,
+    res = constructor name ar) Block.
+
+func coq.build-mindt-decl-copy-clauses list (pair inductive term), list term -> list prop.
+coq.build-mindt-decl-copy-clauses [] _ [].
+coq.build-mindt-decl-copy-clauses [pr GR I|Rest] ParamsR [
+    (pi l rest r\ copy (app[global (indt GR)|l]) r :- !, std.append ParamsR rest l, coq.mk-app I rest r, !),
+    (pi l rest r ui\ copy (app[pglobal (indt GR) ui|l]) r :- !, std.append ParamsR rest l, coq.mk-app I rest r, !),
+    (copy (global (indt GR)) I :- !),
+    (pi ui\ copy (pglobal (indt GR) ui) I :- !)
+  | More] :-
+  coq.build-mindt-decl-copy-clauses Rest ParamsR More.
 
 % [coq.indt-unif->indt-nonunif I O] takes an inductive declaration I which may
 % contain uniform parameters (i.e. be headed by the `parameter` constructor),
@@ -314,55 +362,6 @@ coq.indt-unif->indt-nonunif (parameter N Expl Ty RestI) (inductive IN IsInd IA C
 coq.indt-unif->indt-nonunif (inductive _ _ _ _ as I) I.
 coq.indt-unif->indt-nonunif (record _ _ _ _) _ :-
   coq.error "coq.indt-unif->indt-nonunif does not support record types".
-
-func coq.build-mindt-decl-aux list coq.mindt-spec, int, int, list term -> indt-decl.
-coq.build-mindt-decl-aux Specs 0 0 Params Decl :- !,
-  rev Params ParamsR,
-  coq.build-mindt-decl-binders Specs Specs ParamsR [] Decl.
-coq.build-mindt-decl-aux ([coq.mindt-spec _ _ _ (prod N S _) _ _|_] as Specs) Pno UPno Params (parameter NS explicit S Res) :- Pno > 0, UPno > 0, !,
-  coq.name->id N NS,
-  Pno1 is Pno - 1,
-  UPno1 is UPno - 1,
-  pi p\
-    std.map Specs (coq.build-mindt-decl-subst-param p) Specs1,
-    coq.build-mindt-decl-aux Specs1 Pno1 UPno1 [p|Params] (Res p).
-:name "coq.build-mindt-decl-aux:fail"
-coq.build-mindt-decl-aux _ _ _ _ _ :- !,
-  fatal-error "coq.build-mindt-decl-aux: invalid mutual declaration".
-
-func coq.build-mindt-decl-subst-param term, coq.mindt-spec -> coq.mindt-spec.
-coq.build-mindt-decl-subst-param P (coq.mindt-spec GR ID IsInd (prod _ _ T) Kns Ktys) (coq.mindt-spec GR ID IsInd (T P) Kns Ktys1) :- !,
-  std.map Ktys (coq.subst-prod [P]) Ktys1.
-coq.build-mindt-decl-subst-param _ _ _ :- !,
-  fatal-error "coq.build-mindt-decl-subst-param: parameter mismatch".
-
-func coq.build-mindt-decl-binders list coq.mindt-spec, list coq.mindt-spec, list term, list (pair inductive term) -> indt-decl.
-coq.build-mindt-decl-binders All [] ParamsR Acc (mblock Blocks) :- !,
-  rev Acc Pairs,
-  std.map All (coq.build-mindt-decl-block Pairs ParamsR) Blocks.
-coq.build-mindt-decl-binders All [coq.mindt-spec GR ID IsInd Ty _ _|Rest] ParamsR Acc (minductive ID IsInd Arity More) :- !,
-  coq.term->arity Ty 0 Arity,
-  @pi-inductive ID Arity i\
-    coq.build-mindt-decl-binders All Rest ParamsR [pr GR i|Acc] (More i).
-
-func coq.build-mindt-decl-block list (pair inductive term), list term, coq.mindt-spec -> list indc-decl.
-coq.build-mindt-decl-block Pairs ParamsR (coq.mindt-spec _ _ _ _ Kns Ktys) Block :-
-  coq.build-mindt-decl-copy-clauses Pairs ParamsR Sub,
-  std.map2 Kns Ktys (gr_name\ ty\ res\ sigma tmp name ar\
-    (Sub ==> copy ty tmp),
-    coq.term->arity tmp 0 ar,
-    gr_name = pr _ name,
-    res = constructor name ar) Block.
-
-func coq.build-mindt-decl-copy-clauses list (pair inductive term), list term -> list prop.
-coq.build-mindt-decl-copy-clauses [] _ [].
-coq.build-mindt-decl-copy-clauses [pr GR I|Rest] ParamsR [
-    (pi l rest r\ copy (app[global (indt GR)|l]) r :- !, std.append ParamsR rest l, coq.mk-app I rest r, !),
-    (pi l rest r ui\ copy (app[pglobal (indt GR) ui|l]) r :- !, std.append ParamsR rest l, coq.mk-app I rest r, !),
-    (copy (global (indt GR)) I :- !),
-    (pi ui\ copy (pglobal (indt GR) ui) I :- !)
-  | More] :-
-  coq.build-mindt-decl-copy-clauses Rest ParamsR More.
 
 :index (_ 1)
 func coq.rename-arity

--- a/examples/example_fuzzer.v
+++ b/examples/example_fuzzer.v
@@ -87,7 +87,7 @@ main [str IN, str OUT ] :-
   % we rename them, otherwise Coq complains the names are already used
   std.map KN rename-constructors KN1,
   % declare the new inductive
-  coq.build-indt-decl (pr I OUT) B NP NPU A KN1 KT1 Decl,
+  coq.build-indt-decl (coq.indt-spec I OUT B A KN1 KT1) NP NPU  Decl,
   coq.env.add-indt Decl _.
 
 }}.

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3748,7 +3748,7 @@ type record_decl = {
 type ind_decl =
   | Inductive of inductive_decl
   | Record of record_decl
-  | Mutual of ind_decl list
+  | Mutual of inductive_decl list
 type hoas_ind = {
   params : Glob_term.binding_kind ctx_entry list;
   decl : ind_decl;
@@ -3867,10 +3867,7 @@ let hoas_ind2lp ~depth coq_ctx state { params; decl } =
       let state, ks, gls2 =
         API.Utils.map_acc embed_constructor state constructors in
       state, in_elpi_indtdecl_inductive state kind (Name id) arity ks, List.flatten [gls1 ; gls2]
-   | Mutual decls ->
-      let inds = List.map (function
-        | Inductive i -> i
-        | Record _ | Mutual _ -> nYI "records inside mutual inductive blocks") decls in
+   | Mutual inds ->
       let ninds = List.length inds in
       if ninds < 2 then nYI "ill-formed mutual inductive block";
       let sigma = get_sigma state in
@@ -4073,7 +4070,8 @@ let inductive_decl2lp ~depth coq_ctx constraints state (mutind,uinst,mind,(i_imp
     one_inductive_decl i ind i_impls_i k_impls_i) packets in
   let decl = match decls with
     | [decl] -> decl
-    | decls -> Mutual decls in
+    | decls ->
+        Mutual (List.map (function Inductive d -> d | Record _ -> nYI "mutual records" | Mutual _ -> assert false) decls) in
   let ind = { params; decl } in
   hoas_ind2lp ~depth coq_ctx state ind
 ;;
@@ -4152,7 +4150,7 @@ let inductive_entry2lp ~depth coq_ctx constraints state ~loose_udecl e =
       List.map (fun ((id,typ),_impls) ->
         (* FIXME, arity could be longer *)
         { id; arity = nuparams; typ = EConstr.of_constr typ }) in
-    Inductive { nuparams; id; typ; kind; constructors } in
+    { nuparams; id; typ; kind; constructors } in
   let rec pad_impls xs ys default =
     match xs, ys with
     | [], _ -> []
@@ -4161,7 +4159,7 @@ let inductive_entry2lp ~depth coq_ctx constraints state ~loose_udecl e =
   let k_impls = pad_impls mie.mind_entry_inds k_impls [] in
   let decls = List.map2 one_ind mie.mind_entry_inds k_impls in
   let decl = match decls with
-    | [decl] -> decl
+    | [decl] -> Inductive decl
     | decls -> Mutual decls in
   let ind = { params; decl } in
   let state, i, gls = hoas_ind2lp ~depth coq_ctx state ind in

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3632,16 +3632,7 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
       when c == inductivec ->
         let  state, e, fin, iname, nuparams, nuimpls, arity, gl1 =
           aux_inductive ~depth id fin arity coq_ctx state in
-        begin match E.look ~depth ks with
-        | E.Lam t ->
-            let ks = U.lp_list_to_list ~depth:(depth+1) t in
-            let state, melims, idecl, uctx, ubinders, i_impls, ks_impls, gl2 =
-              aux_construtors (push_coq_ctx_local depth e coq_ctx) ~depth:(depth+1) (params,List.rev impls) (nuparams, List.rev nuimpls) arity iname fin
-                state ks in
-            state, (melims, idecl, uctx, ubinders, None, [i_impls, ks_impls]), List.(concat (rev (gl2 :: gl1 :: extra)))
-        | _ -> err Pp.(str"lambda expected: "  ++
-                 str (pp2string P.(term depth) ks))
-        end
+        aux_ind_lam e coq_ctx ~depth params impls state ks nuparams nuimpls arity iname fin (gl1 :: extra)
     | E.App(c,id,[arity;kn;fields]) when c == recordc ->
       begin match E.look ~depth kn with
       | E.CData kname when CD.is_string kname ->
@@ -3697,6 +3688,17 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
         let state, res, gl2 = aux_mutual_constructors coq_ctx ~depth (params,List.rev impls) inds state constructor_blocks in
         state, res, List.(concat (rev (gl2 :: extra)))
     | _ -> err Pp.(str"minductive/mblock expected: " ++ str (pp2string P.(term depth) t))
+  and aux_ind_lam e coq_ctx ~depth params impls state ks nuparams nuimpls arity iname fin extra =
+    match E.look ~depth ks with
+    | E.Lam t ->
+        let ks = U.lp_list_to_list ~depth:(depth+1) t in
+        let state, melims, idecl, uctx, ubinders, i_impls, ks_impls, gl2 =
+          aux_construtors (push_coq_ctx_local depth e coq_ctx) ~depth:(depth+1) (params,List.rev impls) (nuparams, List.rev nuimpls) arity iname fin
+            state ks in
+        state, (melims, idecl, uctx, ubinders, None, [i_impls, ks_impls]), List.(concat (rev (gl2 :: extra)))
+    | _ -> err Pp.(str"lambda expected: "  ++
+              str (pp2string P.(term depth) ks))
+      
   and aux_mind_lam e coq_ctx ~depth params impls inds state extra t =
     match E.look ~depth t with
     | E.Lam t -> aux_mind_decl (push_coq_ctx_local depth e coq_ctx) ~depth:(depth+1) params impls inds state extra t
@@ -3834,7 +3836,7 @@ let hoas_ind2lp ~depth coq_ctx state { params; decl } =
       let ninds = List.length inds in
       let sigma = get_sigma state in
       let paramsno = List.length params in
-      (* Relocation to match Coq's API.
+     (* Relocation to match Coq's API.
       * From
       *  Ind, Params, NuParams |- ktys
       * To

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3153,6 +3153,8 @@ let inductive_parameterc = E.Constants.declare_global_symbol ~variant:2 "paramet
 let arityc = E.Constants.declare_global_symbol "arity"
 let constructorc = E.Constants.declare_global_symbol "constructor"
 let inductivec = E.Constants.declare_global_symbol "inductive"
+let minductivec = E.Constants.declare_global_symbol "minductive"
+let mblockc = E.Constants.declare_global_symbol "mblock"
 let recordc = E.Constants.declare_global_symbol "record"
 let fieldc = E.Constants.declare_global_symbol "field"
 let end_recordc = E.Constants.declare_global_symbol "end-record"
@@ -3189,6 +3191,14 @@ let in_elpi_field atts n ty fields =
 let in_elpi_indtdecl_inductive state find id arity constructors =
   let coind = not (Declarations.CoFinite = find) in
   E.mkApp inductivec (in_elpi_id id) [in_elpi_bool state coind; arity;E.mkLam @@ U.list_to_lp_list constructors]
+
+let in_elpi_indtdecl_minductive state find id arity rest =
+  let coind = not (Declarations.CoFinite = find) in
+  E.mkApp minductivec (in_elpi_id id) [in_elpi_bool state coind; arity;E.mkLam rest]
+
+let in_elpi_indtdecl_mblock constructor_blocks =
+  let constructor_blocks = List.map U.list_to_lp_list constructor_blocks in
+  E.mkApp mblockc (U.list_to_lp_list constructor_blocks) []
 
 let in_elpi_indtdecl_constructor id ty =
   E.mkApp constructorc (in_elpi_id id) [ty]
@@ -3303,7 +3313,7 @@ let poly_cumul_udecl_variance_of_options state options =
     Array.of_list variance
 
 [%%if coq = "9.0"]
-let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~finite =
+let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~finite ~indnames =
   let flags = {
     ComInductive.poly;
     cumulative;
@@ -3312,9 +3322,11 @@ let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~fin
     mode = None;
   }
   in
-  ComInductive.interp_mutual_inductive_constr ~arities_explicit:[true] ~template_syntax:[SyntaxAllowsTemplatePoly] ~flags
+  let arities_explicit = List.map (fun _ -> true) indnames in
+  let template_syntax = List.map (fun _ -> ComInductive.SyntaxAllowsTemplatePoly) indnames in
+  ComInductive.interp_mutual_inductive_constr ~indnames ~arities_explicit ~template_syntax ~flags
 [%%elif coq = "9.1"]
-let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~finite ~ctx_params ~env_ar_params =
+let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~finite ~ctx_params ~env_ar_params ~indnames =
   let flags = {
     ComInductive.poly;
     cumulative;
@@ -3323,10 +3335,12 @@ let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~fin
     mode = None;
   }
   in
+  let arities_explicit = List.map (fun _ -> true) indnames in
+  let template_syntax = List.map (fun _ -> ComInductive.SyntaxAllowsTemplatePoly) indnames in
   let env_ar = Environ.pop_rel_context (List.length ctx_params) env_ar_params in
-  ComInductive.interp_mutual_inductive_constr ~arities_explicit:[true] ~template_syntax:[SyntaxAllowsTemplatePoly] ~flags ~env_ar ~ctx_params
+  ComInductive.interp_mutual_inductive_constr ~indnames ~arities_explicit ~template_syntax ~flags ~env_ar ~ctx_params
 [%%else]
-let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~finite ~ctx_params ~env_ar_params =
+let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~finite ~ctx_params ~env_ar_params ~indnames =
   let flags = {
     ComInductive.poly = PolyFlags.make ~univ_poly:poly ~cumulative ~collapse_sort_variables:true;
     template = Some false;
@@ -3335,8 +3349,10 @@ let comInductive_interp_mutual_inductive_constr ~cumulative ~poly ~template ~fin
     schemes = Default;
   }
   in
+  let arities_explicit = List.map (fun _ -> true) indnames in
+  let template_syntax = List.map (fun _ -> ComInductive.SyntaxAllowsTemplatePoly) indnames in
   let env_ar = Environ.pop_rel_context (List.length ctx_params) env_ar_params in
-  ComInductive.interp_mutual_inductive_constr ~arities_explicit:[true] ~template_syntax:[SyntaxAllowsTemplatePoly] ~flags ~env_ar ~ctx_params
+  ComInductive.interp_mutual_inductive_constr ~indnames ~arities_explicit ~template_syntax ~flags ~env_ar ~ctx_params
 [%%endif]
 
 
@@ -3453,14 +3469,14 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
         ~udecl
         ~variances
         ~ctx_params:(nuparams @ params)
-        ~indnames:[itname]
         ~arities:[arity]
         ~constructors:[knames, ktypes]
         ~env_ar_params
         ~cumulative
         ~poly
         ~private_ind
-        ~finite:finiteness |> comInductive_interp_mutual_inductive_constr_post
+        ~finite:finiteness
+        ~indnames:[itname] |> comInductive_interp_mutual_inductive_constr_post
       in
     let mind = { mind with
       Entries.mind_entry_record =
@@ -3492,6 +3508,111 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
                  str (pp2string P.(term depth) fields))
   in
 
+  let constructor_blocks_of_lp ~depth blocks =
+    U.lp_list_to_list ~depth blocks |>
+    List.map (fun block -> U.lp_list_to_list ~depth block)
+  in
+
+  let relocate_mutual_constructor_type ~paramsno ~ninds t =
+    let subst = CList.init (paramsno + ninds) (fun i ->
+      let rel = i + 1 in
+      if rel <= ninds then
+        let ind = EC.mkRel (paramsno + rel) in
+        if paramsno = 0 then ind
+        else
+          let ps = CArray.init paramsno (fun i -> EC.mkRel (paramsno - i)) in
+          EC.mkApp (ind, ps)
+      else EC.mkRel (rel - ninds)) in
+    EC.Vars.substl subst t
+  in
+
+  let aux_mutual_constructors coq_ctx ~depth (params,impls) inds state constructor_blocks =
+    let params = force_name_ctx params in
+    let paramsno = List.length params in
+    let ninds = List.length inds in
+    if List.length constructor_blocks <> ninds then
+      err Pp.(str"mblock: expected " ++ int ninds ++ str" constructor blocks, got " ++
+              int (List.length constructor_blocks));
+    let state, constructor_infos, gls_rev =
+      List.fold_left2 (fun (state, infos, gls_acc) (name, nuparams, nuimpls, arity, _kind) ks ->
+        if nuparams <> [] then nYI "non-uniform parameters in mutual inductives";
+        let (state, gls_rev), names_ktypes_impls =
+          CList.fold_left_map (fun (state, extra) t ->
+            match E.look ~depth t with
+            | E.App(c,kname,[ty]) when c == constructorc ->
+                begin match E.look ~depth kname with
+                | E.CData kname when CD.is_string kname ->
+                  let kname = Id.of_string (CD.to_string kname) in
+                  let state, kparams, kimpls, ty, gls = readback_arity ~depth coq_ctx constraints state ty in
+                  let ty = check_consistency_and_drop_nuparams (get_sigma state) nuparams kname kparams ty in
+                  let ty = relocate_mutual_constructor_type ~paramsno ~ninds ty in
+                  (state, gls :: extra), (kname, ty, impls @ (List.rev nuimpls) @ kimpls)
+                | _ -> err Pp.(str"@gref expected: " ++ str (pp2string P.(term depth) kname))
+                end
+            | _ -> err Pp.(str"constructor expected: " ++ str (pp2string P.(term depth) t)))
+          (state,[]) ks in
+        let knames, ktypes, kimpls = CList.split3 names_ktypes_impls in
+        state, (name, arity, knames, ktypes, impls @ List.rev nuimpls, kimpls) :: infos, gls_rev @ gls_acc)
+      (state, [], []) inds constructor_blocks in
+    let constructor_infos = List.rev constructor_infos in
+    let indnames = List.map (fun (name, _, _, _, _, _) -> name) constructor_infos in
+    let arities = List.map (fun (_, arity, _, _, _, _) -> arity) constructor_infos in
+    let constructors = List.map (fun (_, _, knames, ktypes, _, _) -> knames, ktypes) constructor_infos in
+    let ind_impls = List.map (fun (_, _, _, _, i_impls, k_impls) -> i_impls, k_impls) constructor_infos in
+    let finiteness =
+      match inds with
+      | [] -> err Pp.(str"mblock: empty mutual inductive block")
+      | (_, _, _, _, kind) :: rest ->
+          if List.for_all (fun (_, _, _, _, kind') -> kind = kind') rest then kind
+          else err Pp.(str"mblock: cannot mix inductive and coinductive declarations") in
+    let state, (melims, mind, ubinders, uctx) =
+      let private_ind = false in
+      let state, poly, cumulative, udecl, variances =
+        poly_cumul_udecl_variance_of_options state coq_ctx.options in
+      let ind_types =
+        List.mapi (fun i (name, arity) ->
+          let ty = EConstr.it_mkProd_or_LetIn arity params in
+          Context.Rel.Declaration.LocalAssum(nameR name, EConstr.Vars.lift i ty))
+          (List.combine indnames arities) in
+      let env_ar_params =
+        let env_ar = List.fold_left (fun env ind_type -> EC.push_rel ind_type env) (Global.env ()) ind_types in
+        EC.push_rel_context params env_ar in
+      let state = minimize_universes state in
+      let used =
+        List.fold_left (fun acc t ->
+          Univ.Level.Set.union acc (universes_of_term state t))
+          Univ.Level.Set.empty arities in
+      let used =
+        List.fold_left (fun acc (_, ktypes) ->
+          List.fold_left (fun acc t -> Univ.Level.Set.union acc (universes_of_term state t)) acc ktypes)
+          used constructors in
+      let used =
+        let open Context.Rel.Declaration in
+        List.fold_left (fun acc -> function
+          | LocalDef(_,t,b) ->
+              Univ.Level.Set.union acc
+                (Univ.Level.Set.union (universes_of_term state t) (universes_of_term state b))
+          | LocalAssum(_,t) -> Univ.Level.Set.union acc (universes_of_term state t))
+          used params in
+      let sigma = restricted_sigma_of used state in
+      state, comInductive_interp_mutual_inductive_constr
+        ~sigma
+        ~template:(Some false)
+        ~udecl
+        ~variances
+        ~ctx_params:params
+        ~arities
+        ~constructors
+        ~env_ar_params
+        ~cumulative
+        ~poly
+        ~private_ind
+        ~finite:finiteness
+        ~indnames |> comInductive_interp_mutual_inductive_constr_post
+    in
+    state, (melims, mind, uctx, ubinders, None, ind_impls), List.concat (List.rev gls_rev)
+  in
+
 
   let rec aux_decl coq_ctx ~depth params impls state extra t =
 
@@ -3502,6 +3623,17 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
         let state, ty, gls = lp2constr coq_ctx ~depth state ty in
         let e = Context.Rel.Declaration.LocalAssum(name,ty) in
         aux_lam e coq_ctx ~depth (e :: params) (manual_implicit_of_binding_kind (Context.binder_name name) imp :: impls) state (gls :: extra) decl
+    | E.App(c,id,[fin;arity;rest])
+      when c == minductivec ->
+        let name = in_coq_annot ~depth id in
+        if Name.is_anonymous (Context.binder_name name) then
+          err Pp.(str"id expected, got: "++ str (pp2string P.(term depth) id));
+        let fin = if in_coq_bool ~depth state ~default:true fin then Declarations.Finite else Declarations.CoFinite in
+        let state, nuparams, nuimpls, arity, gl1 = readback_arity ~depth coq_ctx constraints state arity in
+        let iname =
+          match Context.binder_name name with Name x -> x | _ -> assert false in
+        let e = Context.Rel.Declaration.LocalAssum(name,arity) in
+        aux_mind_lam e coq_ctx ~depth params impls [(iname, nuparams, List.rev nuimpls, arity, fin)] state (gl1 :: extra) rest
     | E.App(c,id,[fin;arity;ks])
       when c == inductivec ->
         let name = in_coq_annot ~depth id in
@@ -3554,6 +3686,28 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
     | E.Lam t -> aux_decl (push_coq_ctx_local depth e coq_ctx) ~depth:(depth+1) params impls state extra t
     | _ -> err Pp.(str"lambda expected: "  ++
                  str (pp2string P.(term depth) t))
+  and aux_mind_decl coq_ctx ~depth params impls inds state extra t =
+    match E.look ~depth t with
+    | E.App(c,id,[fin;arity;rest]) when c == minductivec ->
+        let name = in_coq_annot ~depth id in
+        if Name.is_anonymous (Context.binder_name name) then
+          err Pp.(str"id expected, got: "++ str (pp2string P.(term depth) id));
+        let fin = if in_coq_bool ~depth state ~default:true fin then Declarations.Finite else Declarations.CoFinite in
+        let state, nuparams, nuimpls, arity, gl1 = readback_arity ~depth coq_ctx constraints state arity in
+        let iname =
+          match Context.binder_name name with Name x -> x | _ -> assert false in
+        let e = Context.Rel.Declaration.LocalAssum(name,arity) in
+        aux_mind_lam e coq_ctx ~depth params impls ((iname, nuparams, List.rev nuimpls, arity, fin) :: inds) state (gl1 :: extra) rest
+    | E.App(c,blocks,[]) when c == mblockc ->
+        let inds = List.rev inds in
+        let constructor_blocks = constructor_blocks_of_lp ~depth blocks in
+        let state, res, gl2 = aux_mutual_constructors coq_ctx ~depth (params,List.rev impls) inds state constructor_blocks in
+        state, res, List.(concat (rev (gl2 :: extra)))
+    | _ -> err Pp.(str"minductive/mblock expected: " ++ str (pp2string P.(term depth) t))
+  and aux_mind_lam e coq_ctx ~depth params impls inds state extra t =
+    match E.look ~depth t with
+    | E.Lam t -> aux_mind_decl (push_coq_ctx_local depth e coq_ctx) ~depth:(depth+1) params impls inds state extra t
+    | _ -> err Pp.(str"lambda expected: " ++ str (pp2string P.(term depth) t))
   in
   aux_decl coq_ctx ~depth [] [] state [] t
 ;;
@@ -3577,21 +3731,24 @@ let safe_combine2_impls l1 l2 ~default2 =
 
 (* convention: nuparams are also in each constructor *)
 type 'a ctx_entry = { id : Id.t; typ : EConstr.t; extra : 'a }
-type constructor = { id : Id.t; arity : Glob_term.binding_kind ctx_entry list; typ : EConstr.t } 
+type constructor = { id : Id.t; arity : Glob_term.binding_kind ctx_entry list; typ : EConstr.t }
+type inductive_decl = {
+  id : Id.t;
+  nuparams : Glob_term.binding_kind ctx_entry list;
+  typ : EConstr.t;
+  constructors : constructor list;
+  kind : Declarations.recursivity_kind;
+}
+type record_decl = {
+  id : Id.t;
+  kid : Id.t;
+  typ : EConstr.t;
+  fields : record_field_att list ctx_entry list;
+}
 type ind_decl =
-  | Inductive of {
-      id : Id.t;
-      nuparams : Glob_term.binding_kind ctx_entry list;
-      typ : EConstr.t;
-      constructors : constructor list;
-      kind : Declarations.recursivity_kind;
-    }
-  | Record of {
-      id : Id.t;
-      kid : Id.t;
-      typ : EConstr.t;
-      fields : record_field_att list ctx_entry list;
-    }
+  | Inductive of inductive_decl
+  | Record of record_decl
+  | Mutual of ind_decl list
 type hoas_ind = {
   params : Glob_term.binding_kind ctx_entry list;
   decl : ind_decl;
@@ -3710,6 +3867,51 @@ let hoas_ind2lp ~depth coq_ctx state { params; decl } =
       let state, ks, gls2 =
         API.Utils.map_acc embed_constructor state constructors in
       state, in_elpi_indtdecl_inductive state kind (Name id) arity ks, List.flatten [gls1 ; gls2]
+   | Mutual decls ->
+      let inds = List.map (function
+        | Inductive i -> i
+        | Record _ | Mutual _ -> nYI "records inside mutual inductive blocks") decls in
+      let ninds = List.length inds in
+      if ninds < 2 then nYI "ill-formed mutual inductive block";
+      let sigma = get_sigma state in
+      let paramsno = List.length params in
+      let rec iter n acc f =
+        if n = 0 then acc
+        else iter (n-1) (f acc) f in
+      let subst arityno = CList.init (arityno + paramsno + ninds) (fun i ->
+        let i = i + 1 in
+        if i <= arityno then EC.mkRel i
+        else if i <= arityno + paramsno then EC.mkRel (i + ninds)
+        else
+          let indno = i - arityno - paramsno in
+          let ind = EC.mkRel (arityno + indno) in
+          iter paramsno ind (fun x -> EConstr.mkLambda (anonR,EConstr.mkProp,EConstr.Vars.lift 1 x))) in
+      let reloc ctx_len t =
+        let t = EC.Vars.substl (subst ctx_len) t in
+        Reductionops.nf_beta (Global.env()) sigma t in
+      let rec embed_arities coq_ctx depth state = function
+        | [] -> state, [], coq_ctx, depth, []
+        | { id; nuparams; typ; _ } :: rest ->
+            let state, arity, gls = embed_arity ~depth coq_ctx state (nuparams,typ) in
+            let coq_ctx = push_coq_ctx_local depth (Context.Rel.Declaration.LocalAssum(anonR,EConstr.mkProp)) coq_ctx in
+            let state, arities, coq_ctx, depth, gls_rest = embed_arities coq_ctx (depth+1) state rest in
+            state, arity :: arities, coq_ctx, depth, gls @ gls_rest in
+      let state, arities, coq_ctx, depth, gls1 = embed_arities coq_ctx depth state inds in
+      let embed_constructor state { id; arity; typ } =
+        let alen = List.length arity in
+        let kctx = List.mapi (fun i ({ extra; typ } as x) -> { x with typ = reloc (alen - i -1) typ }) arity in
+        let state, karity, gl = embed_arity ~depth coq_ctx state (kctx,reloc alen typ) in
+        state, in_elpi_indtdecl_constructor (Name id) karity, gl in
+      let embed_constructor_block state { constructors; _ } =
+        API.Utils.map_acc embed_constructor state constructors in
+      let state, constructor_blocks, gls2 =
+        API.Utils.map_acc embed_constructor_block state inds in
+      let body = in_elpi_indtdecl_mblock constructor_blocks in
+      let body =
+        List.fold_right2 (fun { id; kind; _ } arity body ->
+          in_elpi_indtdecl_minductive state kind (Name id) arity body)
+          inds arities body in
+      state, body, List.flatten [gls1; gls2]
    | Record { id; kid; typ; fields } ->
       let embed_record_constructor state fields =
         under_coq2elpi_relctx ~calldepth:depth state fields
@@ -3767,7 +3969,7 @@ let get_template_instance mind uinst = match mind.Declarations.mind_template wit
 | Some templ -> templ.template_defaults
 [%%endif]
 
-let inductive_decl2lp ~depth coq_ctx constraints state (mutind,uinst,(mind,ind),(i_impls,k_impls)) =
+let inductive_decl2lp ~depth coq_ctx constraints state (mutind,uinst,mind,(i_impls,k_impls)) =
   let { Declarations.mind_params_ctxt;
         mind_finite = kind;
         mind_nparams = allparamsno;
@@ -3777,27 +3979,39 @@ let inductive_decl2lp ~depth coq_ctx constraints state (mutind,uinst,(mind,ind),
   let ntyps = Array.length mind.mind_packets in
   let mind_params_ctxt = Vars.subst_instance_context t_uinst mind_params_ctxt in
   let allparams = List.map EConstr.of_rel_decl mind_params_ctxt in
-  let allparams = safe_combine2_impls allparams i_impls ~default2:Glob_term.Explicit |> param2ctx in
+  let i_impls0 = match i_impls with [] -> [] | x :: _ -> x in
+  let allparams = safe_combine2_impls allparams i_impls0 ~default2:Glob_term.Explicit |> param2ctx in
   let nuparamsno = allparamsno - paramsno in
   let nuparams, params = CList.chop nuparamsno allparams in
-  let { Declarations.mind_consnames = constructor_names;
-        mind_typename = id;
-        mind_nf_lc = constructor_types;
-      } = ind in
-  let mind_record = mind_record (mind,ind) in
-  let constructor_types = constructor_types |> Array.map (fun (ctx,ty) -> Vars.subst_instance_context t_uinst ctx, Vars.subst_instance_constr t_uinst ty) in
-  let arity_w_params = Inductive.type_of_inductive ((mind,ind),uinst) in
+
   let sigma = get_sigma state in
   let drop_nparams_from_term n x =
     let x = EConstr.of_constr x in
     let ctx, sort = EConstr.decompose_prod_decls sigma x in
     let ctx = drop_nparams_from_ctx n ctx in
     EConstr.it_mkProd_or_LetIn sort ctx in
-  let decl =
+  let one_inductive_decl ind_index ind _i_impls k_impls =
+    let { Declarations.mind_consnames = constructor_names;
+          mind_typename = id;
+          mind_nf_lc = constructor_types;
+        } = ind in
+    let mind_record = mind_record (mind,ind) in
+    let constructor_types =
+      constructor_types |> Array.map (fun (ctx,ty) ->
+        Vars.subst_instance_context t_uinst ctx, Vars.subst_instance_constr t_uinst ty) in
+    let arity_w_params = Inductive.type_of_inductive ((mind,ind),uinst) in
     if mind_record = Declarations.NotRecord then
       let typ = drop_nparams_from_term allparamsno arity_w_params in
+      let constructor_names = Array.to_list constructor_names in
+      let constructor_types = Array.to_list constructor_types in
+      if List.length constructor_names <> List.length constructor_types ||
+         List.length k_impls > List.length constructor_names then
+        err Pp.(str"ill-shaped mutual inductive constructor metadata for " ++ Id.print id ++
+                str": names=" ++ int (List.length constructor_names) ++
+                str" types=" ++ int (List.length constructor_types) ++
+                str" implicits=" ++ int (List.length k_impls));
       let constructors =
-        safe_combine3 (Array.to_list constructor_names) (Array.to_list constructor_types) k_impls ~default3:[] |>
+        safe_combine3 constructor_names constructor_types k_impls ~default3:[] |>
         List.map (fun (id,(ctx,x),impls) ->
           let x =
             Term.it_mkProd_or_LetIn x ctx |>
@@ -3810,11 +4024,12 @@ let inductive_decl2lp ~depth coq_ctx constraints state (mutind,uinst,(mind,ind),
           let arity = drop_nparams_from_ctx paramsno ctx |> param2ctx in
           { id; arity; typ }) in
       Inductive { nuparams; id; typ; kind; constructors }
-    else
+    else begin
+      if ntyps <> 1 then nYI "mutual records";
       let kid = constructor_names.(0) in
       if (nuparamsno != 0) then nYI "record with non uniform paramters";
       let env = get_global_env state in
-      let projections = (find_structure env (mutind,0)).Structures.Structure.projections in
+      let projections = (find_structure env (mutind,ind_index)).Structures.Structure.projections in
       let fieldsno = List.length projections in
       let kctx, _ = constructor_types.(0) in
       let kctx = EConstr.of_rel_context kctx in
@@ -3842,11 +4057,26 @@ let inductive_decl2lp ~depth coq_ctx constraints state (mutind,uinst,(mind,ind),
         | LocalDef _, _ -> nYI "let-in in record fields parameters") l in
       let fields = List.combine kctx fields_atts |> param2field in
       Record { id; kid; typ; fields }
-    in
+    end
+  in
+  let packets = Array.to_list mind.mind_packets in
+  let rec pad_impls xs ys default =
+    match xs, ys with
+    | [], _ -> []
+    | _ :: xs, y :: ys -> y :: pad_impls xs ys default
+    | _ :: xs, [] -> default :: pad_impls xs [] default in
+  let i_impls = pad_impls packets i_impls [] in
+  let k_impls = pad_impls packets k_impls [] in
+  let decls = List.mapi (fun i ind ->
+    let i_impls_i = List.nth i_impls i in
+    let k_impls_i = List.nth k_impls i in
+    one_inductive_decl i ind i_impls_i k_impls_i) packets in
+  let decl = match decls with
+    | [decl] -> decl
+    | decls -> Mutual decls in
   let ind = { params; decl } in
   hoas_ind2lp ~depth coq_ctx state ind
 ;;
-       
 let upoly_decl_of ~depth state ~loose_udecl mie =
   let open Entries in
   match mie.mind_entry_universes with
@@ -3882,16 +4112,13 @@ let inductive_entry2lp ~depth coq_ctx constraints state ~loose_udecl e =
   let open ComInductive.Mind_decl in
   let open Entries in
   let { mie; nuparams; univ_binders; implicits; uctx } = e in
-  let i_impls, k_impls = match implicits with
-    | [i,k] ->
+  let i_impls, k_impls =
+    List.map (fun (i,k) ->
       List.map binding_kind_of_manual_implicit i,
-      List.map (List.map binding_kind_of_manual_implicit) k
-    | _ -> nYI "mutual inductives" in
-  let ind = match mie.mind_entry_inds with
-  | [ x ] -> x
-  | _ -> nYI "mutual inductives" in
-  let indno = 1 in
-  let state = 
+      List.map (List.map binding_kind_of_manual_implicit) k) implicits
+    |> List.split in
+  let indno = List.length mie.mind_entry_inds in
+  let state =
     S.update engine state (fun e ->
       { e with sigma = merge_universe_context_set UState.univ_flexible e.sigma uctx}) in
   let state = match mie.mind_entry_universes with
@@ -3913,16 +4140,30 @@ let inductive_entry2lp ~depth coq_ctx constraints state ~loose_udecl e =
         | Finite | CoFinite ->
           if (allparams <> []) then inference_nonuniform_params_off ();
           0 in
+  let i_impls0 = match i_impls with [] -> [] | x :: _ -> x in
   let allparams = EConstr.of_rel_context allparams in
-  let allparams = safe_combine2_impls allparams i_impls ~default2:Glob_term.Explicit |> param2ctx in
+  let allparams = safe_combine2_impls allparams i_impls0 ~default2:Glob_term.Explicit |> param2ctx in
   let nuparams, params = CList.chop nuparamsno allparams in
-  let id = ind.mind_entry_typename in
-  let typ = EConstr.of_constr ind.mind_entry_arity in
-  let constructors = List.combine ind.mind_entry_consnames ind.mind_entry_lc in
-  let constructors = List.map (fun (id,typ) ->
-    (* FIXME, arity could be longer *)
-    { id; arity = nuparams; typ = EConstr.of_constr typ }) constructors in
-  let ind = { params; decl = Inductive { id; nuparams; typ; kind; constructors } } in
+  let one_ind ind k_impls =
+    let id = ind.mind_entry_typename in
+    let typ = EConstr.of_constr ind.mind_entry_arity in
+    let constructors = List.combine ind.mind_entry_consnames ind.mind_entry_lc in
+    let constructors = safe_combine2_impls constructors k_impls ~default2:[] |>
+      List.map (fun ((id,typ),_impls) ->
+        (* FIXME, arity could be longer *)
+        { id; arity = nuparams; typ = EConstr.of_constr typ }) in
+    Inductive { nuparams; id; typ; kind; constructors } in
+  let rec pad_impls xs ys default =
+    match xs, ys with
+    | [], _ -> []
+    | _ :: xs, y :: ys -> y :: pad_impls xs ys default
+    | _ :: xs, [] -> default :: pad_impls xs [] default in
+  let k_impls = pad_impls mie.mind_entry_inds k_impls [] in
+  let decls = List.map2 one_ind mie.mind_entry_inds k_impls in
+  let decl = match decls with
+    | [decl] -> decl
+    | decls -> Mutual decls in
+  let ind = { params; decl } in
   let state, i, gls = hoas_ind2lp ~depth coq_ctx state ind in
   state, upoly_decl_of i, gls @ upoly_decl_gls
 ;;

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3625,25 +3625,13 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
         aux_lam e coq_ctx ~depth (e :: params) (manual_implicit_of_binding_kind (Context.binder_name name) imp :: impls) state (gls :: extra) decl
     | E.App(c,id,[fin;arity;rest])
       when c == minductivec ->
-        let name = in_coq_annot ~depth id in
-        if Name.is_anonymous (Context.binder_name name) then
-          err Pp.(str"id expected, got: "++ str (pp2string P.(term depth) id));
-        let fin = if in_coq_bool ~depth state ~default:true fin then Declarations.Finite else Declarations.CoFinite in
-        let state, nuparams, nuimpls, arity, gl1 = readback_arity ~depth coq_ctx constraints state arity in
-        let iname =
-          match Context.binder_name name with Name x -> x | _ -> assert false in
-        let e = Context.Rel.Declaration.LocalAssum(name,arity) in
+        let  state, e, fin, iname, nuparams, nuimpls, arity, gl1 =
+          aux_inductive ~depth id fin arity coq_ctx state in
         aux_mind_lam e coq_ctx ~depth params impls [(iname, nuparams, List.rev nuimpls, arity, fin)] state (gl1 :: extra) rest
     | E.App(c,id,[fin;arity;ks])
       when c == inductivec ->
-        let name = in_coq_annot ~depth id in
-        if Name.is_anonymous (Context.binder_name name) then
-          err Pp.(str"id expected, got: "++ str (pp2string P.(term depth) id));
-        let fin = if in_coq_bool ~depth state ~default:true fin then Declarations.Finite else Declarations.CoFinite in
-        let state, nuparams, nuimpls, arity, gl1 = readback_arity ~depth coq_ctx constraints state arity in
-        let e = Context.Rel.Declaration.LocalAssum(name,arity) in
-        let iname =
-          match Context.binder_name name with Name x -> x | _ -> assert false in
+        let  state, e, fin, iname, nuparams, nuimpls, arity, gl1 =
+          aux_inductive ~depth id fin arity coq_ctx state in
         begin match E.look ~depth ks with
         | E.Lam t ->
             let ks = U.lp_list_to_list ~depth:(depth+1) t in
@@ -3686,17 +3674,22 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
     | E.Lam t -> aux_decl (push_coq_ctx_local depth e coq_ctx) ~depth:(depth+1) params impls state extra t
     | _ -> err Pp.(str"lambda expected: "  ++
                  str (pp2string P.(term depth) t))
+  and aux_inductive ~depth id fin arity coq_ctx state =
+    let name = in_coq_annot ~depth id in
+    if Name.is_anonymous (Context.binder_name name) then
+      err Pp.(str"id expected, got: "++ str (pp2string P.(term depth) id));
+    let fin = if in_coq_bool ~depth state ~default:true fin then Declarations.Finite else Declarations.CoFinite in
+    let state, nuparams, nuimpls, arity, gl1 = readback_arity ~depth coq_ctx constraints state arity in
+    let e = Context.Rel.Declaration.LocalAssum(name,arity) in
+    let iname =
+      match Context.binder_name name with Name x -> x | _ -> assert false in
+    state, e, fin, iname, nuparams, nuimpls, arity, gl1
+
   and aux_mind_decl coq_ctx ~depth params impls inds state extra t =
     match E.look ~depth t with
     | E.App(c,id,[fin;arity;rest]) when c == minductivec ->
-        let name = in_coq_annot ~depth id in
-        if Name.is_anonymous (Context.binder_name name) then
-          err Pp.(str"id expected, got: "++ str (pp2string P.(term depth) id));
-        let fin = if in_coq_bool ~depth state ~default:true fin then Declarations.Finite else Declarations.CoFinite in
-        let state, nuparams, nuimpls, arity, gl1 = readback_arity ~depth coq_ctx constraints state arity in
-        let iname =
-          match Context.binder_name name with Name x -> x | _ -> assert false in
-        let e = Context.Rel.Declaration.LocalAssum(name,arity) in
+        let  state, e, fin, iname, nuparams, nuimpls, arity, gl1 =
+          aux_inductive ~depth id fin arity coq_ctx state in
         aux_mind_lam e coq_ctx ~depth params impls ((iname, nuparams, List.rev nuimpls, arity, fin) :: inds) state (gl1 :: extra) rest
     | E.App(c,blocks,[]) when c == mblockc ->
         let inds = List.rev inds in

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3833,45 +3833,20 @@ let hoas_ind2lp ~depth coq_ctx state { params; decl } =
   under_coq2elpi_relctx ~calldepth ~coq_ctx state params
     ~mk_ctx_item:mk_inductive_parameter2
     (fun coq_ctx hyps ~depth state -> match decl with
-    | Inductive { id; nuparams; typ; constructors; kind } ->
+   | Inductive _
+   | Mutual _ ->
+      let inds =
+        match decl with
+        | Mutual l -> l | Inductive x -> [x] | Record _ -> assert false in
+      let ninds = List.length inds in
       let sigma = get_sigma state in
       let paramsno = List.length params in
-     (* Relocation to match Coq's API.
+      (* Relocation to match Coq's API.
       * From
       *  Ind, Params, NuParams |- ktys
       * To
       *  Params, Ind, NuParams |- ktys
       *)
-      let rec iter n acc f =
-        if n = 0 then acc
-        else iter (n-1) (f acc) f in
-      let subst arityno = CList.init (arityno + paramsno + 1) (fun i ->
-        let i = i + 1 in (* init is 0 based, rels are 1 base *)
-        if i = arityno + paramsno + 1 then
-          let ind = EC.mkRel (arityno + 1) in
-          iter paramsno ind (fun x -> EConstr.mkLambda (anonR,EConstr.mkProp,EConstr.Vars.lift 1 x))
-        else if i > arityno then EC.mkRel(i+1)
-        else EC.mkRel i) in
-      let reloc ctx_len t =
-        let t = EC.Vars.substl (subst ctx_len) t in
-        Reductionops.nf_beta (Global.env()) sigma t in
-    
-      let state, arity, gls1 = embed_arity ~depth coq_ctx state (nuparams,typ) in
-      let coq_ctx = push_coq_ctx_local depth (Context.Rel.Declaration.LocalAssum(anonR,EConstr.mkProp)) coq_ctx in
-      let depth = depth+1 in
-      let embed_constructor state { id; arity; typ } =
-        let alen = List.length arity in
-        let kctx = List.mapi (fun i ({ extra; typ } as x) -> { x with typ = reloc (alen - i -1) typ }) arity in
-        let state, karity, gl = embed_arity ~depth coq_ctx state (kctx,reloc alen typ) in
-        state, in_elpi_indtdecl_constructor (Name id) karity, gl in
-      let state, ks, gls2 =
-        API.Utils.map_acc embed_constructor state constructors in
-      state, in_elpi_indtdecl_inductive state kind (Name id) arity ks, List.flatten [gls1 ; gls2]
-   | Mutual inds ->
-      let ninds = List.length inds in
-      if ninds < 2 then nYI "ill-formed mutual inductive block";
-      let sigma = get_sigma state in
-      let paramsno = List.length params in
       let rec iter n acc f =
         if n = 0 then acc
         else iter (n-1) (f acc) f in
@@ -3899,16 +3874,24 @@ let hoas_ind2lp ~depth coq_ctx state { params; decl } =
         let kctx = List.mapi (fun i ({ extra; typ } as x) -> { x with typ = reloc (alen - i -1) typ }) arity in
         let state, karity, gl = embed_arity ~depth coq_ctx state (kctx,reloc alen typ) in
         state, in_elpi_indtdecl_constructor (Name id) karity, gl in
-      let embed_constructor_block state { constructors; _ } =
-        API.Utils.map_acc embed_constructor state constructors in
-      let state, constructor_blocks, gls2 =
-        API.Utils.map_acc embed_constructor_block state inds in
-      let body = in_elpi_indtdecl_mblock constructor_blocks in
-      let body =
-        List.fold_right2 (fun { id; kind; _ } arity body ->
-          in_elpi_indtdecl_minductive state kind (Name id) arity body)
-          inds arities body in
-      state, body, List.flatten [gls1; gls2]
+      begin match decl with
+      | Record _ -> assert false
+      | Mutual _ ->
+          let embed_constructor_block state { constructors; _ } =
+            API.Utils.map_acc embed_constructor state constructors in
+          let state, constructor_blocks, gls2 =
+            API.Utils.map_acc embed_constructor_block state inds in
+          let body = in_elpi_indtdecl_mblock constructor_blocks in
+          let body =
+            List.fold_right2 (fun { id; kind; _ } arity body ->
+              in_elpi_indtdecl_minductive state kind (Name id) arity body)
+              inds arities body in
+          state, body, List.flatten [gls1; gls2]
+      | Inductive { constructors; id; kind } ->
+          let state, ks, gls2 =
+            API.Utils.map_acc embed_constructor state constructors in
+          state, in_elpi_indtdecl_inductive state kind (Name id) (List.hd arities) ks, List.flatten [gls1 ; gls2]
+      end
    | Record { id; kid; typ; fields } ->
       let embed_record_constructor state fields =
         under_coq2elpi_relctx ~calldepth:depth state fields

--- a/src/rocq_elpi_HOAS.mli
+++ b/src/rocq_elpi_HOAS.mli
@@ -141,7 +141,7 @@ val lp2record_field_spec : record_field_spec -> Name.t * Record.Data.projection_
 [%%endif]
 
 val inductive_decl2lp :
-  depth:int -> empty conv_context -> constraints -> State.t -> (Names.MutInd.t * UVars.Instance.t * (Declarations.mutual_inductive_body * Declarations.one_inductive_body) * (Glob_term.binding_kind list * Glob_term.binding_kind list list)) ->
+  depth:int -> empty conv_context -> constraints -> State.t -> (Names.MutInd.t * UVars.Instance.t * Declarations.mutual_inductive_body * (Glob_term.binding_kind list list * Glob_term.binding_kind list list list)) ->
     State.t * term * Conversion.extra_goals
 
 val inductive_entry2lp :

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -2101,6 +2101,36 @@ Supported attributes:
 
   DocNext);
 
+  MLCode(Pred("coq.env.indt-block",
+    In(inductive, "Ind",
+    Out(bool, "tt if the type is inductive (ff for co-inductive)",
+    Out(int,  "number of parameters",
+    Out(int,  "number of parameters that are uniform (<= parameters)",
+    Out(list inductive, "all inductives in the block",
+    COut(B.listC closed_ground_term, "types of the inductive types constructors including parameters",
+    Out(list (list constructor), "lists of constructor names",
+    COut(B.listC (B.listC closed_ground_term), "lists of the types of the constructors (type of KNames) including parameters",
+    Full(global, {|reads the inductive type declaration for the environment.|}))))))))),
+  (fun i _ _ _ _ arity knames ktypes ~depth { env ; options } _ state ->
+    let open Declarations in
+    let mind, _indbo as _ind = lookup_inductive env i in
+    let co  = mind.mind_finite <> Declarations.CoFinite in
+    let lno = mind.mind_nparams in
+    let luno = mind.mind_nparams_rec in
+    let uinst, state, extra_goals = handle_uinst_option_for_inductive ~depth options i state in
+    let arity = if_keep arity (fun () ->
+      mind.mind_packets |> CArray.map_to_list (fun ind -> Inductive.type_of_inductive ((mind,ind),uinst) |> EConstr.of_constr)) in
+    let knames = if_keep knames (fun () ->
+      mind.mind_packets |> CArray.map_to_list (fun ind -> 
+        CList.(init (Array.length Declarations.(ind.mind_consnames)) (fun k -> i,k+1)))) in
+    let ktypes = if_keep ktypes (fun () ->
+      mind.mind_packets |> CArray.map_to_list (fun ind -> 
+      Inductive.type_of_constructors (i,uinst) (mind,ind)
+      |> CArray.map_to_list EConstr.of_constr)) in
+     let inames = CList.(init (Array.length Declarations.(mind.mind_packets)) (fun k -> fst i, k)) in
+     state, !:  co +! lno +! luno +! inames +? arity +? knames +? ktypes, extra_goals)),
+  DocNext);
+
   MLCode(Pred("coq.env.indt-decl",
     In(inductive, "reference to the inductive type",
     COut(indt_decl_out,"HOAS description of the inductive type",
@@ -2120,15 +2150,6 @@ Supported attributes:
        List.map (fun x -> Impargs.extract_impargs_data (Impargs.implicits_of_global x) |> hd) knames) packets in
      state, !: (fst i, uinst, mind, (i_impls,k_impls)), extra_goals)),
   DocNext);
-
-  MLCode(Pred("coq.env.indt-block",
-    In(inductive, "Ind",
-    Out(list inductive, "AllInd",
-    Read(global, "AllInd are all the inductive types in the mutual block of Ind, in declaration order"))),
-  (fun i _ ~depth { env } _ _state ->
-     let mind, _indbo = lookup_inductive env i in
-     !: CList.(init (Array.length Declarations.(mind.mind_packets)) (fun k -> fst i, k)))),
-  DocAbove);
 
   MLCode(Pred("coq.env.indc->indt",
     In(constructor,"K",

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -2121,10 +2121,10 @@ Supported attributes:
      state, !: (fst i, uinst, mind, (i_impls,k_impls)), extra_goals)),
   DocNext);
 
-  MLCode(Pred("coq.env.mutual-inductives",
-    In(inductive, "reference to an inductive type",
-    Out(list inductive, "Inductives",
-    Read(global, "lists all inductive types in the same mutual block, in declaration order"))),
+  MLCode(Pred("coq.env.indt-block",
+    In(inductive, "Ind",
+    Out(list inductive, "AllInd",
+    Read(global, "AllInd are all the inductive types in the mutual block of Ind, in declaration order"))),
   (fun i _ ~depth { env } _ _state ->
      let mind, _indbo = lookup_inductive env i in
      !: CList.(init (Array.length Declarations.(mind.mind_packets)) (fun k -> fst i, k)))),

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -2093,7 +2093,7 @@ Supported attributes:
       Inductive.type_of_inductive (ind,uinst)
       |> EConstr.of_constr) in
     let knames = if_keep knames (fun () ->
-      CList.(init Declarations.(indbo.mind_nb_constant + indbo.mind_nb_args) (fun k -> i,k+1))) in
+      CList.(init (Array.length Declarations.(indbo.mind_consnames)) (fun k -> i,k+1))) in
     let ktypes = if_keep ktypes (fun () ->
       Inductive.type_of_constructors (i,uinst) ind
       |> CArray.map_to_list EConstr.of_constr) in
@@ -2108,16 +2108,27 @@ Supported attributes:
 % Supported attributes:
 % - @uinstance! I (default: fresh instance I)|}))),
   (fun i _ ~depth { env; options } _ state  ->
-     let mind, indbo = lookup_inductive env i in
+     let mind, _indbo = lookup_inductive env i in
      let uinst, state, extra_goals = handle_uinst_option_for_inductive ~depth options i state in
-     let knames = CList.(init Declarations.(indbo.mind_nb_constant + indbo.mind_nb_args) (fun k -> GlobRef.ConstructRef(i,k+1))) in
-     let k_impls = List.map (fun x -> Impargs.extract_impargs_data (Impargs.implicits_of_global x)) knames in
      let hd x = match x with [] -> [] | (_,x) :: _ -> List.map implicit_kind_of_status x in
-     let k_impls = List.map hd k_impls in
-     let i_impls = Impargs.extract_impargs_data @@ Impargs.implicits_of_global (GlobRef.IndRef i) in
-     let i_impls = hd i_impls in
-     state, !: (fst i, uinst, (mind,indbo), (i_impls,k_impls)), extra_goals)),
+     let packets = Array.to_list mind.Declarations.mind_packets in
+     let i_impls = List.mapi (fun indno _ ->
+       Impargs.extract_impargs_data (Impargs.implicits_of_global (GlobRef.IndRef (fst i, indno))) |> hd) packets in
+     let k_impls = List.mapi (fun indno indbo ->
+       let ind = (fst i, indno) in
+       let knames = CList.(init (Array.length Declarations.(indbo.mind_consnames)) (fun k -> GlobRef.ConstructRef(ind,k+1))) in
+       List.map (fun x -> Impargs.extract_impargs_data (Impargs.implicits_of_global x) |> hd) knames) packets in
+     state, !: (fst i, uinst, mind, (i_impls,k_impls)), extra_goals)),
   DocNext);
+
+  MLCode(Pred("coq.env.mutual-inductives",
+    In(inductive, "reference to an inductive type",
+    Out(list inductive, "Inductives",
+    Read(global, "lists all inductive types in the same mutual block, in declaration order"))),
+  (fun i _ ~depth { env } _ _state ->
+     let mind, _indbo = lookup_inductive env i in
+     !: CList.(init (Array.length Declarations.(mind.mind_packets)) (fun k -> fst i, k)))),
+  DocAbove);
 
   MLCode(Pred("coq.env.indc->indt",
     In(constructor,"K",
@@ -2202,12 +2213,9 @@ regarded as not non-informative).|})),
     In(inductive, "Ind",
     Read(global, "checks if Ind is recursive")),
   (fun i ~depth {env} _ state ->
-      let mind, indbo = Inductive.lookup_mind_specif env i in
-      match mind.Declarations.mind_packets with
-      | [| mip |] ->
-           if mis_is_recursive mip then ()
-           else raise No_clause
-      | _ -> assert false
+      let _, indbo = Inductive.lookup_mind_specif env i in
+      if mis_is_recursive indbo then ()
+      else raise No_clause
     )),
   DocAbove);
 
@@ -2619,16 +2627,17 @@ Supported attributes:
        let univ_binders = univ_binder_compat_820 (uentry', ubinders) univ_binders in
        declare_mutual_inductive_with_eliminations ~primitive_expected ~default_dep_elim me univ_binders ind_impls in
      let ind = mind, 0 in
-     let id, cids = match me.Entries.mind_entry_inds with
-       | [ { Entries.mind_entry_typename = id; mind_entry_consnames = cids }] -> id, cids
-       | _ -> assert false
-       in
      let lid_of id = CAst.make ~loc:(to_coq_loc @@ State.get Rocq_elpi_builtins_synterp.invocation_site_loc state) id in
      begin match record_info with
      | None -> (* regular inductive *)
-        Dumpglob.dump_definition (lid_of id) false "ind";
-        List.iter (fun x -> Dumpglob.dump_definition (lid_of x) false "constr") cids
+        List.iter (fun { Entries.mind_entry_typename = id; mind_entry_consnames = cids; _ } ->
+          Dumpglob.dump_definition (lid_of id) false "ind";
+          List.iter (fun x -> Dumpglob.dump_definition (lid_of x) false "constr") cids)
+          me.Entries.mind_entry_inds
      | Some (primitive,field_specs) -> (* record: projection... *)
+         let id = match me.Entries.mind_entry_inds with
+           | [ { Entries.mind_entry_typename = id; _ } ] -> id
+           | _ -> assert false in
          let names, flags =
            List.(split (map lp2record_field_spec field_specs))
          in

--- a/src/rocq_elpi_utils.ml
+++ b/src/rocq_elpi_utils.ml
@@ -205,9 +205,7 @@ let binding_kind_of_manual_implicit x =
 let manual_implicit_of_gdecl (name, _, bk, _, _) = manual_implicit_of_binding_kind name bk
 
 let lookup_inductive env i =
-  let mind, indbo = Inductive.lookup_mind_specif env i in
-  if Array.length mind.Declarations.mind_packets <> 1 then nYI "API(env) mutual inductive";
-  (mind, indbo)
+  Inductive.lookup_mind_specif env i
 
 [%%if coq = "9.0" || coq = "9.1"]
 let abbreviation_find_interp = Abbreviation.search_abbreviation

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -942,9 +942,9 @@ Elpi Query lp:{{
 
 (************** *)
 
-Inductive i1 (A: Type) | (B : Type) : (forall x : nat, x + 1 = x) -> Prop :=
-  | K11 : forall p, forall x : bool, x = x -> i2 B -> i1 (B * B) p -> i1 B p
-with i2 (A:Type) | (B : Type) : Type := K21.
+Inductive i1 (A: Type) (B : Type) : (forall x : nat, x + 1 = x) -> Prop :=
+  | K11 : forall p, forall x : bool, x = x -> i2 A B -> i1 A (B * B) p -> i1 A B p
+with i2 (A:Type) (B : Type) : Type := K21.
 
 Elpi Query lp:{{
   {{ i1 }} = global (indt I),

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -943,14 +943,14 @@ Elpi Query lp:{{
 (************** *)
 
 Inductive i1 (A: Type) (B : Type) : (forall x : nat, x + 1 = x) -> Prop :=
-  | K11 : forall p, forall x : bool, x = x -> i2 A B -> i1 A (B * B) p -> i1 A B p
+  | K11 : forall p, forall x : bool, x = x -> i2 A B -> i1 A B p -> i1 A B p
 with i2 (A:Type) (B : Type) : Type := K21.
 
 Elpi Query lp:{{
   {{ i1 }} = global (indt I),
   coq.env.indt-block I tt NP NUP [I,I2] SL KNL KTL,
   std.assert! (NP = 2) "NP",
-  std.assert! (NUP = 1) "NUP",
+  std.assert! (NUP = 2) "NUP",
   std.assert! (SL = [_,_]) "SL",
   std.assert! (KNL = [[_],[_]]) "KNL",
   std.assert! (KTL = [[_],[_]]) "KTL",

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -939,3 +939,14 @@ Elpi Query lp:{{
 
 
 }}.
+
+(************** *)
+
+Inductive i1 (A: Type) | (B : Type) : (forall x : nat, x + 1 = x) -> Prop :=
+  | K11 : forall p, forall x : bool, x = x -> i2 B -> i1 (B * B) p -> i1 B p
+with i2 (A:Type) | (B : Type) : Type := K21.
+
+Elpi Query lp:{{
+  {{ i1 }} = global (indt I),
+  coq.env.indt-block I [I,I2]
+}}.

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -948,5 +948,9 @@ with i2 (A:Type) | (B : Type) : Type := K21.
 
 Elpi Query lp:{{
   {{ i1 }} = global (indt I),
-  coq.env.indt-block I [I,I2]
+  coq.env.indt-block I [I,I2],
+  coq.env.indt-decl I D,
+  coq.env.indt-decl I2 D2,
+  std.assert! (D = D2) "different inductives",
+  coq.typecheck-indt-decl D ok.
 }}.

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -948,7 +948,12 @@ with i2 (A:Type) (B : Type) : Type := K21.
 
 Elpi Query lp:{{
   {{ i1 }} = global (indt I),
-  coq.env.indt-block I [I,I2],
+  coq.env.indt-block I tt NP NUP [I,I2] SL KNL KTL,
+  std.assert! (NP = 2) "NP",
+  std.assert! (NUP = 1) "NUP",
+  std.assert! (SL = [_,_]) "SL",
+  std.assert! (KNL = [[_],[_]]) "KNL",
+  std.assert! (KTL = [[_],[_]]) "KTL",
   coq.env.indt-decl I D,
   coq.env.indt-decl I2 D2,
   std.assert! (D = D2) "different inductives",

--- a/tests/test_mutind.v
+++ b/tests/test_mutind.v
@@ -1,0 +1,95 @@
+From elpi Require Import elpi.
+
+Inductive tree : Type :=
+| node (f : forest)
+with forest : Type :=
+| empty
+| cons (t : tree) (f : forest).
+
+Inductive ptree (A : Type) : Type :=
+| pnode (x : A) (f : pforest A)
+with pforest (A : Type) : Type :=
+| pempty
+| pcons (t : ptree A) (f : pforest A).
+
+Inductive even : nat -> Type :=
+| evenO : even 0
+| evenS n : odd n -> even (S n)
+with odd : nat -> Type :=
+| oddS n : even n -> odd (S n).
+
+Elpi Command test_mutind.
+Elpi Accumulate lp:{{
+main _ :-
+  coq.locate "tree" (indt Tree),
+  coq.env.indt-decl Tree TreeDecl,
+  std.assert-ok! (coq.typecheck-indt-decl TreeDecl) "tree declaration illtyped",
+
+  coq.locate "ptree" (indt PTree),
+  coq.env.indt-decl PTree PTreeDecl,
+  std.assert-ok! (coq.typecheck-indt-decl PTreeDecl) "ptree declaration illtyped",
+
+  coq.locate "even" (indt Even),
+  coq.env.indt-decl Even EvenDecl,
+  std.assert-ok! (coq.typecheck-indt-decl EvenDecl) "even declaration illtyped",
+
+  Tree2Decl = (minductive "tree2" tt (arity {{ Type }}) t\
+    (minductive "forest2" tt (arity {{ Type }}) f\
+      (mblock [
+        [constructor "node2" (arity {{ lp:f -> lp:t }})],
+        [constructor "empty2" (arity f),
+         constructor "cons2" (arity {{ lp:t -> lp:f -> lp:f }})]
+      ]))),
+  std.assert-ok! (coq.typecheck-indt-decl Tree2Decl) "tree2 declaration illtyped",
+  coq.env.add-indt Tree2Decl _,
+
+  PTree2Decl = (parameter "A" explicit {{ Type }} a\
+    (minductive "ptree2" tt (arity {{ Type }}) t\
+    (minductive "pforest2" tt (arity {{ Type }}) f\
+      (mblock [
+        [constructor "pnode2" (arity {{ lp:a -> lp:f -> lp:t }})],
+        [constructor "pempty2" (arity f),
+         constructor "pcons2" (arity {{ lp:t -> lp:f -> lp:f }})]
+      ])))),
+  std.assert-ok! (coq.typecheck-indt-decl PTree2Decl) "ptree2 declaration illtyped",
+  coq.env.add-indt PTree2Decl _,
+
+  Even2Decl = (minductive "even2" tt (arity {{ nat -> Type }}) even\
+    (minductive "odd2" tt (arity {{ nat -> Type }}) odd\
+      (mblock [
+        [constructor "evenO2" (arity {{ lp:even 0 }}),
+         constructor "evenS2" (parameter "n" explicit {{ nat }} n\
+           arity {{ lp:odd lp:n -> lp:even (S lp:n) }})],
+        [constructor "oddS2" (parameter "n" explicit {{ nat }} n\
+           arity {{ lp:even lp:n -> lp:odd (S lp:n) }})]
+      ]))),
+  std.assert-ok! (coq.typecheck-indt-decl Even2Decl) "even2 declaration illtyped",
+  coq.env.add-indt Even2Decl _.
+}}.
+Module Generated.
+  Elpi test_mutind.
+End Generated.
+
+Universe tree2_u ptree2_arg_u ptree2_u even2_u.
+
+Module Type GeneratedMutualInductives.
+  Inductive tree2 : Type@{tree2_u} :=
+  | node2 (f : forest2)
+  with forest2 : Type@{tree2_u} :=
+  | empty2
+  | cons2 (t : tree2) (f : forest2).
+
+  Inductive ptree2 (A : Type@{ptree2_arg_u}) : Type@{ptree2_u} :=
+  | pnode2 (x : A) (f : pforest2 A)
+  with pforest2 (A : Type@{ptree2_arg_u}) : Type@{ptree2_u} :=
+  | pempty2
+  | pcons2 (t : ptree2 A) (f : pforest2 A).
+
+  Inductive even2 : nat -> Type@{even2_u} :=
+  | evenO2 : even2 0
+  | evenS2 n : odd2 n -> even2 (S n)
+  with odd2 : nat -> Type@{even2_u} :=
+  | oddS2 n : even2 n -> odd2 (S n).
+End GeneratedMutualInductives.
+
+Module GeneratedMatches <: GeneratedMutualInductives := Generated.


### PR DESCRIPTION
This is #1053 restricted to `src/`, `elpi/`, and `test/`. It should contain only changes related to the HOAS representation of mutual inductive types.

- [x] `coq.env.indt-block` should also also output the knames and types as `coq.env.indt` does