### PR TITLE
Allow '~' in the path of shafile.ml

### DIFF
--- a/etc/shafile.ml
+++ b/etc/shafile.ml
@@ -1,5 +1,5 @@
 let mk_ident =
-  String.map (function '.' | '/' | '-' -> '_' | c -> c)
+  String.map (function '.' | '/' | '-' | '~' -> '_' | c -> c)
 
 let () =
   Printf.printf "Local Set Warnings \"-abstract-large-number\".\n";


### PR DESCRIPTION
If the path of shafile.ml contains a ~, coq fails to interpret the name generated by shafile.ml as a valid name.