### PR TITLE
Build binders from the relevance of their type, not of their id (negative result)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@
   parameter, in both directions (reading a declaration back was raising
   `Invalid_argument("index out of bounds")` from the kernel, printing one
   was producing an ill-typed declaration)
+- New `coq.id->name-of-ty`, building a name whose relevance mark is the one of
+  the given type; `coq.arity->term`, `@pi-parameter` and `@pi-inductive` use it
+  instead of `coq.id->name`, so a parameter whose type lives in `SProp` no
+  longer gets a relevant binder that the kernel rejects
 
 ### API:
 - New `coq.string->name-irrelevant`, the counterpart of

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,12 @@
   `Invalid_argument("index out of bounds")` from the kernel, printing one
   was producing an ill-typed declaration)
 
+### API:
+- New `coq.string->name-irrelevant`, the counterpart of
+  `coq.string->name-relevant`
+- New `coq.typecheck-relevance` recomputing, by retyping, the relevance mark of
+  every binder of a term
+
 ### LIB:
 - New  `coq.indt-decl->ids`, `coq.mutual?`, `coq.mutual.members`
 

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -1517,6 +1517,13 @@ external func coq.typecheck term -> term, diagnostic.
 % Universe constraints are put in the constraint store.
 external func coq.typecheck-ty term -> sort, diagnostic.
 
+% [coq.typecheck-relevance T T1] recomputes by retyping the relevance
+% mark of every binder of T: binders whose type lives in SProp become
+% irrelevant, the others relevant. A binder whose type does not retype
+% keeps the mark it has. The kernel checks these marks, so a term
+% assembled by hand rather than obtained from elaboration may need this.
+external func coq.typecheck-relevance term -> term.
+
 % [coq.unify-eq A B Diagnostic] unifies the two terms
 external func coq.unify-eq term, term -> diagnostic.
 
@@ -1821,6 +1828,10 @@ external func coq.string->name string -> name.
 % [coq.string->name-relevant Hint Name] creates a name hint with the
 % relevant mark (see SProp)
 external func coq.string->name-relevant string -> name.
+
+% [coq.string->name-irrelevant Hint Name] creates a name hint with the
+% irrelevant mark (see SProp)
+external func coq.string->name-irrelevant string -> name.
 
 
 func coq.id->name id -> name.

--- a/builtin-doc/coq-builtin.elpi
+++ b/builtin-doc/coq-builtin.elpi
@@ -342,17 +342,26 @@ evar _ _ _. % volatile, only unresolved evars are considered as evars
 macro @pi-decl N T F :- pi x\ decl x N T => F x.
 macro @pi-def N T B F :- pi x\ def x N T B => cache x B_ => F x.
 
+% [coq.id->name-of-ty ID Ty Name] turns an id into a name carrying the
+% relevance mark of Ty. [coq.id->name] cannot do that: it only sees the id, so
+% it always answers a relevant name, and the kernel rejects a relevant binder
+% whose type lives in SProp. Ty not retyping leaves the mark alone.
+func coq.id->name-of-ty id, term -> name.
+coq.id->name-of-ty ID Ty Name :-
+  coq.id->name ID N,
+  coq.typecheck-relevance (prod N Ty _\ Ty) (prod Name _ _).
+
 % Converts an arity to a term
 func coq.arity->term arity -> term.
 coq.arity->term (parameter ID _ Ty Rest) (prod Name Ty R) :-
-  coq.id->name ID Name,
+  coq.id->name-of-ty ID Ty Name,
   @pi-decl Name Ty x\ coq.arity->term (Rest x) (R x).
 coq.arity->term (arity A) A.
 
 macro @pi-parameter ID T F :-
-  sigma N\ (coq.id->name ID N, pi x\ decl x N T => F x).
+  sigma N\ (coq.id->name-of-ty ID T N, pi x\ decl x N T => F x).
 macro @pi-inductive ID A F :-
-  sigma N\ (coq.id->name ID N, coq.arity->term A T, pi x\ decl x N T => F x).
+  sigma N\ (coq.arity->term A T, coq.id->name-of-ty ID T N, pi x\ decl x N T => F x).
 
 
 % Sometimes it can be useful to pass to Coq a term with unification variables

--- a/elpi/coq-HOAS.elpi
+++ b/elpi/coq-HOAS.elpi
@@ -154,17 +154,26 @@ evar _ _ _. % volatile, only unresolved evars are considered as evars
 macro @pi-decl N T F :- pi x\ decl x N T => F x.
 macro @pi-def N T B F :- pi x\ def x N T B => cache x B_ => F x.
 
+% [coq.id->name-of-ty ID Ty Name] turns an id into a name carrying the
+% relevance mark of Ty. [coq.id->name] cannot do that: it only sees the id, so
+% it always answers a relevant name, and the kernel rejects a relevant binder
+% whose type lives in SProp. Ty not retyping leaves the mark alone.
+func coq.id->name-of-ty id, term -> name.
+coq.id->name-of-ty ID Ty Name :-
+  coq.id->name ID N,
+  coq.typecheck-relevance (prod N Ty _\ Ty) (prod Name _ _).
+
 % Converts an arity to a term
 func coq.arity->term arity -> term.
 coq.arity->term (parameter ID _ Ty Rest) (prod Name Ty R) :-
-  coq.id->name ID Name,
+  coq.id->name-of-ty ID Ty Name,
   @pi-decl Name Ty x\ coq.arity->term (Rest x) (R x).
 coq.arity->term (arity A) A.
 
 macro @pi-parameter ID T F :-
-  sigma N\ (coq.id->name ID N, pi x\ decl x N T => F x).
+  sigma N\ (coq.id->name-of-ty ID T N, pi x\ decl x N T => F x).
 macro @pi-inductive ID A F :-
-  sigma N\ (coq.id->name ID N, coq.arity->term A T, pi x\ decl x N T => F x).
+  sigma N\ (coq.arity->term A T, coq.id->name-of-ty ID T N, pi x\ decl x N T => F x).
 
 
 % Sometimes it can be useful to pass to Coq a term with unification variables

--- a/src/rocq_elpi_HOAS.ml
+++ b/src/rocq_elpi_HOAS.ml
@@ -3265,6 +3265,77 @@ let force_name_ctx =
     | LocalDef(n,b,ty) -> LocalDef(map_annot (fun n -> Name (force_name n)) n, b, ty))
 ;;
 
+(* The kernel checks the relevance mark carried by a binder against the sort of
+   the binder's type, so a term assembled by hand -- rather than obtained from
+   elaboration -- can be rejected on a mark alone.  Retyping recovers the right
+   mark, but it is partial on open terms: when it gives up we keep the mark that
+   was already there rather than guess. *)
+let retyped_relevance env sigma ~dflt ty =
+  try Retyping.relevance_of_type env sigma ty
+  with Retyping.RetypeError _ -> dflt
+
+let relevance_of_binder env sigma na ty =
+  { na with Context.binder_relevance =
+      retyped_relevance env sigma ~dflt:na.Context.binder_relevance ty }
+
+(* Same, for every binder of a term.  Each type is retyped in the environment of
+   the binders that precede it, so [Case], [Fix] and [CoFix] have to push their
+   own binders too: their bodies are not closed, and typing them in the ambient
+   context would not fail, it would silently produce marks for the wrong types. *)
+let retype_relevance_of_binders env sigma t =
+  let open Context.Rel.Declaration in
+  (* A rel_context is innermost-first, the [name] arrays of a [Case] run the
+     other way; [decls] below is the context reversed to match. *)
+  let rec fix_telescope env acc decls nas =
+    match decls, nas with
+    | [], [] -> env, Array.of_list (List.rev acc)
+    | d :: decls, na :: nas ->
+        let na = relevance_of_binder env sigma na (get_type d) in
+        fix_telescope (EConstr.push_rel (set_annot na d) env) (na :: acc) decls nas
+    | _ -> assert false (* annotate_case returns a context per bound name *)
+  in
+  let rec aux env t =
+    match EConstr.kind sigma t with
+    | Constr.Prod(na,ty,bo) ->
+        let ty = aux env ty in
+        let na = relevance_of_binder env sigma na ty in
+        EConstr.mkProd(na,ty,aux (EConstr.push_rel (LocalAssum(na,ty)) env) bo)
+    | Constr.Lambda(na,ty,bo) ->
+        let ty = aux env ty in
+        let na = relevance_of_binder env sigma na ty in
+        EConstr.mkLambda(na,ty,aux (EConstr.push_rel (LocalAssum(na,ty)) env) bo)
+    | Constr.LetIn(na,v,ty,bo) ->
+        let v = aux env v in
+        let ty = aux env ty in
+        let na = relevance_of_binder env sigma na ty in
+        EConstr.mkLetIn(na,v,ty,aux (EConstr.push_rel (LocalDef(na,v,ty)) env) bo)
+    | Constr.Fix(ri,(nas,tys,bos)) ->
+        let tys = Array.map (aux env) tys in
+        let nas = Array.map2 (relevance_of_binder env sigma) nas tys in
+        let env = EConstr.push_rec_types (nas,tys,bos) env in
+        EConstr.mkFix(ri,(nas,tys,Array.map (aux env) bos))
+    | Constr.CoFix(i,(nas,tys,bos)) ->
+        let tys = Array.map (aux env) tys in
+        let nas = Array.map2 (relevance_of_binder env sigma) nas tys in
+        let env = EConstr.push_rec_types (nas,tys,bos) env in
+        EConstr.mkCoFix(i,(nas,tys,Array.map (aux env) bos))
+    | Constr.Case(ci,u,pms,((rnas,rbo),rrel),iv,c,bs) ->
+        (* The names of the return clause and of the branches bind the
+           inductive's indices and the constructors' arguments; their types are
+           not in the node, they have to be recovered from the inductive. *)
+        let _, _, _, ((rctx,_),_), _, _, abs =
+          EConstr.annotate_case env sigma (ci,u,pms,((rnas,rbo),rrel),iv,c,bs) in
+        let renv, rnas = fix_telescope env [] (List.rev rctx) (Array.to_list rnas) in
+        let rrel = retyped_relevance renv sigma ~dflt:rrel rbo in
+        let bs = Array.map2 (fun (ctx,_) (nas,bo) ->
+            let env, nas = fix_telescope env [] (List.rev ctx) (Array.to_list nas) in
+            nas, aux env bo) abs bs in
+        let iv = Constr.map_invert (aux env) iv in
+        EConstr.mkCase(ci,u,Array.map (aux env) pms,
+          ((rnas,aux renv rbo),rrel),iv,aux env c,bs)
+    | _ -> EConstr.map sigma (aux env) t
+  in
+    aux env t
 
 let readback_arity ~depth coq_ctx constraints state t =
   let lp2constr coq_ctx ~depth state t =

--- a/src/rocq_elpi_HOAS.mli
+++ b/src/rocq_elpi_HOAS.mli
@@ -233,6 +233,12 @@ val sort : (Sorts.t,'a conv_context,constraints) ContextualConversion.t
 val global_constant_of_globref : Names.GlobRef.t -> global_constant
 val abbreviation : Globnames.abbreviation Conversion.t
 val implicit_kind : Glob_term.binding_kind Conversion.t
+
+(* Recomputes, by retyping, the relevance mark of every binder of a term, the
+   binders of Case/Fix/CoFix included.  Marks whose type does not retype are
+   left alone. *)
+val retype_relevance_of_binders : Environ.env -> Evd.evar_map -> EConstr.t -> EConstr.t
+
 val collect_term_variables : depth:int -> term -> Names.Id.t list
 val subst_cdata : Mod_subst.substitution -> Elpi.API.RawOpaqueData.t -> Elpi.API.RawOpaqueData.t
 type pstring = Pstring.t

--- a/src/rocq_elpi_builtins.ml
+++ b/src/rocq_elpi_builtins.ml
@@ -3948,6 +3948,19 @@ Universe constraints are put in the constraint store.|})))),
           state, ?: None +! B.mkERROR error, [])),
   DocAbove);
 
+  MLCode(Pred("coq.typecheck-relevance",
+    CIn(term, "T",
+    COut(term, "T1",
+    Read (proof_context,
+{|recomputes by retyping the relevance
+mark of every binder of T: binders whose type lives in SProp become
+irrelevant, the others relevant. A binder whose type does not retype
+keeps the mark it has. The kernel checks these marks, so a term
+assembled by hand rather than obtained from elaboration may need this.|}))),
+  (fun t _ ~depth proof_context _ state ->
+     !: (retype_relevance_of_binders proof_context.env (get_sigma state) t))),
+  DocAbove);
+
   MLCode(Pred("coq.unify-eq",
     CIn(term, "A",
     CIn(term, "B",
@@ -4603,8 +4616,17 @@ and for all in a .v file which your clients will load. Eg.
     In(B.string, "Hint",
     Out(name,  "Name",
     Easy("creates a name hint with the relevant mark (see SProp)"))),
-  (fun s _ ~depth -> 
+  (fun s _ ~depth ->
     let s = EConstr.nameR (Id.of_string s) in
+    !: s)),
+  DocAbove);
+
+  MLCode(Pred("coq.string->name-irrelevant",
+    In(B.string, "Hint",
+    Out(name,  "Name",
+    Easy("creates a name hint with the irrelevant mark (see SProp)"))),
+  (fun s _ ~depth ->
+    let s = Context.make_annot (Name.mk_name (Id.of_string s)) EConstr.ERelevance.irrelevant in
     !: s)),
   DocAbove);
 

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -1021,3 +1021,48 @@ Elpi Query lp:{{
   coq.env.add-const "sprop_after_fix" Body1 _ @transparent! _.
 }}.
 
+(* -------- Relevance of inductive parameters -------- *)
+
+(* A parameter whose type lives in SProp: the binder [coq.arity->term] and
+   [@pi-parameter] build for it has to be irrelevant, or the kernel rejects the
+   inductive on the mark alone. *)
+Elpi Query lp:{{
+  coq.locate "sTrue" (indt ST),
+  Decl =
+    (parameter "proof" explicit (global (indt ST)) proof\
+      inductive "sprop_parameter_inductive" tt (arity {{ Type }}) ind\
+        [constructor "sprop_parameter_constructor"
+           (arity ind)]),
+  std.assert-ok! (coq.elaborate-indt-decl-skeleton Decl Elaborated)
+    "failed to elaborate SProp-parameter inductive",
+  coq.env.add-indt Elaborated _.
+}}.
+
+(* Same, for a parameter of an arity *)
+Elpi Query lp:{{
+  coq.locate "sTrue" (indt ST),
+  Decl =
+    (inductive "sprop_arity_parameter_inductive" tt
+      (parameter "proof" explicit (global (indt ST)) proof\
+        arity {{ Type }}) ind\
+        [constructor "sprop_arity_parameter_constructor"
+           (parameter "proof" explicit (global (indt ST)) proof\
+             arity (app [ind, proof]))]),
+  std.assert-ok! (coq.elaborate-indt-decl-skeleton Decl Elaborated)
+    "failed to elaborate SProp-arity-parameter inductive",
+  coq.env.add-indt Elaborated _.
+}}.
+
+(* coq.id->name-of-ty answers the mark of the type, not of the id *)
+Elpi Query lp:{{
+  coq.locate "sTrue" (indt ST),
+  coq.id->name-of-ty "proof" (global (indt ST)) NS,
+  coq.name.relevant? NS RS,
+  std.assert! (RS = some ff) "an SProp binder should be irrelevant",
+  coq.id->name-of-ty "n" {{ nat }} NN,
+  coq.name.relevant? NN RN,
+  std.assert! (RN = some tt) "a nat binder should be relevant",
+  coq.id->name-of-ty "p" {{ True }} NP,
+  coq.name.relevant? NP RP,
+  std.assert! (RP = some tt) "a Prop binder should be relevant".
+}}.

--- a/tests/test_HOAS.v
+++ b/tests/test_HOAS.v
@@ -959,3 +959,65 @@ Elpi Query lp:{{
   std.assert! (D = D2) "different inductives",
   coq.typecheck-indt-decl D ok.
 }}.
+
+(* -------- Relevance of binders -------- *)
+
+Inductive sTrue : SProp := sI.
+
+(* coq.string->name-relevant and coq.string->name-irrelevant *)
+Elpi Query lp:{{
+  coq.string->name "x" N,
+  coq.name.relevant? N R,
+  std.assert! (R = none) "coq.string->name should leave the mark unset",
+  coq.string->name-relevant "x" NR,
+  coq.name.relevant? NR RR,
+  std.assert! (RR = some tt) "coq.string->name-relevant is not relevant",
+  coq.string->name-irrelevant "x" NI,
+  coq.name.relevant? NI RI,
+  std.assert! (RI = some ff) "coq.string->name-irrelevant is not irrelevant".
+}}.
+
+(* coq.typecheck-relevance fixes both directions, on nested binders *)
+Elpi Query lp:{{
+  coq.locate "sTrue" (indt ST),
+  coq.string->name-irrelevant "n" Nwrong,
+  coq.string->name-relevant "p" Pwrong,
+  coq.typecheck-relevance
+    (prod Nwrong {{ nat }} _\ prod Pwrong (global (indt ST)) _\ {{ nat }}) T,
+  T = prod Nfixed _ F, pi n\
+  F n = prod Pfixed _ _,
+  coq.name.relevant? Nfixed Rn,
+  coq.name.relevant? Pfixed Rp,
+  std.assert! (Rn = some tt) "the nat binder should have become relevant",
+  std.assert! (Rp = some ff) "the SProp binder should have become irrelevant".
+}}.
+
+(* The binders of a match branch have to be pushed before its body is retyped:
+   here [T], the type of [y], is the second de Bruijn index inside the branch
+   and the first one outside it, where it is an SProp.  The kernel checks the
+   marks, so the term is rejected on the mark alone if the branch's own binders
+   are not in the environment. *)
+Inductive box : Type := Box (T : Type) (t : T).
+
+Definition sprop_before_match (P : SProp) (b : box) : nat :=
+  match b with Box T t => (fun y : T => 0) t end.
+
+Elpi Query lp:{{
+  coq.locate "sprop_before_match" (const C),
+  coq.env.const C (some Body) _,
+  coq.typecheck-relevance Body Body1,
+  coq.env.add-const "sprop_after_match" Body1 _ @transparent! _.
+}}.
+
+(* Same, for the binders of a fix: [Q], the type of [y], is shifted by the
+   recursive binder [f]. *)
+Definition sprop_before_fix (P : SProp) (Q : Type) (q : Q) : nat -> nat :=
+  fix f (n : nat) : nat := (fun y : Q => 0) q.
+
+Elpi Query lp:{{
+  coq.locate "sprop_before_fix" (const C),
+  coq.env.const C (some Body) _,
+  coq.typecheck-relevance Body Body1,
+  coq.env.add-const "sprop_after_fix" Body1 _ @transparent! _.
+}}.
+


### PR DESCRIPTION
**Negative result — this does not work. Keeping it open only as the record of
the experiment; #1093 is the fix.** CI fails on exactly the test it was meant
to make pass, on every Rocq version:

```
File "./tests/test_HOAS.v", line 1029:
Error: Binder (proof : "sTrue") has relevance mark set to relevant but was
expected to be irrelevant (maybe a bugged tactic).
Raised at Type_errors.error_bad_binder_relevance
Called from Typeops.check_assum_annot
Called from Typeops.check_context.(fun)
Called from IndTyping.typecheck_inductive
```

That backtrace is the point: the mark the kernel rejects is on the *parameter
context of the entry*, which `lp2inductive_entry` builds by reading the `id`
back, not one of the marks the elpi helpers patched here. Fixing
`coq.arity->term` and `@pi-parameter` changes the context the declaration is
elaborated in, and changes nothing about the entry that reaches the kernel.
So there is no fix for this at the `coq.id->name` layer; it has to be at
readback, which is what #1093 does.

The observation below still stands on its own — `coq.arity->term` does produce
an ill-marked `prod` for an SProp parameter — it is just not what breaks
`coq.env.add-indt`.

---

<details>
<summary>Original description</summary>

An `indt-decl` carries its parameter names as `id`s, which have no relevance
mark of their own. Two elpi helpers invent one:

```elpi
coq.arity->term (parameter ID _ Ty Rest) (prod Name Ty R) :-
  coq.id->name ID Name, ...

macro @pi-parameter ID T F :-
  sigma N\ (coq.id->name ID N, pi x\ decl x N T => F x).
```

Since 3b62afd2 `coq.id->name` is `coq.string->name-relevant`, so both answer a
*relevant* binder whatever the type is:

```coq
Inductive sTrue : SProp := sI.

Elpi Query lp:{{
  coq.locate "sTrue" (indt ST),
  coq.arity->term
    (parameter "proof" explicit (global (indt ST)) _\ arity {{ Type }}) T,
  T = prod N _ _, coq.name.relevant? N R.   % R = some tt
}}.
```

and the kernel rejects such a term on the mark alone.

Reverting the hack does not help either: it puts a fresh relevance *variable*
back on the name, nothing solves it on this path, and it is defaulted to
relevant. Measured on a build that has 3b62afd2:

| name for `proof : sTrue` | `coq.env.add-const` |
|---|---|
| `coq.id->name` (relevant) | rejected |
| `coq.string->name` (relevance variable) | rejected |
| mark taken from the type | accepted |

So this adds `coq.id->name-of-ty ID Ty Name`, `coq.id->name` with the mark of
`Ty`, and uses it in `coq.arity->term`, `@pi-parameter` and `@pi-inductive`.
`coq.id->name` itself is untouched.

</details>
