### PR TITLE
Fix inductive parameter relevance; new coq.string->name-irrelevant and coq.typecheck-relevance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@
   `Invalid_argument("index out of bounds")` from the kernel, printing one
   was producing an ill-typed declaration)
 
+### API:
+- New `coq.string->name-irrelevant`, the counterpart of
+  `coq.string->name-relevant`
+- New `coq.typecheck-relevance` recomputing, by retyping, the relevance mark of
+  every binder of a term
+
 ### LIB:
 - New  `coq.indt-decl->ids`, `coq.mutual?`, `coq.mutual.members`
 

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -1517,6 +1517,13 @@ external func coq.typecheck term -> term, diagnostic.
 % Universe constraints are put in the constraint store.
 external func coq.typecheck-ty term -> sort, diagnostic.
 
+% [coq.typecheck-relevance T T1] recomputes by retyping the relevance
+% mark of every binder of T: binders whose type lives in SProp become
+% irrelevant, the others relevant. A binder whose type does not retype
+% keeps the mark it has. The kernel checks these marks, so a term
+% assembled by hand rather than obtained from elaboration may need this.
+external func coq.typecheck-relevance term -> term.
+
 % [coq.unify-eq A B Diagnostic] unifies the two terms
 external func coq.unify-eq term, term -> diagnostic.
 
@@ -1821,6 +1828,10 @@ external func coq.string->name string -> name.
 % [coq.string->name-relevant Hint Name] creates a name hint with the
 % relevant mark (see SProp)
 external func coq.string->name-relevant string -> name.
+
+% [coq.string->name-irrelevant Hint Name] creates a name hint with the
+% irrelevant mark (see SProp)
+external func coq.string->name-irrelevant string -> name.
 
 
 func coq.id->name id -> name.

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3265,6 +3265,67 @@ let force_name_ctx =
     | LocalDef(n,b,ty) -> LocalDef(map_annot (fun n -> Name (force_name n)) n, b, ty))
 ;;
 
+(* The kernel checks the relevance mark carried by a binder against the sort of
+   the binder's type, so a term assembled by hand -- rather than obtained from
+   elaboration -- can be rejected on a mark alone.  Retyping recovers the right
+   mark, but it is partial on open terms: when it gives up we keep the mark that
+   was already there rather than guess. *)
+let retyped_relevance env sigma ~dflt ty =
+  try Retyping.relevance_of_type env sigma ty
+  with Retyping.RetypeError _ -> dflt
+
+let relevance_of_binder env sigma na ty =
+  { na with Context.binder_relevance =
+      retyped_relevance env sigma ~dflt:na.Context.binder_relevance ty }
+
+(* Same, for every binder of a term.  Only the marks a node's own binders carry
+   are fixed here; the descent, and the environment each subterm is retyped in,
+   are [Termops.map_constr_with_full_binders]'.  That is what makes [Case], [Fix]
+   and [CoFix] safe: their bodies are not closed, and retyping them in the
+   ambient context would not fail, it would silently mark the wrong types. *)
+let retype_relevance_of_binders env sigma t =
+  let open Context.Rel.Declaration in
+  (* A rel_context is innermost-first, the [name] arrays of a [Case] run the
+     other way; [decls] below is the context reversed to match. *)
+  let rec fix_telescope env acc decls nas =
+    match decls, nas with
+    | [], [] -> env, Array.of_list (List.rev acc)
+    | d :: decls, na :: nas ->
+        let na = relevance_of_binder env sigma na (get_type d) in
+        fix_telescope (EConstr.push_rel (set_annot na d) env) (na :: acc) decls nas
+    | _ -> assert false (* annotate_case returns a context per bound name *)
+  in
+  let fix_binders env t =
+    match EConstr.kind sigma t with
+    | Constr.Prod(na,ty,bo) ->
+        EConstr.mkProd(relevance_of_binder env sigma na ty,ty,bo)
+    | Constr.Lambda(na,ty,bo) ->
+        EConstr.mkLambda(relevance_of_binder env sigma na ty,ty,bo)
+    | Constr.LetIn(na,v,ty,bo) ->
+        EConstr.mkLetIn(relevance_of_binder env sigma na ty,v,ty,bo)
+    | Constr.Fix(ri,(nas,tys,bos)) ->
+        EConstr.mkFix(ri,(Array.map2 (relevance_of_binder env sigma) nas tys,tys,bos))
+    | Constr.CoFix(i,(nas,tys,bos)) ->
+        EConstr.mkCoFix(i,(Array.map2 (relevance_of_binder env sigma) nas tys,tys,bos))
+    | Constr.Case(ci,u,pms,((rnas,rbo),rrel),iv,c,bs) ->
+        (* The names of the return clause and of the branches bind the
+           inductive's indices and the constructors' arguments; their types are
+           not in the node, they have to be recovered from the inductive. *)
+        let _, _, _, ((rctx,_),_), _, _, abs =
+          EConstr.annotate_case env sigma (ci,u,pms,((rnas,rbo),rrel),iv,c,bs) in
+        let renv, rnas = fix_telescope env [] (List.rev rctx) (Array.to_list rnas) in
+        let bs = Array.map2 (fun (ctx,_) (nas,bo) ->
+            snd (fix_telescope env [] (List.rev ctx) (Array.to_list nas)), bo) abs bs in
+        EConstr.mkCase(ci,u,pms,
+          ((rnas,rbo),retyped_relevance renv sigma ~dflt:rrel rbo),iv,c,bs)
+    | _ -> t
+  in
+  (* The marks have to be fixed before the descent, not after: the binders a
+     node is rebuilt with are the ones the map found there. *)
+  let rec aux env t =
+    Termops.map_constr_with_full_binders env sigma EConstr.push_rel aux env
+      (fix_binders env t) in
+    aux env t
 
 let readback_arity ~depth coq_ctx constraints state t =
   let lp2constr coq_ctx ~depth state t =

--- a/src/rocq_elpi_HOAS.mli
+++ b/src/rocq_elpi_HOAS.mli
@@ -233,6 +233,12 @@ val sort : (Sorts.t,'a conv_context,constraints) ContextualConversion.t
 val global_constant_of_globref : Names.GlobRef.t -> global_constant
 val abbreviation : Globnames.abbreviation Conversion.t
 val implicit_kind : Glob_term.binding_kind Conversion.t
+
+(* Recomputes, by retyping, the relevance mark of every binder of a term, the
+   binders of Case/Fix/CoFix included.  Marks whose type does not retype are
+   left alone. *)
+val retype_relevance_of_binders : Environ.env -> Evd.evar_map -> EConstr.t -> EConstr.t
+
 val collect_term_variables : depth:int -> term -> Names.Id.t list
 val subst_cdata : Mod_subst.substitution -> Elpi.API.RawOpaqueData.t -> Elpi.API.RawOpaqueData.t
 type pstring = Pstring.t

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -3948,6 +3948,19 @@ Universe constraints are put in the constraint store.|})))),
           state, ?: None +! B.mkERROR error, [])),
   DocAbove);
 
+  MLCode(Pred("coq.typecheck-relevance",
+    CIn(term, "T",
+    COut(term, "T1",
+    Read (proof_context,
+{|recomputes by retyping the relevance
+mark of every binder of T: binders whose type lives in SProp become
+irrelevant, the others relevant. A binder whose type does not retype
+keeps the mark it has. The kernel checks these marks, so a term
+assembled by hand rather than obtained from elaboration may need this.|}))),
+  (fun t _ ~depth proof_context _ state ->
+     !: (retype_relevance_of_binders proof_context.env (get_sigma state) t))),
+  DocAbove);
+
   MLCode(Pred("coq.unify-eq",
     CIn(term, "A",
     CIn(term, "B",
@@ -4603,8 +4616,17 @@ and for all in a .v file which your clients will load. Eg.
     In(B.string, "Hint",
     Out(name,  "Name",
     Easy("creates a name hint with the relevant mark (see SProp)"))),
-  (fun s _ ~depth -> 
+  (fun s _ ~depth ->
     let s = EConstr.nameR (Id.of_string s) in
+    !: s)),
+  DocAbove);
+
+  MLCode(Pred("coq.string->name-irrelevant",
+    In(B.string, "Hint",
+    Out(name,  "Name",
+    Easy("creates a name hint with the irrelevant mark (see SProp)"))),
+  (fun s _ ~depth ->
+    let s = Context.make_annot (Name.mk_name (Id.of_string s)) EConstr.ERelevance.irrelevant in
     !: s)),
   DocAbove);
 

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -959,3 +959,65 @@ Elpi Query lp:{{
   std.assert! (D = D2) "different inductives",
   coq.typecheck-indt-decl D ok.
 }}.
+
+(* -------- Relevance of binders -------- *)
+
+Inductive sTrue : SProp := sI.
+
+(* coq.string->name-relevant and coq.string->name-irrelevant *)
+Elpi Query lp:{{
+  coq.string->name "x" N,
+  coq.name.relevant? N R,
+  std.assert! (R = none) "coq.string->name should leave the mark unset",
+  coq.string->name-relevant "x" NR,
+  coq.name.relevant? NR RR,
+  std.assert! (RR = some tt) "coq.string->name-relevant is not relevant",
+  coq.string->name-irrelevant "x" NI,
+  coq.name.relevant? NI RI,
+  std.assert! (RI = some ff) "coq.string->name-irrelevant is not irrelevant".
+}}.
+
+(* coq.typecheck-relevance fixes both directions, on nested binders *)
+Elpi Query lp:{{
+  coq.locate "sTrue" (indt ST),
+  coq.string->name-irrelevant "n" Nwrong,
+  coq.string->name-relevant "p" Pwrong,
+  coq.typecheck-relevance
+    (prod Nwrong {{ nat }} _\ prod Pwrong (global (indt ST)) _\ {{ nat }}) T,
+  T = prod Nfixed _ F, pi n\
+  F n = prod Pfixed _ _,
+  coq.name.relevant? Nfixed Rn,
+  coq.name.relevant? Pfixed Rp,
+  std.assert! (Rn = some tt) "the nat binder should have become relevant",
+  std.assert! (Rp = some ff) "the SProp binder should have become irrelevant".
+}}.
+
+(* The binders of a match branch have to be pushed before its body is retyped:
+   here [T], the type of [y], is the second de Bruijn index inside the branch
+   and the first one outside it, where it is an SProp.  The kernel checks the
+   marks, so the term is rejected on the mark alone if the branch's own binders
+   are not in the environment. *)
+Inductive box : Type := Box (T : Type) (t : T).
+
+Definition sprop_before_match (P : SProp) (b : box) : nat :=
+  match b with Box T t => (fun y : T => 0) t end.
+
+Elpi Query lp:{{
+  coq.locate "sprop_before_match" (const C),
+  coq.env.const C (some Body) _,
+  coq.typecheck-relevance Body Body1,
+  coq.env.add-const "sprop_after_match" Body1 _ @transparent! _.
+}}.
+
+(* Same, for the binders of a fix: [Q], the type of [y], is shifted by the
+   recursive binder [f]. *)
+Definition sprop_before_fix (P : SProp) (Q : Type) (q : Q) : nat -> nat :=
+  fix f (n : nat) : nat := (fun y : Q => 0) q.
+
+Elpi Query lp:{{
+  coq.locate "sprop_before_fix" (const C),
+  coq.env.const C (some Body) _,
+  coq.typecheck-relevance Body Body1,
+  coq.env.add-const "sprop_after_fix" Body1 _ @transparent! _.
+}}.
+


### PR DESCRIPTION
Elpi code that constructs binders over SProp types can leave relevant marks on irrelevant binders, causing the kernel error:

```
Binder ... has relevance mark set to Relevant but was expected to be
Irrelevant (maybe a bugged tactic)
```

This adds `coq.string->name-irrelevant` alongside `coq.string->name-relevant` for constructing an irrelevant name, and `coq.typecheck-relevance T T1` alongside `coq.typecheck-ty` for recomputing every binder mark from its type. If a binder's type does not retype, its existing mark is retained.

The latter uses `Retyping.relevance_of_type` and catches only `Retyping.RetypeError`. It fixes the marks a node's own binders carry and leaves the descent to `Termops.map_constr_with_full_binders`, so a binder under a `Case`, `Fix`, or `CoFix` is retyped with the enclosing binders in scope. Without that context, an open branch body can silently derive marks from unrelated ambient de Bruijn indices. The final two tests in `tests/test_HOAS.v` exercise cases where the answers differ; `coq.env.add-const` confirms that the kernel accepts the corrected marks.

#1093 remains separate because its readback change is an independent behavior question.

Wordsmithed by Codex.

