### PR TITLE
Fix minductive when a member arity mentions a parameter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 
 # UNRELEASED
 
+### HOAS:
+- Fix `minductive` when the arity of a member of the block mentions a
+  parameter, in both directions (reading a declaration back was raising
+  `Invalid_argument("index out of bounds")` from the kernel, printing one
+  was producing an ill-typed declaration)
+
 ### LIB:
 - New  `coq.indt-decl->ids`, `coq.mutual?`, `coq.mutual.members`
 

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3566,6 +3566,20 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
     EC.Vars.substl subst t
   in
 
+  (* The arity of the i-th member of a mutual block is read back in a context
+     already extended with the binders of the i preceding members (see
+     aux_mind_lam), hence its parameters live at de Bruijn i+1..i+paramsno.
+     Arities cannot mention the inductive types being defined, so we drop these
+     i binders and bring the parameters back to 1..paramsno, which is what
+     it_mkProd_or_LetIn expects below. *)
+  let relocate_mutual_arity sigma ~name ~nindsbefore t =
+    if nindsbefore = 0 then t
+    else if not (EConstr.Vars.noccur_between sigma 1 nindsbefore t) then
+      err Pp.(str"minductive: the arity of " ++ Id.print name ++
+              str" mentions an inductive type of the same block")
+    else EConstr.Vars.liftn (-nindsbefore) (nindsbefore + 1) t
+  in
+
   let aux_mutual_constructors coq_ctx ~depth (params,impls) inds state constructor_blocks =
     let params = force_name_ctx params in
     let paramsno = List.length params in
@@ -3596,7 +3610,10 @@ let lp2inductive_entry ~depth coq_ctx constraints state t =
       (state, [], []) inds constructor_blocks in
     let constructor_infos = List.rev constructor_infos in
     let indnames = List.map (fun (name, _, _, _, _, _) -> name) constructor_infos in
-    let arities = List.map (fun (_, arity, _, _, _, _) -> arity) constructor_infos in
+    let arities =
+      List.mapi (fun i (name, arity, _, _, _, _) ->
+        relocate_mutual_arity (get_sigma state) ~name ~nindsbefore:i arity)
+        constructor_infos in
     let constructors = List.map (fun (_, _, knames, ktypes, _, _) -> knames, ktypes) constructor_infos in
     let ind_impls = List.map (fun (_, _, _, _, i_impls, k_impls) -> i_impls, k_impls) constructor_infos in
     let finiteness =
@@ -3896,14 +3913,26 @@ let hoas_ind2lp ~depth coq_ctx state { params; decl } =
       let reloc ctx_len t =
         let t = EC.Vars.substl (subst ctx_len) t in
         Reductionops.nf_beta (Global.env()) sigma t in
-      let rec embed_arities coq_ctx depth state = function
+      (* Arities are stated in the context of the parameters only, while the
+         embedding of the n-th member of a mutual block takes place in a
+         coq_ctx already extended with the binders of the n preceding members.
+         We hence lift the arity telescope over these n binders. *)
+      let lift_arity_over_inds n ((nuparams : Glob_term.binding_kind ctx_entry list),typ) =
+        if n = 0 then (nuparams,typ)
+        else
+          let len = List.length nuparams in
+          List.mapi (fun i (x : Glob_term.binding_kind ctx_entry) ->
+            { x with typ = EC.Vars.liftn n (len - i) x.typ }) nuparams,
+          EC.Vars.liftn n (len + 1) typ in
+      let rec embed_arities coq_ctx depth state nindsbefore = function
         | [] -> state, [], coq_ctx, depth, []
         | { id; nuparams; typ; _ } :: rest ->
+            let nuparams, typ = lift_arity_over_inds nindsbefore (nuparams,typ) in
             let state, arity, gls = embed_arity ~depth coq_ctx state (nuparams,typ) in
             let coq_ctx = push_coq_ctx_local depth (Context.Rel.Declaration.LocalAssum(EConstr.anonR,EConstr.mkProp)) coq_ctx in
-            let state, arities, coq_ctx, depth, gls_rest = embed_arities coq_ctx (depth+1) state rest in
+            let state, arities, coq_ctx, depth, gls_rest = embed_arities coq_ctx (depth+1) state (nindsbefore+1) rest in
             state, arity :: arities, coq_ctx, depth, gls @ gls_rest in
-      let state, arities, coq_ctx, depth, gls1 = embed_arities coq_ctx depth state inds in
+      let state, arities, coq_ctx, depth, gls1 = embed_arities coq_ctx depth state 0 inds in
       let embed_constructor state { id; arity; typ } =
         let alen = List.length arity in
         let kctx = List.mapi (fun i ({ extra; typ } as x) -> { x with typ = reloc (alen - i -1) typ }) arity in

--- a/tests/test_mutind.v
+++ b/tests/test_mutind.v
@@ -12,6 +12,13 @@ with pforest (A : Type) : Type :=
 | pempty
 | pcons (t : ptree A) (f : pforest A).
 
+(* Arities that mention a parameter of the block. *)
+Inductive stree (A : Type) : A -> Type :=
+| snode (x : A) (f : sforest A x) : stree A x
+with sforest (A : Type) : A -> Type :=
+| sempty (x : A) : sforest A x
+| scons (x : A) (t : stree A x) (f : sforest A x) : sforest A x.
+
 Inductive even : nat -> Type :=
 | evenO : even 0
 | evenS n : odd n -> even (S n)
@@ -28,6 +35,10 @@ main _ :-
   coq.locate "ptree" (indt PTree),
   coq.env.indt-decl PTree PTreeDecl,
   std.assert-ok! (coq.typecheck-indt-decl PTreeDecl) "ptree declaration illtyped",
+
+  coq.locate "stree" (indt STree),
+  coq.env.indt-decl STree STreeDecl,
+  std.assert-ok! (coq.typecheck-indt-decl STreeDecl) "stree declaration illtyped",
 
   coq.locate "even" (indt Even),
   coq.env.indt-decl Even EvenDecl,
@@ -54,6 +65,21 @@ main _ :-
   std.assert-ok! (coq.typecheck-indt-decl PTree2Decl) "ptree2 declaration illtyped",
   coq.env.add-indt PTree2Decl _,
 
+  % The arity of each member mentions the parameter A.
+  STree2Decl = (parameter "A" explicit {{ Type }} a\
+    (minductive "stree2" tt (arity {{ lp:a -> Type }}) t\
+    (minductive "sforest2" tt (arity {{ lp:a -> Type }}) f\
+      (mblock [
+        [constructor "snode2" (parameter "x" explicit a x\
+           arity {{ lp:f lp:x -> lp:t lp:x }})],
+        [constructor "sempty2" (parameter "x" explicit a x\
+           arity {{ lp:f lp:x }}),
+         constructor "scons2" (parameter "x" explicit a x\
+           arity {{ lp:t lp:x -> lp:f lp:x -> lp:f lp:x }})]
+      ])))),
+  std.assert-ok! (coq.typecheck-indt-decl STree2Decl) "stree2 declaration illtyped",
+  coq.env.add-indt STree2Decl _,
+
   Even2Decl = (minductive "even2" tt (arity {{ nat -> Type }}) even\
     (minductive "odd2" tt (arity {{ nat -> Type }}) odd\
       (mblock [
@@ -70,7 +96,7 @@ Module Generated.
   Elpi test_mutind.
 End Generated.
 
-Universe tree2_u ptree2_arg_u ptree2_u even2_u.
+Universe tree2_u ptree2_arg_u ptree2_u stree2_arg_u stree2_u even2_u.
 
 Module Type GeneratedMutualInductives.
   Inductive tree2 : Type@{tree2_u} :=
@@ -84,6 +110,12 @@ Module Type GeneratedMutualInductives.
   with pforest2 (A : Type@{ptree2_arg_u}) : Type@{ptree2_u} :=
   | pempty2
   | pcons2 (t : ptree2 A) (f : pforest2 A).
+
+  Inductive stree2 (A : Type@{stree2_arg_u}) : A -> Type@{stree2_u} :=
+  | snode2 (x : A) (f : sforest2 A x) : stree2 A x
+  with sforest2 (A : Type@{stree2_arg_u}) : A -> Type@{stree2_u} :=
+  | sempty2 (x : A) : sforest2 A x
+  | scons2 (x : A) (t : stree2 A x) (f : sforest2 A x) : sforest2 A x.
 
   Inductive even2 : nat -> Type@{even2_u} :=
   | evenO2 : even2 0


### PR DESCRIPTION
`coq.env.add-indt` raises

```
Anomaly "Uncaught exception Invalid_argument("index out of bounds")."
```

for any mutual inductive block in which the arity of a member mentions a parameter of the block.

### Reproducer

```coq
From elpi Require Import elpi.
Elpi Command tB.
Elpi Accumulate lp:{{
main _ :-
  D = (parameter "A" explicit {{ Type }} a\
    (minductive "stree" tt (arity {{ Type }}) t\
    (minductive "sforest" tt (arity {{ lp:a -> Type }}) f\
      (mblock [
        [constructor "snode" (parameter "x" explicit a x\ arity {{ lp:f lp:x -> lp:t }})],
        [constructor "sempty" (parameter "x" explicit a x\ arity {{ lp:f lp:x }})]
      ])))),
  std.assert-ok! (coq.typecheck-indt-decl D) "illtyped",
  coq.env.add-indt D _.
}}.
Elpi tB.
```

`coq.typecheck-indt-decl` and `coq.elaborate-indt-decl-skeleton` both accept the declaration; the failure only shows up in the kernel, at `IndTyping.check_arity` ← `typecheck_inductive` ← `Safe_typing.add_mind`.

Shape of the bug:

- one `minductive` with a parameter-dependent arity: works
- two members with parameter-*in*dependent arities: works (this is what `tests/test_mutind.v` covered, hence the miss)
- two members where any arity mentions a parameter: anomaly

### Cause

`aux_mind_lam` extends the `coq_ctx` with one binder per member as it walks the chain of `minductive` nodes, so `aux_inductive` reads the arity of the *i*-th member in a context that already holds the binders of the *i* preceding ones: its parameters sit at de Bruijn `i+1 .. i+paramsno`. `aux_mutual_constructors` then closes that arity with `it_mkProd_or_LetIn arity params`, which expects the parameters at `1 .. paramsno`. Constructor types were already relocated for exactly this reason (`relocate_mutual_constructor_type`); arities were not.

While writing the regression test I found the mirror image of the same defect in the printing direction. `hoas_ind2lp`'s `embed_arities` pushes a binder per member into `coq_ctx` but embeds each arity unlifted, so for

```coq
Inductive stree (A : Type) : A -> Type :=
| snode (x : A) (f : sforest A x) : stree A x
with sforest (A : Type) : A -> Type :=
| sempty (x : A) : sforest A x
| scons (x : A) (t : stree A x) (f : sforest A x) : sforest A x.
```

`coq.env.indt-decl` used to produce

```
parameter A explicit (sort (typ «stree.u0»)) c0 \
 minductive stree tt (arity (prod `_` c0 c1 \ sort (typ ...))) c1 \
  minductive sforest tt (arity (prod `_` c1 c2 \ sort (typ ...))) c2 \
   ...
```

where `sforest`'s arity is indexed by `c1`, the `stree` binder, instead of `c0`, the parameter. The resulting `indt-decl` is ill-typed, so `coq.env.indt-decl` followed by `coq.typecheck-indt-decl` fails on such a block.

### Fix

Relocate the arity of member *i* across the *i* preceding binders, in both directions. An arity may not mention the inductive types being defined; that is now reported as an error rather than silently reinterpreted as a parameter.

Non-mutual inductives take the same code path with `i = 0` and are unaffected.

### Tests

`tests/test_mutind.v` gains a block whose members are both indexed by a parameter, exercising the two directions (`coq.env.indt-decl` on a Rocq-declared block, and `coq.env.add-indt` on an elpi-built one) plus the existing `Module Type` equivalence check.

Verified against Rocq `master`: without the patch, the `coq.env.add-indt` reproducer above raises the anomaly and the printing half produces an ill-typed declaration; with it both succeed, and `dune build tests` + `dune runtest tests` pass.
