### PR TITLE
feat: :bug: Fixes the bug of building for Coq 8

### DIFF
--- a/src/dune.in
+++ b/src/dune.in
@@ -2,6 +2,7 @@
  (name elpi_plugin)
  (public_name rocq-elpi.elpi)
  (synopsis "Elpi")
+ (modes byte native)
  (flags :standard -w -27)
  (preprocessor_deps rocq_elpi_config.mlh)
  (preprocess


### PR DESCRIPTION
Fixes https://github.com/LPCIC/coq-elpi/issues/1061

The cause was that the native plugin was not being generated.
I fixed the issue by adding a line to the `dune` configuration file to ensure that `coqc` generates the `cmxs` file it expects. Applying this change to tag 3.2.0 will resolve the problem.