### PR TITLE
declare goals as future goals (avoid accidental TC resolution)

### DIFF
--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3013,6 +3013,7 @@ let tclSOLUTION2EVD ~eta_contract_solution sigma0 solution gls =
     let roots = List.fold_right Evar.Set.add gls Evar.Set.empty in
     let sigma, declared_goals, shelved_goals = solution2evd ~eta_contract_solution sigma0 solution roots in
     let sigma = Evd.fold_future_goals Evd.remove_future_goal sigma in
+    let sigma = List.fold_right Evd.declare_future_goal declared_goals sigma in
     (* debug Pp.(fun () -> str "Old Shelved Goals: " ++ prlist_with_sep spc Evar.print sh);
     debug Pp.(fun () -> str "New Evd Shelved Goals: " ++ prlist_with_sep spc Evar.print (Evd.shelf sigma)); *)
   tclTHENLIST [

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3012,13 +3012,16 @@ let tclSOLUTION2EVD ~eta_contract_solution sigma0 solution gls =
   tclGETSHELF >>= fun sh ->
     let roots = List.fold_right Evar.Set.add gls Evar.Set.empty in
     let sigma, declared_goals, shelved_goals = solution2evd ~eta_contract_solution sigma0 solution roots in
-    let sigma = Evd.fold_future_goals Evd.remove_future_goal sigma in
-    let sigma = List.fold_right Evd.declare_future_goal declared_goals sigma in
-    (* debug Pp.(fun () -> str "Old Shelved Goals: " ++ prlist_with_sep spc Evar.print sh);
-    debug Pp.(fun () -> str "New Evd Shelved Goals: " ++ prlist_with_sep spc Evar.print (Evd.shelf sigma)); *)
+
+    let future_goals, sigma = Evd.pop_future_goals sigma in
+    let future_goals = Evd.FutureGoals.map_filter (Proofview.Unsafe.advance sigma) future_goals in
+    let future_goals = Evd.FutureGoals.filter (fun ev -> not @@ List.mem ev (Evd.shelf sigma) && not @@ List.mem ev shelved_goals) future_goals in
+    let sigma = Proofview.Unsafe.mark_as_goals sigma (Evd.FutureGoals.comb future_goals @ declared_goals) in
+    let comb = CList.map (fun x -> Proofview.with_empty_state x) (Evd.FutureGoals.comb future_goals @ declared_goals) in
+
   tclTHENLIST [
     tclEVARS sigma;
-    tclSETGOALS @@ List.map Proofview.with_empty_state declared_goals;
+    tclSETGOALS @@ comb;
     tclNEWSHELVED shelved_goals
   ]
 

--- a/src/rocq_elpi_vernacular.ml
+++ b/src/rocq_elpi_vernacular.ml
@@ -712,6 +712,7 @@ let run_tactic_common ~loc program ~main ?(atts=[]) () =
   Unsafe.tclGETGOALS >>= fun gls ->
   let gls = CList.map Proofview.drop_state gls in
   Proofview.tclEVARMAP >>= fun sigma ->
+  let sigma = Evd.push_future_goals sigma in (* avoid touching unrelated future goals *)
   let query ~base state =
     let loc = of_coq_loc loc in
     let depth = 0 in

--- a/tests/test_API2.v
+++ b/tests/test_API2.v
@@ -448,6 +448,7 @@ Elpi Accumulate lp:{{
 
 Goal 3+2=5.
 elpi spawn_tc_goal.
+  Show.
   (* 2: shelve. Unshelve. *)
   easy.
 constructor. easy.

--- a/tests/test_API2.v
+++ b/tests/test_API2.v
@@ -432,3 +432,23 @@ main _ :-
 Elpi Accumulate Db foo.db.
 
 Elpi acc_foo2. (* since r has no type in foo.db *)
+
+(* test goals that are TC are flagged as interactive *)
+
+Class Foo (A : Type) := { a : A }.
+
+Elpi Tactic spawn_tc_goal.
+Elpi Accumulate lp:{{
+  solve (goal _ _ Ty _ _ as G) GL :-
+    T = {{ proj1 (conj _ (@a True _)) }},
+    (std.assert-ok! (coq.elaborate-skeleton T Ty T') "??"),
+    refine T' G GL.
+
+}}.
+
+Goal 3+2=5.
+elpi spawn_tc_goal.
+  (* 2: shelve. Unshelve. *)
+  easy.
+constructor. easy.
+Qed.


### PR DESCRIPTION
Apparently some tactics, but not all, trigger a TC resolution of all evars that are TC and are not flagged as goals.

CC @ybertot 
CC @SkySkimmer I could not really find the link between future goals and TC resolution. I'd like a confirmation I'm not just moving the problem.